### PR TITLE
Refactor code to decouple source code from test code

### DIFF
--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -139,7 +139,7 @@ def main():
     elif args.dry_run:
         json_input = True if args.dry_run_input_type == 'json' else False
         dry_runner = DryRunner(args.dry_run, args.config,
-                               args.dry_run_full_output, json_input)
+                               args.dry_run_full_output, json_input, logger)
         dry_runner.run()
     else:
         _run_logprep(args, logger, status_logger)

--- a/logprep/util/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester.py
@@ -20,7 +20,6 @@ from difflib import ndiff
 from ruamel.yaml import YAML, YAMLError
 
 from logprep.framework.rule_tree.rule_tree import RuleTree
-from tests.acceptance.util import remove_file_if_exists
 
 from logprep.processor.processor_factory import ProcessorFactory
 from logprep.processor.base.rule import Rule
@@ -29,7 +28,7 @@ from logprep.processor.base.processor import RuleBasedProcessor
 from logprep.processor.pre_detector.processor import PreDetector
 
 from logprep.util.grok_pattern_loader import GrokPatternLoader as gpl
-from logprep.util.helper import print_fcolor
+from logprep.util.helper import print_fcolor, remove_file_if_exists
 
 logger = getLogger()
 logger.disabled = True

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,5 +1,5 @@
 """This module contains helper functions that are shared by different modules."""
-
+from os import remove
 from typing import Optional, Union
 
 from colorama import Fore, Back
@@ -103,3 +103,38 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         else:
             return None
     return dict_
+
+
+def recursive_compare(test_output, expected_output):
+    result = None
+
+    if not isinstance(test_output, type(expected_output)):
+        return test_output, expected_output
+
+    elif isinstance(test_output, dict) and isinstance(expected_output, dict):
+        if sorted(test_output.keys()) != sorted(expected_output.keys()):
+            return sorted(test_output.keys()), sorted(expected_output.keys())
+
+        for key in test_output.keys():
+            result = recursive_compare(test_output[key], expected_output[key])
+            if result:
+                return result
+
+    elif isinstance(test_output, list) and isinstance(expected_output, list):
+        for x, _ in enumerate(test_output):
+            result = recursive_compare(test_output[x], expected_output[x])
+            if result:
+                return result
+
+    else:
+        if test_output != expected_output:
+            result = test_output, expected_output
+
+    return result
+
+
+def remove_file_if_exists(test_output_path):
+    try:
+        remove(test_output_path)
+    except FileNotFoundError:
+        pass

--- a/logprep/util/json_handling.py
+++ b/logprep/util/json_handling.py
@@ -1,0 +1,60 @@
+import json
+
+from yaml import safe_dump
+
+
+def dump_config_as_file(config_path, config):
+    """
+    Saves a config file based on the given config dictionary.
+
+    Parameters
+    ----------
+    config_path: str
+        The path were the File should be saved
+    config: dict
+        The configuration that should be saved
+    """
+
+    with open(config_path, 'w') as generated_config_file:
+        safe_dump(config, generated_config_file)
+
+
+def parse_jsonl(jsonl_path):
+    """
+    Read and parse all json events from a given jsonl file.
+
+    Parameters
+    ----------
+    jsonl_path: str
+        Path to the jsonl file that contains all the events.
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries where each dictionary represents one event
+    """
+    parsed_events = []
+    with open(jsonl_path, 'r') as jsonl_file:
+        for json_string in jsonl_file.readlines():
+            if json_string.strip() != '':
+                event = json.loads(json_string)
+                parsed_events.append(event)
+    return parsed_events
+
+
+def parse_json(json_path):
+    """
+    Reads and parses one json file
+
+    Parameters
+    ----------
+    json_path: str
+        Path to the json file.
+
+    Returns
+    -------
+    dict
+        The dictionary representing the json.
+    """
+    with open(json_path, 'r') as json_file:
+        return json.load(json_file)

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -12,18 +12,49 @@ import json
 from ruamel.yaml import YAML
 from colorama import Fore, Back
 
-from logprep.util.helper import print_color
-
-from tests.acceptance.util import (create_temporary_config_file_at_path, get_test_output_multi,
-                                   parse_json, parse_jsonl, recursive_compare)
+from logprep.runner import Runner
+from logprep.util.helper import print_color, recursive_compare, remove_file_if_exists
+from logprep.util.json_handling import dump_config_as_file, parse_jsonl, parse_json
 
 yaml = YAML(typ='safe', pure=True)
