### PR TITLE
add unix source format for timestamp normalization

### DIFF
--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -277,7 +277,10 @@ Optionally, it can be defined if the normalization is allowed to override existi
 It is allowed to override by default.
 
 Valid formats for timestamps are defined by the notation of the Python datetime module.
-Additionally, the value `ISO8601` can be used if the timestamp already exists in this format.
+Additionally, the value `ISO8601` and `UNIX` can be used for the `source_formats` field. The former can be used if the
+timestamp already exists in the ISO98601 format, such that only a timezone conversion should be applied. And the latter
+can be used if the timestamp is given in the UNIX Epoch Time. This supports the Unix timestamps in seconds and
+milliseconds.
 
 Valid timezones are defined in the pytz module:
 

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -235,6 +235,16 @@ class Normalizer(RuleBasedProcessor):
                 try:
                     if source_format == 'ISO8601':
                         timestamp = parser.isoparse(source_timestamp)
+
+                    elif source_format == 'UNIX':
+                        # convert UNIX Epoch timestamp string to int (with or without milliseconds)
+                        new_stamp = int(source_timestamp)
+                        if len(source_timestamp) > 10:
+                            # Epoch with milliseconds
+                            timestamp = datetime.fromtimestamp(new_stamp/1000, timezone(source_timezone))
+                        else:
+                            # Epoch without milliseconds
+                            timestamp = datetime.fromtimestamp(new_stamp, timezone(source_timezone))
                     else:
                         timestamp = datetime.strptime(source_timestamp, source_format)
                         # Set year to current year if no year was provided in timestamp

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -864,6 +864,88 @@ class TestNormalizer:
 
         assert event == expected
 
+    def test_normalization_from_UNIX_with_millis_timestamp(self, normalizer):
+        expected = {
+            '@timestamp': '2022-01-14T12:40:49.843000+01:00',
+            'winlog': {
+                'api': 'wineventlog',
+                'event_id': 123456789,
+                'event_data': {
+                    'some_timestamp_utc': '1642160449843'
+                }
+            }
+        }
+
+        event = {
+            'winlog': {
+                'api': 'wineventlog',
+                'event_id': 123456789,
+                'event_data': {
+                    'some_timestamp_utc': '1642160449843'
+                }
+            }
+        }
+
+        rule = {
+            'filter': 'winlog.event_id: 123456789',
+            'normalize': {
+                'winlog.event_data.some_timestamp_utc': {
+                    'timestamp': {
+                        'destination': '@timestamp',
+                        'source_formats': ['UNIX'],
+                        'source_timezone': 'UTC',
+                        'destination_timezone': 'Europe/Berlin'
+                    }
+                }
+            }
+        }
+
+        self._load_specific_rule(normalizer, rule)
+        normalizer.process(event)
+
+        assert event == expected
+
+    def test_normalization_from_UNIX_with_seconds_timestamp(self, normalizer):
+        expected = {
+            '@timestamp': '2022-01-14T12:40:49+01:00',
+            'winlog': {
+                'api': 'wineventlog',
+                'event_id': 123456789,
+                'event_data': {
+                    'some_timestamp_utc': '1642160449'
+                }
+            }
+        }
+
+        event = {
+            'winlog': {
+                'api': 'wineventlog',
+                'event_id': 123456789,
+                'event_data': {
+                    'some_timestamp_utc': '1642160449'
+                }
+            }
+        }
+
+        rule = {
+            'filter': 'winlog.event_id: 123456789',
+            'normalize': {
+                'winlog.event_data.some_timestamp_utc': {
+                    'timestamp': {
+                        'destination': '@timestamp',
+                        'source_formats': ['UNIX'],
+                        'source_timezone': 'UTC',
+                        'destination_timezone': 'Europe/Berlin'
+                    }
+                }
+            }
+        }
+
+        self._load_specific_rule(normalizer, rule)
+        normalizer.process(event)
+
+        assert event == expected
+
     def test_normalization_from_timestamp_with_non_matching_patterns(self, normalizer):
         event = {
             'winlog': {


### PR DESCRIPTION
This pull request implements a unix source format feature for the timestamp normalization. With this it is possible to use 'UNIX' in a normalization rule to normalize a unix epoch timestamp. This works with seconds and milliseconds. 