### PR TITLE
Dev configurable output fields geoip and domain resolver

### DIFF
--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -983,7 +983,10 @@ Domain Resolver
 The generic adder requires the additional field :code:`domain_resolver`.
 The additional field :code:`domain_resolver.source_url_or_domain` must be defined.
 It contains the field from which an URL should be parsed and then written to :code:`resolved_ip`.
-The URL can be located in continuous text insofar the URL is valid.
+The URL can be located in continuous text insofar the URL is valid.  
+  
+Optionally, the output field can be configured (overriding the default :code:`resolved_ip`) using the parameter :code:`output_field`.
+This can be a dotted subfield.
 
 In the following example the URL from the field :code:`url` will be extracted and written to :code:`resolved_ip`.
 
@@ -1000,6 +1003,7 @@ GeoIP Enricher
 ==============
 
 The generic adder requires the additional field :code:`geoip`.
+This output_field can be overridden using the optional parameter :code:`output_field`.
 The additional field :code:`geoip.source_ip` must be given.
 It contains the IP for which the geoip data should be added.
 

--- a/logprep/processor/domain_resolver/rule.py
+++ b/logprep/processor/domain_resolver/rule.py
@@ -27,6 +27,11 @@ class DomainResolverRule(Rule):
         super().__init__(filter_rule)
 
         self._source_url_or_domain = domain_resolver_cfg['source_url_or_domain']
+        # Added flexible output field assignment. If none is specified, resolved_ip is used.
+        if 'output_field' in domain_resolver_cfg.keys():
+            self._output_field = domain_resolver_cfg['output_field']
+        else:
+            self._output_field = 'resolved_ip'
 
     def __eq__(self, other: 'DomainResolverRule') -> bool:
         return (other.filter == self._filter) and \
@@ -40,6 +45,10 @@ class DomainResolverRule(Rule):
     def source_url_or_domain(self) -> str:
         return self._source_url_or_domain
     # pylint: enable=C0111
+
+    @property
+    def output_field(self) -> str:
+        return self._output_field
 
     @staticmethod
     def _create_from_dict(rule: dict) -> 'DomainResolverRule':
@@ -56,3 +65,9 @@ class DomainResolverRule(Rule):
             if not isinstance(domain_resolver_cfg[field], str):
                 raise InvalidDomainResolverDefinition('"{}" value "{}" is not a dict!'.format(
                                                 field, domain_resolver_cfg[field]))
+
+        if 'output_field' in domain_resolver_cfg.keys():
+            for field in ('output_field',):
+                if not isinstance(domain_resolver_cfg[field], str):
+                    raise InvalidDomainResolverDefinition('"{}" value "{}" is not a dict!'.format(
+                                                    field, domain_resolver_cfg[field]))

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -34,7 +34,7 @@ class DuplicationError(GeoIPEnricherError):
 
     def __init__(self, name: str, skipped_fields: List[str]):
         message = 'The following fields already existed and ' \
-                  'were not overwritten by the Normalizer: '
+                  'were not overwritten by the GeoIPEnricher: '
         message += ' '.join(skipped_fields)
 
         super().__init__(name, message)
@@ -162,11 +162,12 @@ class GeoIPEnricher(RuleBasedProcessor):
 
     def _apply_rules(self, event, rule):
         source_ip = rule.source_ip
+        output_field = rule.output_field
         if source_ip:
             ip_string = self._get_dotted_field_value(event, source_ip)
             geoip_data = self._try_getting_geoip_data(ip_string)
             if geoip_data:
-                if 'geoip' not in event:
-                    event['geoip'] = geoip_data
-                elif event['geoip'] != geoip_data:
-                    raise DuplicationError(self._name, ['geoip'])
+                if output_field not in event:
+                    event[output_field] = geoip_data
+                elif event[output_field] != geoip_data:
+                    raise DuplicationError(self._name, [output_field])

--- a/logprep/processor/geoip_enricher/rule.py
+++ b/logprep/processor/geoip_enricher/rule.py
@@ -25,7 +25,12 @@ class GeoIPEnricherRule(Rule):
 
     def __init__(self, filter_rule: FilterExpression, geoip_enricher_cfg: dict):
         super().__init__(filter_rule)
-
+        
+        if 'output_field' in geoip_enricher_cfg.keys():
+            self._output_field = geoip_enricher_cfg['output_field']
+        else:
+            self._output_field = 'geoip'
+        
         self._source_ip = geoip_enricher_cfg['source_ip']
 
     def __eq__(self, other: 'GeoIPEnricherRule') -> bool:
@@ -39,6 +44,10 @@ class GeoIPEnricherRule(Rule):
     def source_ip(self) -> dict:
         return self._source_ip
     # pylint: enable=C0111