+
+
+def get_test_output_multi(config_path, logger):
+    patched_runner = get_patched_runner(config_path, logger)
+
+    parsed_outputs = list()
+    output_paths = list()
+    output_paths.append(patched_runner._configuration['connector'].get('output_path', None))
+    output_paths.append(patched_runner._configuration['connector'].get('output_path_custom', None))
+    output_paths.append(patched_runner._configuration['connector'].get('output_path_errors', None))
+    output_paths = [output_path for output_path in output_paths if output_path]
+
+    for output_path in output_paths:
+        remove_file_if_exists(output_path)
+
+    patched_runner.start()
+
+    for output_path in output_paths:
+        parsed_outputs.append(parse_jsonl(output_path))
+        remove_file_if_exists(output_path)
+
+    return parsed_outputs
+
+
+def get_patched_runner(config_path, logger):
+    runner = Runner(bypass_check_to_obtain_non_singleton_instance=True)
+    runner.set_logger(logger)
+    runner.load_configuration(config_path)
+    # patch runner to stop on empty pipeline
+    runner._keep_iterating = lambda: False
+
+    return runner
 
 
 class DryRunner:
     """Used to run pipeline with given events and show changes made by processing."""
 
-    def __init__(self, dry_run: str, config_path: str, full_output: str, use_json: bool):
+    def __init__(self, dry_run: str, config_path: str, full_output: str, use_json: bool, logger):
         with open(config_path, 'r') as yaml_file:
             self._config_yml = yaml.load(yaml_file)
 
@@ -31,10 +62,12 @@ class DryRunner:
         self._use_json = use_json
 
         self._config_yml['connector'] = {
-                'type': 'writer_json_input' if use_json else 'writer',
-                'input_path': dry_run
-            }
+            'type': 'writer_json_input' if use_json else 'writer',
+            'input_path': dry_run
+        }
         self._config_yml['process_count'] = 1
+
+        self._logger = logger
 
     def run(self):
         """Run the dry runner."""
@@ -47,9 +80,9 @@ class DryRunner:
                                                                         'output_errors.jsonl')
 
         config_path = path.join(tmp_path, 'generated_config.yml')
-        create_temporary_config_file_at_path(config_path, self._config_yml)
+        dump_config_as_file(config_path, self._config_yml)
 
-        test_output, test_output_custom, test_output_error = get_test_output_multi(config_path)
+        test_output, test_output_custom, test_output_error = get_test_output_multi(config_path, self._logger)
 
         input_path = self._config_yml['connector']['input_path']
         input_data = parse_json(input_path) if self._use_json else parse_jsonl(input_path)

--- a/tests/acceptance/test_full_message_pass_with_hmac.py
+++ b/tests/acceptance/test_full_message_pass_with_hmac.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 import pytest
 import ujson
 
-from tests.acceptance.util import create_temporary_config_file_at_path, mock_kafka_and_run_pipeline, \
-    get_default_logprep_config
+from tests.acceptance.util import mock_kafka_and_run_pipeline,  get_default_logprep_config
+from logprep.util.json_handling import dump_config_as_file
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ class TestFullHMACPassTest:
 
     def test_full_message_pass_with_hmac(self, tmp_path, config):
         config_path = str(tmp_path / 'generated_config.yml')
-        create_temporary_config_file_at_path(config_path, config)
+        dump_config_as_file(config_path, config)
 
         with patch('logprep.connector.connector_factory.ConnectorFactory.create') as mock_connector_factory:
             input_test_event = {"test": "message"}

--- a/tests/acceptance/test_pre_detection.py
+++ b/tests/acceptance/test_pre_detection.py
@@ -2,6 +2,8 @@
 import pytest
 
 from tests.acceptance.util import *
+from logprep.util.helper import recursive_compare
+from logprep.util.json_handling import dump_config_as_file, parse_jsonl
 
 basicConfig(level=DEBUG, format='%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s')
 logger = getLogger('Logprep-Test')
@@ -37,7 +39,7 @@ def test_events_pre_detected_correctly(tmp_path, config):
     expected_output_path = path.join('tests/testdata/acceptance/expected_result', expected_output)
 
     config_path = str(tmp_path / 'generated_config.yml')
-    create_temporary_config_file_at_path(config_path, config)
+    dump_config_as_file(config_path, config)
 
     test_output = get_test_output(config_path)
     store_latest_test_output(expected_output, test_output)

--- a/tests/acceptance/test_selective_extractor_full_pipeline_pass.py
+++ b/tests/acceptance/test_selective_extractor_full_pipeline_pass.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 import pytest
 import ujson
 
-from tests.acceptance.util import create_temporary_config_file_at_path, mock_kafka_and_run_pipeline, \
-    get_default_logprep_config
+from tests.acceptance.util import mock_kafka_and_run_pipeline, get_default_logprep_config
+from logprep.util.json_handling import dump_config_as_file
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ class TestSelectiveExtractor:
 
     def test_selective_extractor_full_pipeline_pass(self, tmp_path, config):
         config_path = str(tmp_path / 'generated_config.yml')
