### PR TITLE
Improve the domain label extraction processor

### DIFF
--- a/doc/source/user_manual/configuration/processor.rst
+++ b/doc/source/user_manual/configuration/processor.rst
@@ -289,6 +289,13 @@ tree_config
 
 Path to JSON file with rule tree matcher config.
 
+tld_lists
+~~~~~~~~~
+
+Optional list of path to files with top-level domain lists (like https://publicsuffix.org/list/public_suffix_list.dat).
+If no path is given a default list will be retrieved online and cached in a local directory. For local files the path
+has to be given with :code:`file:///path/to/file.dat`.
+
 List Comparison Enricher
 ------------------------
 

--- a/doc/source/user_manual/configuration/processor.rst
+++ b/doc/source/user_manual/configuration/processor.rst
@@ -296,6 +296,12 @@ Optional list of path to files with top-level domain lists (like https://publics
 If no path is given a default list will be retrieved online and cached in a local directory. For local files the path
 has to be given with :code:`file:///path/to/file.dat`.
 
+tagging_field_name
+~~~~~~~~~~~~~~~~~~
+
+Optional configuration field that defines into which field in the event the error indication 'unrecognized_domain'
+should be written to. If this field is not present it defaults to 'tags'.
+
 List Comparison Enricher
 ------------------------
 

--- a/doc/source/user_manual/introduction.rst
+++ b/doc/source/user_manual/introduction.rst
@@ -71,7 +71,7 @@ Domain Label Extractor
 
 The domain label extractor is a processor that splits a domain into it's corresponding labels like registered_domain,
 top_level_domain and subdomain. If instead an IP is given in the target field nothing is done. If neither a domain nor
-ip address can be recognized a tag 'unrecognized_domain' will be added to the 'tags' field in the event.
+ip address can be recognized a tag 'unrecognized_domain' will be added to a configurable tag field in the event.
 
 List Comparison Enricher
 ------------------------

--- a/doc/source/user_manual/introduction.rst
+++ b/doc/source/user_manual/introduction.rst
@@ -70,7 +70,8 @@ Domain Label Extractor
 ----------------------
 
 The domain label extractor is a processor that splits a domain into it's corresponding labels like registered_domain,
-top_level_domain and subdomain.
+top_level_domain and subdomain. If instead an IP is given in the target field nothing is done. If neither a domain nor
+ip address can be recognized a tag 'unrecognized_domain' will be added to the 'tags' field in the event.
 
 List Comparison Enricher
 ------------------------

--- a/logprep/processor/domain_label_extractor/factory.py
+++ b/logprep/processor/domain_label_extractor/factory.py
@@ -18,6 +18,7 @@ class DomainLabelExtractorFactory(BaseFactory):
         domain_label_extractor = DomainLabelExtractor(name,
                                                       configuration.get('tree_config'),
                                                       configuration.get('tld_lists', None),
+                                                      configuration.get('tagging_field_name', 'tags'),
                                                       logger)
         domain_label_extractor.add_rules_from_directory(configuration['rules'])
 

--- a/logprep/processor/domain_label_extractor/factory.py
+++ b/logprep/processor/domain_label_extractor/factory.py
@@ -15,7 +15,10 @@ class DomainLabelExtractorFactory(BaseFactory):
         """
         DomainLabelExtractorFactory._check_configuration(configuration)
 
-        domain_label_extractor = DomainLabelExtractor(name, configuration.get('tree_config'), logger)
+        domain_label_extractor = DomainLabelExtractor(name,
+                                                      configuration.get('tree_config'),
+                                                      configuration.get('tld_lists', None),
+                                                      logger)
         domain_label_extractor.add_rules_from_directory(configuration['rules'])
 
         return domain_label_extractor

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
@@ -1,4 +1,5 @@
 import copy
+from pathlib import Path
 import pytest
 
 pytest.importorskip('logprep.processor.domain_label_extractor')
@@ -7,12 +8,15 @@ from logging import getLogger
 
 from logprep.processor.base.processor import RuleBasedProcessor, ProcessingWarning
 from logprep.processor.processor_factory_error import InvalidConfigurationError
-from logprep.processor.domain_label_extractor.rule import DomainLabelExtractorRule
+from logprep.processor.domain_label_extractor.rule import DomainLabelExtractorRule, \
+    InvalidDomainLabelExtractorDefinition
 from logprep.processor.domain_label_extractor.factory import DomainLabelExtractorFactory
-from logprep.processor.domain_label_extractor.processor import UnrecognizedTldError, DomainLabelExtractor
+from logprep.processor.domain_label_extractor.processor import DomainLabelExtractor, DuplicationError
 
 logger = getLogger()
 rules_dir = 'tests/testdata/unit/domain_label_extractor/rules/'
+rel_tld_list_path = 'tests/testdata/external/public_suffix_list.dat'
+tld_list = f'file://{Path().absolute().joinpath(rel_tld_list_path).as_posix()}'
 
 
 @pytest.fixture()
@@ -112,9 +116,17 @@ class TestDomainLabelExtractor:
 
     def test_domain_extraction_without_recognized_tld(self, domain_label_extractor):
         document = {'url': {'domain': 'domain.fubarbo'}}
+        expected_output = {'url': {'domain': 'domain.fubarbo'}, "tags": ['unrecognized_domain']}
 
-        with pytest.raises(UnrecognizedTldError):
-            domain_label_extractor.process(document)
+        domain_label_extractor.process(document)
+        assert document == expected_output
+
+    def test_domain_extraction_without_recognized_tld_with_existing_tag_field(self, domain_label_extractor):
+        document = {'url': {'domain': 'domain.fubarbo'}, "tags": ['source']}
+        expected_output = {'url': {'domain': 'domain.fubarbo'}, "tags": ['source', 'unrecognized_domain']}
+
+        domain_label_extractor.process(document)
+        assert document == expected_output
 
     def test_domain_extraction_with_separated_tld(self, domain_label_extractor):
         document = {'url': {'domain': 'domain.co.uk'}}
@@ -130,20 +142,102 @@ class TestDomainLabelExtractor:
 
         assert document == expected_output
 
+    def test_domain_extraction_with_ipv4_target(self, domain_label_extractor):
+        document = {'url': {'domain': '123.123.123.123'}}
+        expected_output = {'url': {'domain': '123.123.123.123'}}
+
+        domain_label_extractor.process(document)
+        assert document == expected_output
+
+    def test_domain_extraction_with_ipv6_target(self, domain_label_extractor):
+        document = {'url': {'domain': '2001:0db8:85a3:0000:0000:8a2e:0370:7334'}}
+        expected_output = {'url': {'domain': '2001:0db8:85a3:0000:0000:8a2e:0370:7334'}}
+
+        domain_label_extractor.process(document)
+        assert document == expected_output
+
+    def test_domain_extraction_with_existing_output_field(self, domain_label_extractor):
+        document = {'url': {'domain': 'test.domain.de', "subdomain": "exists already"}}
+
+        with pytest.raises(DuplicationError, match=r"DomainLabelExtractor \(Test DomainLabelExtractor Name\): The "
+                                                   r"following fields already existed and were not overwritten by the "
+                                                   r"DomainLabelExtractor: url\.subdomain"):
+            domain_label_extractor.process(document)
+
+
+class TestDomainLabelExtractorRule:
+
+    RULE = {
+        'filter': 'url.domain',
+        'domain_label_extractor': {
+            'target_field': 'url.domain',
+            'output_field': 'url'
+        },
+        'description': 'insert a description text'
+    }
+
+    def test_valid_rule(self):
+        DomainLabelExtractorRule._create_from_dict(self.RULE)
+
+    def test_missing_target_field(self):
+        rule = copy.deepcopy(self.RULE)
+        del rule["domain_label_extractor"]["target_field"]
+
+        with pytest.raises(InvalidDomainLabelExtractorDefinition, match=r"DomainLabelExtractor rule \(The following "
+                                                                        r"DomainLabelExtractor definition is invalid: "
+                                                                        r"Missing 'target_field' in rule "
+                                                                        r"configuration\.\)"):
+            DomainLabelExtractorRule._create_from_dict(rule)
+
+    def test_wrong_target_field_type(self):
+        rule = copy.deepcopy(self.RULE)
+        rule["domain_label_extractor"]["target_field"] = 123
+
+        with pytest.raises(InvalidDomainLabelExtractorDefinition, match=r"DomainLabelExtractor definition is invalid: "
+                                                                        r"'target_field' should be 'str' and not "
+                                                                        r"'<class 'int'>'"):
+            DomainLabelExtractorRule._create_from_dict(rule)
+
+    def test_missing_output_field(self):
+        rule = copy.deepcopy(self.RULE)
+        del rule["domain_label_extractor"]["output_field"]
+
+        with pytest.raises(InvalidDomainLabelExtractorDefinition, match=r"DomainLabelExtractor rule \(The following "
+                                                                        r"DomainLabelExtractor definition is invalid: "
+                                                                        r"Missing 'output_field' in rule "
+                                                                        r"configuration\.\)"):
+            DomainLabelExtractorRule._create_from_dict(rule)
+
+    def test_wrong_output_field_type(self):
+        rule = copy.deepcopy(self.RULE)
+        rule["domain_label_extractor"]["output_field"] = 123
+
+        with pytest.raises(InvalidDomainLabelExtractorDefinition, match=r"DomainLabelExtractor definition is invalid: "
+                                                                        r"'output_field' should be 'str' and not "
+                                                                        r"'<class 'int'>'"):
+            DomainLabelExtractorRule._create_from_dict(rule)
+
 
 class TestDomainLabelExtractorFactory:
-    VALID_CONFIG = {
+    REQUIRED_CONFIG_FIELDS = {
         'type': 'domain_label_extractor',
-        'rules': [rules_dir]
+        'rules': [rules_dir],
     }
 
     def test_create(self):
-        assert isinstance(DomainLabelExtractorFactory.create('foo', self.VALID_CONFIG, logger), DomainLabelExtractor)
+        assert isinstance(DomainLabelExtractorFactory.create('foo', self.REQUIRED_CONFIG_FIELDS, logger),
+                          DomainLabelExtractor)
 
     def test_check_configuration(self):
-        DomainLabelExtractorFactory._check_configuration(self.VALID_CONFIG)
-        for i in range(len(self.VALID_CONFIG)):
-            cfg = copy.deepcopy(self.VALID_CONFIG)
+        DomainLabelExtractorFactory._check_configuration(self.REQUIRED_CONFIG_FIELDS)
+        for i in range(len(self.REQUIRED_CONFIG_FIELDS)):
+            cfg = copy.deepcopy(self.REQUIRED_CONFIG_FIELDS)
             cfg.pop(list(cfg)[i])
             with pytest.raises(InvalidConfigurationError):
                 DomainLabelExtractorFactory._check_configuration(cfg)
+
+    def test_check_configuration_with_tld_list(self):
+        self.config = copy.deepcopy(self.REQUIRED_CONFIG_FIELDS)
+        self.config['tld_lists'] = [tld_list]
+        assert isinstance(DomainLabelExtractorFactory.create('foo', self.config, logger),
+                          DomainLabelExtractor)


### PR DESCRIPTION
The unrecognized domain label error has been removed. If an ip
address is present the processor does nothing. If neither an
ip nor a domain is present a tag "unrecognized_domain" is added
to the event. Furthermore the domain label extraction processor
can now be configured with a tld suffix list.