### PR TITLE
Add a hmac to an incoming event from kafka

### DIFF
--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -1,16 +1,20 @@
 """This module contains functionality that allows to establish a connection with kafka."""
-
-from typing import List, Optional
+import hashlib
+from base64 import b64encode
 from copy import deepcopy
 from datetime import datetime
-import ujson
+from hmac import HMAC
 from socket import getfqdn
+from typing import List, Optional
+from zlib import compress
 
+import ujson
 from confluent_kafka import Consumer, Producer
 
 from logprep.connector.connector_factory_error import InvalidConfigurationError
 from logprep.input.input import Input, CriticalInputError
 from logprep.output.output import Output, CriticalOutputError
+from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
 class ConfluentKafkaError(BaseException):
@@ -133,7 +137,12 @@ class ConfluentKafka(Input, Output):
                 'auto_commit': True,
                 'session_timeout': 6000,
                 'offset_reset_policy': 'smallest',
-                'enable_auto_offset_store': enable_auto_offset_store
+                'enable_auto_offset_store': enable_auto_offset_store,
+                'hmac': {
+                    'target': "",
+                    'key': "",
+                    'output_field': ""
+                }
             },
             'producer': {
                 'ack_policy': 'all',
@@ -152,6 +161,8 @@ class ConfluentKafka(Input, Output):
         self._producer = None
 
         self._record = None
+
+        self._add_hmac = False
 
         self._enable_auto_offset_store = enable_auto_offset_store
 
@@ -200,6 +211,9 @@ class ConfluentKafka(Input, Output):
             Raises if an option is invalid.
 
         """
+
+        valid_hmac_options = set(self._config.get('consumer', {}).get('hmac', {}).keys())
+
         for key in new_options:
             if key not in self._config:
                 raise UnknownOptionError(f'Unknown Option: {key}')
@@ -208,6 +222,27 @@ class ConfluentKafka(Input, Output):
                     if subkey not in self._config[key]:
                         raise UnknownOptionError(f'Unknown Option: {key}/{subkey}')
                     self._config[key][subkey] = new_options[key][subkey]
+
+        # validate hmac subfields
+        if new_options.get('consumer', {}).get('hmac', None) is not None:
+            new_hmac_options_keys = set(new_options.get('consumer', {}).get('hmac').keys())
+            unknown_options = new_hmac_options_keys.difference(valid_hmac_options)
+            if unknown_options:
+                raise UnknownOptionError(f'Unknown Hmac Options: {unknown_options}')
+
+            missing_options = valid_hmac_options.difference(new_hmac_options_keys)
+            if missing_options:
+                raise InvalidConfigurationError(f'Hmac option(s) missing: {missing_options}')
+
+            for key in valid_hmac_options:
+                config_value = self._config['consumer']['hmac'][key]
+                if not isinstance(config_value, str):
+                    raise InvalidConfigurationError(f"Hmac option '{key}' has wrong type: '{type(config_value)}', "
+                                                    f"expected 'str'")
+                if len(config_value) == 0:
+                    raise InvalidConfigurationError(f"Hmac option '{key}' is empty: '{config_value}'")
+
+            self._add_hmac = True
 
     def get_next(self, timeout: float) -> Optional[dict]:
         """Get next document from Kafka.
@@ -241,9 +276,15 @@ class ConfluentKafka(Input, Output):
             raise CriticalInputError('A confluent-kafka record contains an error code: '
                                      '({})'.format(self._record.error()), None)
         try:
-            json_dict = ujson.loads(self._record.value().decode("utf-8"))
-            if isinstance(json_dict, dict):
-                return json_dict
+            raw_event = self._record.value()
+            event_dict = ujson.loads(raw_event.decode("utf-8"))
+
+            if self._add_hmac:
+                hmac_target_field_name = self._config['consumer']['hmac']['target']
+                event_dict = self._add_hmac_to(event_dict, hmac_target_field_name, raw_event)
+
+            if isinstance(event_dict, dict):
+                return event_dict
             raise InvalidMessageError
         except ValueError as error:
             raise CriticalInputError('Input record value is not a valid json string: '
@@ -256,6 +297,64 @@ class ConfluentKafka(Input, Output):
         except BaseException as error:
             raise CriticalInputError('Error parsing input record: ({})'.format(
                 self._format_message(error)), self._record.value().decode("utf-8")) from error
+
+    def _add_hmac_to(self, event_dict, hmac_target_field_name, raw_event):
+        """
+        Calculates an HMAC (Hash-based message authentication code) based on a given target field and adds it to the
+        given event. If the target field has the value '<RAW_MSG>' the full raw byte message is used instead as a
+        target for the HMAC calculation. As a result the target field value and the resulting hmac will be added to
+        the original event. The target field value will be compressed and base64 encoded though to reduce memory usage.
+
+        Parameters
+        ----------
+        event_dict: dict
+            The event to which the calculated hmac should be appended
+        hmac_target_field_name: str
+            The dotted field name of the target value that should be used for the hmac calculation. If instead
+            '<RAW_MSG>' is used then the hmac will be calculated over the full raw event.
+        raw_event: bytearray
+            The raw event how it is received from kafka.
+
+        Returns
+        -------
+        event_dict: dict
+            The original event extended with a field that has the hmac and the corresponding target field, which was
+            used to calculate the hmac.
+        """
+
+        # calculate hmac of full raw message
+        if hmac_target_field_name == "<RAW_MSG>":
+            received_orig_message = raw_event
+            hmac = HMAC(
+                key=self._config['consumer']['hmac']['key'].encode(),
+                msg=raw_event,
+                digestmod=hashlib.sha256).hexdigest()
+        else:
+            # calculate hmac of dotted field value
+            received_orig_message = get_dotted_field_value(event_dict, hmac_target_field_name)
+            if received_orig_message is not None:
+                received_orig_message = received_orig_message.encode()
+                hmac = HMAC(
+                    key=self._config['consumer']['hmac']['key'].encode(),
+                    msg=received_orig_message,
+                    digestmod=hashlib.sha256).hexdigest()
+            else:
+                hmac = "error"
+                received_orig_message = f"<expected hmac target field '{hmac_target_field_name}' not found>".encode()
+                self.store_failed(f"Couldn't find the hmac target field '{hmac_target_field_name}'",
+                                  event_dict, event_dict)
+
+        # compress received_orig_message and create output with base 64 encoded compressed received_orig_message
+        compressed = compress(received_orig_message, level=-1)
+        hmac_output = {"hmac": hmac, "compressed_base64": b64encode(compressed).decode()}
+
+        # add hmac result to the original event
+        add_was_successful = add_field_to(event_dict, self._config['consumer']['hmac']['output_field'], hmac_output)
+        if not add_was_successful:
+            self.store_failed(f"Couldn't add the hmac to the input event as the desired output "
+                              f"field '{self._config['consumer']['hmac']['output_field']}' already exist.",
+                              event_dict, event_dict)
+        return event_dict
 
     @staticmethod
     def _format_message(error: BaseException) -> str:

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,6 +1,6 @@
 """This module contains helper functions that are shared by different modules."""
 
-from typing import Optional
+from typing import Optional, Union
 
 from colorama import Fore, Back
 from colorama.ansi import AnsiFore, AnsiBack
@@ -25,6 +25,7 @@ def print_bcolor(back: AnsiBack, message: str):
 def print_fcolor(fore: AnsiFore, message: str):
     """Print string with colored font and reset the color afterwards."""
     print_color(None, fore, message)
+
 
 def add_field_to(event, output_field, content):
     """
@@ -58,7 +59,7 @@ def add_field_to(event, output_field, content):
                 break
             dict_[key] = dict()
 
-        if isinstance(dict_[key], dict):
+        if isinstance(dict_[key], dict) and idx < len(keys) - 1:
             dict_ = dict_[key]
         else:
             conflicting_fields.append(keys[idx])
@@ -67,3 +68,33 @@ def add_field_to(event, output_field, content):
         return False
     else:
         return True
+
+
+def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dict, list, str]]:
+    """
+    Returns the value of a requested dotted_field by iterating over the event dictionary until the field was found.
+    In case the field could not be found None is returned
+
+    Parameters
+    ----------
+    event: dict
+        The event from which the dotted field value should be extracted
+    dotted_field: str
+        The dotted field name which identifies the requested value
+
+    Returns
+    -------
+    dict_: dict, list, str
+        The value of the requested dotted field.
+
+    # code is originally from the BaseProcessor, such that duplicated code could be removed there.
+    """
+
+    fields = dotted_field.split('.')
+    dict_ = event
+    for field in fields:
+        if field in dict_ and isinstance(dict_, dict):
+            dict_ = dict_[field]
+        else:
+            return None
+    return dict_

--- a/tests/acceptance/test_full_message_pass_with_hmac.py
+++ b/tests/acceptance/test_full_message_pass_with_hmac.py
@@ -1,0 +1,119 @@
+from logging import Handler
+from os.path import join
+from unittest.mock import patch
+
+import pytest
+import ujson
+
+from logprep.connector.confluent_kafka import ConfluentKafkaFactory
+from logprep.framework.pipeline import Pipeline, SharedCounter
+from tests.acceptance.util import create_temporary_config_file_at_path
+from tests.unit.connector.test_confluent_kafka import RecordMock
+
+
+@pytest.fixture
+def config():
+    config_yml = {
+        'process_count': 1,
+        'timeout': 0.1,
+        'profile_pipelines': False,
+        'pipeline': [
+            {
+                'normalizername': {
+                    'type': 'normalizer',
+                    'specific_rules': ['tests/testdata/acceptance/normalizer/rules_static/specific'],
+                    'generic_rules': ['tests/testdata/acceptance/normalizer/rules_static/generic'],
+                    'regex_mapping': 'tests/testdata/acceptance/normalizer/rules_static/regex_mapping.yml'
+                }
+            }
+        ],
+        'connector': {
+            'type': 'confluentkafka',
+            'bootstrapservers': ['testserver:9092'],
+            'consumer': {
+                'topic': 'test_input_raw',
+                'group': 'test_consumergroup',
+                'auto_commit': False,
+                'session_timeout': 654321,
+                'enable_auto_offset_store': True,
+                'offset_reset_policy': 'latest',
+                'hmac': {
+                    'target': "<RAW_MSG>",
+                    'key': "secret",
+                    'output_field': "hmac"
+                }
+            },
+            'producer': {
+                'topic': 'test_input_processed',
+                'error_topic': 'test_error_producer',
+                'ack_policy': '1',
+                'compression': 'gzip',
+                'maximum_backlog': 987654,
+                'send_timeout': 2,
+                'flush_timeout': 30,
+                'linger_duration': 4321,
+            }
+        }
+    }
+    return config_yml
+
+
+class SingleMessageConsumerJsonMock:
+
+    def __init__(self, record):
+        self.record = ujson.encode(record)
+
+    def poll(self, timeout):
+        return RecordMock(self.record, None)
+
+
+class TmpFileProducerMock:
+
+    def __init__(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def produce(self, target, value):
+        with open(self.tmp_path, "wb") as f:
+            f.write(value)
+
+    def poll(self, _):
+        ...
+
+
+class TestFullHMACPassTest:
+
+    def test_full_message_pass_with_hmac(self, tmp_path, config):
+        config_path = str(tmp_path / 'generated_config.yml')
+        create_temporary_config_file_at_path(config_path, config)
+
+        with patch('logprep.connector.connector_factory.ConnectorFactory.create') as mock_connector_factory:
+            input_test_event = {"test": "message"}
+            expected_output_event = {
+                'test': 'message',
+                'hmac': {
+                    'hmac': '5a77054b5f1d9ea60000520a4e2cf661e7a11de4205ca70c6977fc8040076a6e',
+                    'compressed_base64': 'eJyrVipJLS5RslLKTS0uTkxPVaoFADwCBmA='
+                }
+            }
+
+            # create kafka connector manually and add custom mock consumer and mock producer objects
+            kafka = ConfluentKafkaFactory.create_from_configuration(config['connector'])
+            kafka._consumer = SingleMessageConsumerJsonMock(input_test_event)
+            output_file_path = join(tmp_path, "kafka_out.txt")
+            kafka._producer = TmpFileProducerMock(output_file_path)
+            mock_connector_factory.return_value = (kafka, kafka)
+
+            # Create and setup logprep pipeline
+            pipeline = Pipeline(config['connector'], config['pipeline'], config['timeout'],
+                                SharedCounter(), Handler(), 300, 1800, dict())
+            pipeline._setup()
+
+            # execute full logprep pipeline call
+            pipeline._retrieve_and_process_data()
+
+            # read logprep kafka output from mocked kafka file producer
+            with open(output_file_path, "rb") as f:
+                content = ujson.loads(f.read())
+
+            # compare logprep output with expected output
+            assert content == expected_output_event

--- a/tests/unit/connector/test_confluent_kafka.py
+++ b/tests/unit/connector/test_confluent_kafka.py
@@ -1,9 +1,12 @@
+from base64 import b64decode
 from copy import deepcopy
 from datetime import datetime
 from json import loads
 from math import isclose
 from socket import getfqdn
+from zlib import decompress
 
+import ujson
 from pytest import fail, raises
 
 from logprep.connector.confluent_kafka import ConfluentKafka, ConfluentKafkaFactory, UnknownOptionError
@@ -103,6 +106,19 @@ class TestConfluentKafkaFactory:
             'maximum_backlog']
         assert kafka._config['producer']['send_timeout'] == self.config['producer']['send_timeout']
 
+    def test_config_has_hmac_settings(self):
+        self.config['consumer']['hmac'] = {
+            'target': "<RAW_MSG>",
+            'key': "hmac-test-key",
+            'output_field': "Hmac"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(self.config)
+
+        assert kafka._config['consumer']['hmac']['target'] == "<RAW_MSG>"
+        assert kafka._config['consumer']['hmac']['key'] == "hmac-test-key"
+        assert kafka._config['consumer']['hmac']['output_field'] == "Hmac"
+
 
 class NotJsonSerializableMock:
     pass
@@ -148,6 +164,15 @@ class RecordMock:
         return -1
 
 
+class ConsumerJsonMock:
+
+    def __init__(self, record):
+        self.record = ujson.encode(record)
+
+    def poll(self, timeout):
+        return RecordMock(self.record, None)
+
+
 class ConsumerInvalidJsonMock:
     def poll(self, timeout):
         return RecordMock('This is not a valid JSON string!', None)
@@ -162,6 +187,11 @@ class ConsumerRecordWithKafkaErrorMock:
 class ConsumerNoRecordMock:
     def poll(self, timeout):
         return None
+
+
+def decode_b64_and_decompress(message):
+    decoded = b64decode(message)
+    return decompress(decoded)
 
 
 class TestConfluentKafka:
@@ -387,3 +417,198 @@ class TestConfluentKafka:
                     match=r'Error storing output document\: \(TypeError: <tests\.unit\.connector\.test_confluent_kafka'
                           r'\.NotJsonSerializableMock object at 0x[a-zA-Z0-9]{12}> is not JSON serializable\)'):
             self.kafka.store({'invalid_json': NotJsonSerializableMock(), 'something_valid': 'im_valid!'})
+
+    def test_get_next_with_hmac_of_raw_message(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {
+            'target': "<RAW_MSG>",
+            'key': "hmac-test-key",
+            'output_field': "Hmac"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        test_event = {"message": "with_content"}
+        expected_event = {
+            "message": "with_content",
+            'Hmac': {
+                'compressed_base64': 'eJyrVspNLS5OTE9VslIqzyzJiE/OzytJzStRqgUAgKkJtg==',
+                'hmac': 'dfe78753da634d7b76760488dbb2cf7bfe1b0e4e794930c36e98a984b6b6be63'
+            }
+        }
+
+        kafka._consumer = ConsumerJsonMock(test_event)
+
+        kafka_next_msg = kafka.get_next(1)
+
+        assert kafka_next_msg == expected_event, "Output event with hmac is not as expected"
+
+        decoded_message = decode_b64_and_decompress(kafka_next_msg['Hmac']['compressed_base64'])
+        assert test_event == ujson.loads(decoded_message.decode("utf-8")), \
+            "The hmac base massage was not correctly encoded and compressed. "
+
+    def test_get_next_with_hmac_of_subfield(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {
+            'target': "message.with_subfield",
+            'key': "hmac-test-key",
+            'output_field': "Hmac"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        test_event = {"message": {"with_subfield": "content"}}
+        expected_event = {
+            "message": {"with_subfield": "content"},
+            'Hmac': {
+                'compressed_base64': 'eJxLzs8rSc0rAQALywL8',
+                'hmac': 'e01e02a09cb270eebf7ae846b96d7306681038bd279f85d44c77019e0c4f6316'
+            }
+        }
+
+        kafka._consumer = ConsumerJsonMock(test_event)
+
+        kafka_next_msg = kafka.get_next(1)
+        assert kafka_next_msg == expected_event
+
+        decoded_message = decode_b64_and_decompress(kafka_next_msg['Hmac']['compressed_base64'])
+        assert test_event['message']['with_subfield'] == decoded_message.decode("utf-8"), \
+            "The hmac base massage was not correctly encoded and compressed. "
+
+    def test_get_next_with_hmac_of_non_existing_subfield(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {
+            'target': "non_existing_field",
+            'key': "hmac-test-key",
+            'output_field': "Hmac"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        test_event = {"message": {"with_subfield": "content"}}
+        expected_output_event = {
+            "message": {"with_subfield": "content"},
+            'Hmac': {
+                'hmac': 'error',
+                'compressed_base64': 'eJyzSa0oSE0uSU1RyMhNTFYoSSxKTy1RSMtMzUlRUM/Lz4tPrcgsLsnMS48Hi6kr5OUDpfNL81LsAJILFeQ='
+            }
+        }
+        kafka._consumer = ConsumerJsonMock(test_event)
+        kafka._producer = ProducerMock()
+
+        kafka_next_msg = kafka.get_next(1)
+        assert kafka_next_msg == expected_output_event
+
+        decoded_message = decode_b64_and_decompress(kafka_next_msg['Hmac']['compressed_base64']).decode()
+        assert decoded_message == "<expected hmac target field 'non_existing_field' not found>"
+
+        assert len(kafka._producer.produced) == 1
+        assert kafka._producer.produced[0][1]['error'] == "Couldn't find the hmac target field 'non_existing_field'"
+        assert kafka._producer.produced[0][1]['original'] == test_event
+
+    def test_get_next_with_hmac_result_in_dotted_subfield(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {
+            'target': "<RAW_MSG>",
+            'key': "hmac-test-key",
+            'output_field': "Hmac.dotted.subfield"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        test_event = {"message": "with_content"}
+        expected_event = {
+            "message": "with_content",
+            'Hmac': {
+                'dotted': {
+                    'subfield': {
+                        'compressed_base64': 'eJyrVspNLS5OTE9VslIqzyzJiE/OzytJzStRqgUAgKkJtg==',
+                        'hmac': 'dfe78753da634d7b76760488dbb2cf7bfe1b0e4e794930c36e98a984b6b6be63'
+                    }
+                }
+            }
+        }
+
+        kafka._consumer = ConsumerJsonMock(test_event)
+
+        kafka_next_msg = kafka.get_next(1)
+        assert kafka_next_msg == expected_event
+
+        decoded_message = decode_b64_and_decompress(kafka_next_msg['Hmac']['dotted']['subfield']['compressed_base64'])
+        assert test_event == ujson.loads(decoded_message.decode("utf-8")), \
+            "The hmac base massage was not correctly encoded and compressed. "
+
+    def test_get_next_with_hmac_result_in_already_existing_subfield(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {
+            'target': "<RAW_MSG>",
+            'key': "hmac-test-key",
+            'output_field': "message"
+        }
+
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        test_event = {"message": {"with_subfield": "content"}}
+        kafka._consumer = ConsumerJsonMock(test_event)
+        kafka._producer = ProducerMock()
+
+        _ = kafka.get_next(1)
+
+        assert len(kafka._producer.produced) == 1
+        assert kafka._producer.produced[0][1]['error'] == "Couldn't add the hmac to the input event as the desired output field 'message' already exist."
+        assert kafka._producer.produced[0][1]['original'] == test_event
+
+    def test_get_next_with_wrong_or_missing_hmac_config(self):
+        for key in ['target', 'key', 'output_field']:
+            # set default config
+            config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+            config['consumer']['hmac'] = {'target': "<RAW_MSG>", 'key': "hmac-test-key", 'output_field': "Hmac"}
+
+            # drop option to test for missing option error message
+            del config['consumer']['hmac'][key]
+            with raises(InvalidConfigurationError, match=fr"Hmac option\(s\) missing: {{'{key}'}}"):
+                _ = ConfluentKafkaFactory.create_from_configuration(config)
+
+        # set default config
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        config['consumer']['hmac'] = {'target': "<RAW_MSG>", 'key': "hmac-test-key", 'output_field': "Hmac"}
+
+        # add additional unknown option and test for error message
+        config['consumer']['hmac'] = {'unknown': "option"}
+        with raises(InvalidConfigurationError, match=r"Confluent Kafka: Unknown Hmac Options: {'unknown'}"):
+            _ = ConfluentKafkaFactory.create_from_configuration(config)
+
+    def test_get_next_with_broken_hmac_config(self):
+        for key in ['target', 'key', 'output_field']:
+            # set default config
+            config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+            config['consumer']['hmac'] = {'target': "<RAW_MSG>", 'key': "hmac-test-key", 'output_field': "Hmac"}
+
+            # set one option to non str type and test for error message
+            config['consumer']['hmac'][key] = 1
+            with raises(InvalidConfigurationError, match=fr"Hmac option '{key}' has wrong type: '<class 'int'>', "
+                                                         r"expected 'str'"):
+                _ = ConfluentKafkaFactory.create_from_configuration(config)
+
+            # empty one option and test for error message
+            config['consumer']['hmac'][key] = ''
+            with raises(InvalidConfigurationError, match=fr"Hmac option '{key}' is empty: ''"):
+                _ = ConfluentKafkaFactory.create_from_configuration(config)
+
+    def test_get_next_without_hmac(self):
+        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
+        kafka = ConfluentKafkaFactory.create_from_configuration(config)
+
+        # configuration is not set
+        assert kafka._config['consumer']['hmac']['target'] == ''
+        assert kafka._config['consumer']['hmac']['key'] == ''
+        assert kafka._config['consumer']['hmac']['output_field'] == ''
+
+        test_event = {"message": "with_content"}
+        expected_event = {"message": "with_content"}
+
+        kafka._consumer = ConsumerJsonMock(test_event)
+
+        # output message is the same as the input message
+        kafka_next_msg = kafka.get_next(1)
+        assert kafka_next_msg == expected_event

--- a/tests/unit/util/test_helper_add_field.py
+++ b/tests/unit/util/test_helper_add_field.py
@@ -1,0 +1,86 @@
+from logprep.util.helper import add_field_to
+
+
+class TestHelperAddField:
+
+    def test_add_str_content_as_new_root_field(self):
+        document = {'source': {'ip': '8.8.8.8'}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "field": "content"}
+
+        add_was_successful = add_field_to(document, "field", "content")
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_add_str_content_as_completely_new_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": "content"}}
+
+        add_was_successful = add_field_to(document, "sub.field", "content")
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_add_str_content_as_partially_new_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}, "sub": {"other_field": "other_content"}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": "content", "other_field": "other_content"}}
+
+        add_was_successful = add_field_to(document, "sub.field", "content")
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_provoke_str_duplicate_in_root_field(self):
+        document = {'source': {'ip': '8.8.8.8'}, "field": "exists already"}
+
+        add_was_successful = add_field_to(document, "field", "content")
+
+        assert not add_was_successful, "Found no duplicate even though there should be one"
+
+    def test_provoke_str_duplicate_in_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": "exists already"}}
+
+        add_was_successful = add_field_to(document, "sub.field", "content")
+
+        assert not add_was_successful, "Found no duplicate even though there should be one"
+
+    def test_add_dict_content_as_new_root_field(self):
+        document = {'source': {'ip': '8.8.8.8'}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "field": {"dict": "content"}}
+
+        add_was_successful = add_field_to(document, "field", {"dict": "content"})
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_add_dict_content_as_completely_new_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": {"dict": "content"}}}
+
+        add_was_successful = add_field_to(document, "sub.field", {"dict": "content"})
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_add_dict_content_as_partially_new_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}, "sub": {"other_field": "other_content"}}
+        expected_document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": {"dict": "content"}, "other_field": "other_content"}}
+
+        add_was_successful = add_field_to(document, "sub.field", {"dict": "content"})
+
+        assert add_was_successful, "Found duplicate even though there shouldn't be one"
+        assert document == expected_document
+
+    def test_provoke_dict_duplicate_in_root_field(self):
+        document = {'source': {'ip': '8.8.8.8'}, "field": {"already_existing": "dict"}}
+
+        add_was_successful = add_field_to(document, "field", {"dict": "content"})
+
+        assert not add_was_successful, "Found no duplicate even though there should be one"
+
+    def test_provoke_dict_duplicate_in_dotted_subfield(self):
+        document = {'source': {'ip': '8.8.8.8'}, "sub": {"field": {"already_existing": "dict"}}}
+
+        add_was_successful = add_field_to(document, "sub.field", {"dict": "content"})
+
+        assert not add_was_successful, "Found no duplicate even though there should be one"


### PR DESCRIPTION
This modification to the confluent kafka connector allows to verify the integrity of an incoming message