-        create_temporary_config_file_at_path(config_path, config)
+        dump_config_as_file(config_path, config)
 
         with patch('logprep.connector.connector_factory.ConnectorFactory.create') as mock_connector_factory:
             input_test_event = {
@@ -71,7 +71,7 @@ class TestSelectiveExtractor:
     def test_extraction_field_not_in_event(self, tmp_path, config):
         # tests behaviour in case a field from the extraction list is not in the provided event
         config_path = str(tmp_path / 'generated_config.yml')
-        create_temporary_config_file_at_path(config_path, config)
+        dump_config_as_file(config_path, config)
 
         with patch('logprep.connector.connector_factory.ConnectorFactory.create') as mock_connector_factory:
             input_test_event = {

--- a/tests/acceptance/test_wineventlog_normalization.py
+++ b/tests/acceptance/test_wineventlog_normalization.py
@@ -2,6 +2,7 @@
 import pytest
 
 from tests.acceptance.util import *
+from logprep.util.json_handling import dump_config_as_file, parse_jsonl
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def test_events_normalized_correctly(tmp_path, config):
     expected_output_path = path.join('tests/testdata/acceptance/expected_result', expected_output)
 
     config_path = str(tmp_path / 'generated_config.yml')
-    create_temporary_config_file_at_path(config_path, config)
+    dump_config_as_file(config_path, config)
 
     test_output = get_test_output(config_path)
     store_latest_test_output(expected_output, test_output)

--- a/tests/acceptance/test_wineventlog_processing.py
+++ b/tests/acceptance/test_wineventlog_processing.py
@@ -2,6 +2,7 @@
 import pytest
 
 from tests.acceptance.util import *
+from logprep.util.json_handling import dump_config_as_file, parse_jsonl
 
 basicConfig(level=DEBUG, format='%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s')
 logger = getLogger('Logprep-Test')
@@ -53,7 +54,7 @@ def test_events_labeled_correctly(tmp_path, config_template, rules, schema, expe
 
     set_config(config_template, rules, schema)
     config_path = str(tmp_path / 'generated_config.yml')
-    create_temporary_config_file_at_path(config_path, config_template)
+    dump_config_as_file(config_path, config_template)
 
     test_output = get_test_output(config_path)
     store_latest_test_output(expected_output, test_output)
@@ -69,17 +70,3 @@ def test_events_labeled_correctly(tmp_path, config_template, rules, schema, expe
 def set_config(config_template, rules, schema):
     config_template['pipeline'][0]['labelername']['schema'] = path.join('tests/testdata', schema)
     config_template['pipeline'][0]['labelername']['rules'] = [path.join('tests/testdata', rule) for rule in rules]
-
-
-def get_test_output(config_path):
-    patched_runner = get_patched_runner(config_path)
-
-    test_output_path = patched_runner._configuration['connector']['output_path']
-    remove_file_if_exists(test_output_path)
-
-    patched_runner.start()
-    parsed_test_output = parse_jsonl(test_output_path)
-
-    remove_file_if_exists(test_output_path)
-
-    return parsed_test_output

--- a/tests/acceptance/test_wineventlog_pseudonymization.py
+++ b/tests/acceptance/test_wineventlog_pseudonymization.py
@@ -1,7 +1,12 @@
 #!/usr/bin/python3
+from logging import getLogger, DEBUG, basicConfig
+from os import path
+
 import pytest
 
-from tests.acceptance.util import *
+from logprep.util.json_handling import dump_config_as_file
+from logprep.util.json_handling import parse_jsonl
+from tests.acceptance.util import get_test_output, store_latest_test_output, get_difference
 
 basicConfig(level=DEBUG, format='%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s')
 logger = getLogger('Logprep-Test')
@@ -45,7 +50,7 @@ def test_events_pseudonymized_correctly(tmp_path, config):
     expected_output_path = path.join('tests/testdata/acceptance/expected_result', expected_output)
 
     config_path = str(tmp_path / 'generated_config.yml')
-    create_temporary_config_file_at_path(config_path, config)
+    dump_config_as_file(config_path, config)
 
     test_output = get_test_output(config_path)
     store_latest_test_output(expected_output, test_output)
@@ -57,5 +62,5 @@ def test_events_pseudonymized_correctly(tmp_path, config):
 
     result = get_difference(test_output, expected_output)
 
-    assert result['difference'][0] == result['difference'][1],\
+    assert result['difference'][0] == result['difference'][1], \
         'Missmatch in event at line {}!'.format(result['event_line_no'])

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -1,48 +1,21 @@
 #!/usr/bin/python3
 import json
-from logging import getLogger, DEBUG, basicConfig, Handler
-from os import remove, path, makedirs
 from copy import deepcopy
+from logging import getLogger, DEBUG, basicConfig, Handler
+from os import path, makedirs
 from os.path import join
 
 import ujson
-from yaml import safe_dump
 
 from logprep.connector.confluent_kafka import ConfluentKafkaFactory
 from logprep.framework.pipeline import Pipeline, SharedCounter
-from logprep.runner import Runner
+from logprep.util.helper import recursive_compare, remove_file_if_exists
+from logprep.util.json_handling import parse_jsonl
+from logprep.util.rule_dry_runner import get_patched_runner
 from tests.unit.connector.test_confluent_kafka import RecordMock
 
 basicConfig(level=DEBUG, format='%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s')
 logger = getLogger('Logprep-Test')
-
-
-def recursive_compare(test_output, expected_output):
-    result = None
-
-    if not isinstance(test_output, type(expected_output)):
-        return test_output, expected_output
-
-    elif isinstance(test_output, dict) and isinstance(expected_output, dict):
-        if sorted(test_output.keys()) != sorted(expected_output.keys()):
-            return sorted(test_output.keys()), sorted(expected_output.keys())
-
-        for key in test_output.keys():
-            result = recursive_compare(test_output[key], expected_output[key])
-            if result:
-                return result
-
-    elif isinstance(test_output, list) and isinstance(expected_output, list):
-        for x, _ in enumerate(test_output):
-            result = recursive_compare(test_output[x], expected_output[x])
-            if result:
-                return result
-
-    else:
-        if test_output != expected_output:
-            result = test_output, expected_output
-
-    return result
 
 
 def get_difference(test_output, expected_output):
@@ -74,13 +47,8 @@ def store_latest_test_output(target_output_identifier, output_of_test):
             latest_output.write(json.dumps(test_output_line) + '\n')
 
 
-def create_temporary_config_file_at_path(config_path, config):
-    with open(config_path, 'w') as generated_config_file:
-        safe_dump(config, generated_config_file)
-
-
 def get_test_output(config_path):
-    patched_runner = get_patched_runner(config_path)
+    patched_runner = get_patched_runner(config_path, logger)
 
     test_output_path = patched_runner._configuration['connector']['output_path']
     remove_file_if_exists(test_output_path)
@@ -91,63 +59,6 @@ def get_test_output(config_path):
     remove_file_if_exists(test_output_path)
 
     return parsed_test_output
-
-
-def get_test_output_multi(config_path):
-    patched_runner = get_patched_runner(config_path)
-
-    parsed_outputs = list()
-    output_paths = list()
-    output_paths.append(patched_runner._configuration['connector'].get('output_path', None))
-    output_paths.append(patched_runner._configuration['connector'].get('output_path_custom', None))
-    output_paths.append(patched_runner._configuration['connector'].get('output_path_errors', None))
-    output_paths = [output_path for output_path in output_paths if output_path]
-    
-    for output_path in output_paths:
-        remove_file_if_exists(output_path)
-
-    patched_runner.start()
-
-    for output_path in output_paths:
-        parsed_outputs.append(parse_jsonl(output_path))
-        remove_file_if_exists(output_path)
-
-    return parsed_outputs
-
-
-def get_patched_runner(config_path):
-    runner = Runner(bypass_check_to_obtain_non_singleton_instance=True)
-    runner.set_logger(logger)
-    runner.load_configuration(config_path)
-    patch_runner_to_stop_on_empty_pipeline(runner)
-
-    return runner
-
-
-def patch_runner_to_stop_on_empty_pipeline(runner):
-    runner._keep_iterating = lambda: False
-
-
-def remove_file_if_exists(test_output_path):
-    try:
-        remove(test_output_path)
-    except FileNotFoundError:
-        pass
-
-
-def parse_jsonl(jsonl_path):
-    parsed_events = []
-    with open(jsonl_path, 'r') as jsonl_file:
-        for json_string in jsonl_file.readlines():
-            if json_string.strip() != '':
-                event = json.loads(json_string)
-                parsed_events.append(event)
-    return parsed_events
-
-
-def parse_json(json_path):
-    with open(json_path, 'r') as json_file:
-        return json.load(json_file)
 
 
 def assert_result_equal_expected(config, expected_output, tmp_path):


### PR DESCRIPTION
Some test util functions where moved to logprep source util. This
prevents the need of development libraries such as 'pytest' to be
imported in production. Previously when logprep was called with the
argument --validate-rules test code was imported, this is not the case
anymore.