+    
+    @property
+    def output_field(self) -> dict:
+        return self._output_field
 
     @staticmethod
     def _create_from_dict(rule: dict) -> 'GeoIPEnricherRule':
@@ -55,3 +64,8 @@ class GeoIPEnricherRule(Rule):
             if not isinstance(geoip_enricher_cfg[field], str):
                 raise InvalidGeoIPEnricherDefinition('"{}" value "{}" is not a string!'.format(
                                                 field, geoip_enricher_cfg[field]))
+        if 'output_field' in geoip_enricher_cfg.keys():
+            for field in ('output_field',):
+                if not isinstance(geoip_enricher_cfg[field], str):
+                    raise InvalidGeoIPEnricherDefinition('"{}" value "{}" is not a string!'.format(
+                                                    field, geoip_enricher_cfg[field]))

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -25,3 +25,45 @@ def print_bcolor(back: AnsiBack, message: str):
 def print_fcolor(fore: AnsiFore, message: str):
     """Print string with colored font and reset the color afterwards."""
     print_color(None, fore, message)
+
+def add_field_to(event, output_field, content):
+    """
+    Add content to an output_field in the given event. Output_field can be a dotted subfield. In case of missing fields
+    all intermediate fields will be created.
+
+    Parameters
+    ----------
+    event: dict
+        Original log-event that logprep is currently processing
+    output_field: str
+        Dotted subfield string indicating the target of the output value, e.g. destination.ip
+    content: str, dict
+        Value that should be written into the output_field, can be a str or dict object
+
+    Returns
+    ------
+    This method returns true if no conflicting fields were found during the process of the creation of the dotted
+    subfields. If conflicting fields were found False is returned.
+
+    # code is originally from the generic adder, such that duplicated code could be removed there.
+    """
+    conflicting_fields = list()
+
+    keys = output_field.split('.')
+    dict_ = event
+    for idx, key in enumerate(keys):
+        if key not in dict_:
+            if idx == len(keys) - 1:
+                dict_[key] = content
+                break
+            dict_[key] = dict()
+
+        if isinstance(dict_[key], dict):
+            dict_ = dict_[key]
+        else:
+            conflicting_fields.append(keys[idx])
+
+    if conflicting_fields:
+        return False
+    else:
+        return True

--- a/tests/testdata/unit/domain_resolver/rules/domain_resolver.json
+++ b/tests/testdata/unit/domain_resolver/rules/domain_resolver.json
@@ -2,4 +2,24 @@
   "filter": "url",
   "domain_resolver": {"source_url_or_domain": "url"},
   "description": ""
+},{
+  "filter": "source",
+  "domain_resolver": {
+    "source_url_or_domain": "source",
+    "output_field": "resolved.ip"
+  },
+  "description": ""
+}, {
+  "filter": "client",
+  "domain_resolver": {
+    "source_url_or_domain": "client"
+  },
+  "description": ""
+}, {
+  "filter": "client",
+  "domain_resolver": {
+    "source_url_or_domain": "client",
+    "output_field": "resolved_ip"
+  },
+  "description": ""
 }]

--- a/tests/testdata/unit/geoip_enricher/rules/geoip_all.json
+++ b/tests/testdata/unit/geoip_enricher/rules/geoip_all.json
@@ -2,4 +2,11 @@
   "filter": "client.ip AND NOT winlog.computer_name",
   "geoip_enricher": {"source_ip": "client.ip"},
   "description": ""
+},{
+  "filter": "source.ip",
+  "geoip_enricher": {
+    "source_ip": "source.ip",
+    "output_field": "source_geo_data"
+  },
+  "description": ""
 }]

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -81,6 +81,13 @@ class TestGeoIPEnricher:
         document = {'client': {'ip': '8.8.8.8'}, 'geoip': {'test': 'test'}}
 
         with pytest.raises(DuplicationError, match=r'GeoIPEnricher \(test-geoip-enricher\)\: The following fields '
-                                                   r'already existed and were not overwritten by the Normalizer\:'
+                                                   r'already existed and were not overwritten by the GeoIPEnricher\:'
                                                    r' geoip'):
             geoip_enricher.process(document)
+
+    def test_configured_output_field(self, geoip_enricher):
+        assert geoip_enricher.events_processed_count() == 0
+        document = {'source': {'ip': '8.8.8.8'}}
+
+        geoip_enricher.process(document)
+        assert document.get('source_geo_data') is not None


### PR DESCRIPTION
Modified the geoip_enricher and domain_resolver to allow for configurable output fields (per rule basis).
Both still use the default output fields as default values in case none is provided. 
Also modified unit tests accordingly and extended the documentation.