### PR TITLE
Add dotted output fields for the geoip enricher processor

### DIFF
--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -1082,10 +1082,10 @@ Assuming that the value :code:`non_privileged_user` will match the provided list
 GeoIP Enricher
 ==============
 
-The generic adder requires the additional field :code:`geoip`.
-This output_field can be overridden using the optional parameter :code:`output_field`.
-The additional field :code:`geoip.source_ip` must be given.
-It contains the IP for which the geoip data should be added.
+The geoip enricher requires the additional field :code:`geoip`.
+The default output_field can be overridden using the optional parameter :code:`output_field`. This can be a dotted
+subfield. The additional field :code:`geoip.source_ip` must be given. It contains the IP for which the geoip data
+should be added.
 
 In the following example the IP in :code:`client.ip` will be enriched with geoip data.
 

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -20,6 +20,7 @@ from logprep.processor.base.exceptions import (NotARulesDirectoryError, InvalidR
 
 from logprep.util.processor_stats import ProcessorStats
 from logprep.util.time_measurement import TimeMeasurement
+from logprep.util.helper import add_field_to
 
 
 class GeoIPEnricherError(BaseException):
@@ -167,7 +168,7 @@ class GeoIPEnricher(RuleBasedProcessor):
             ip_string = self._get_dotted_field_value(event, source_ip)
             geoip_data = self._try_getting_geoip_data(ip_string)
             if geoip_data:
-                if output_field not in event:
-                    event[output_field] = geoip_data
-                elif event[output_field] != geoip_data:
+                adding_was_successful = add_field_to(event, output_field, geoip_data)
+
+                if not adding_was_successful:
                     raise DuplicationError(self._name, [output_field])

--- a/tests/testdata/unit/geoip_enricher/rules/geoip_all.json
+++ b/tests/testdata/unit/geoip_enricher/rules/geoip_all.json
@@ -6,7 +6,7 @@
   "filter": "source.ip",
   "geoip_enricher": {
     "source_ip": "source.ip",
-    "output_field": "source_geo_data"
+    "output_field": "source.geo.ip"
   },
   "description": ""
 }]

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -85,9 +85,9 @@ class TestGeoIPEnricher:
                                                    r' geoip'):
             geoip_enricher.process(document)
 
-    def test_configured_output_field(self, geoip_enricher):
+    def test_configured_dotted_output_field(self, geoip_enricher):
         assert geoip_enricher.events_processed_count() == 0
         document = {'source': {'ip': '8.8.8.8'}}
 
         geoip_enricher.process(document)
-        assert document.get('source_geo_data') is not None
+        assert document.get('source', {}).get('geo', {}).get('ip') is not None


### PR DESCRIPTION
This allows to save the geoip data in custom subfields, depending on the configured dotted output field.