### PR TITLE
Improve list comparison performance

### DIFF
--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -164,20 +164,19 @@ class ListComparison(RuleBasedProcessor):
         Check if field value violates block or allow list.
         Returns the result of the comparison (res_key), as well as a dictionary containing the result (key)
         and a list of filenames pertaining to said result (value).
-
         """
 
+        # get value that should be checked in the lists
         field_value = self._get_dotted_field_value(event, rule.check_field)
 
-        list_matches = [item[0] for item in rule.compare_set if item[1] == field_value]
-        unmatched_files = {item[0] for item in rule.compare_set if item[1] != field_value}
+        # iterate over lists and check if element is in any
+        list_matches = []
+        for compare_list in rule.compare_sets.keys():
+            if field_value in rule.compare_sets[compare_list]:
+                list_matches.append(compare_list)
 
+        # if matching list was found return it, otherwise return all list names
         if len(list_matches) > 0:
-            res_key = "in_list"
-            result = [filename for filename in list_matches]
-            return result, res_key
-
+            return list_matches, "in_list"
         elif len(list_matches) == 0:
-            res_key = "not_in_list"
-            result = [filename for filename in unmatched_files]
-            return result, res_key
+            return list(rule.compare_sets.keys()), "not_in_list"

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -51,7 +51,7 @@ class ListComparisonRule(Rule):
         self._check_field = list_comparison_cfg["check_field"]
         self._list_comparison_output_field = list_comparison_cfg["output_field"]
 
-        self._compare_set = set()
+        self._compare_sets = dict()
         self._config = list_comparison_cfg
 
     def init_list_comparison(self, list_search_base_path: Optional[str]):
@@ -64,20 +64,19 @@ class ListComparisonRule(Rule):
                     # iterate over all files specified in rule
                     with open(list_path, 'r') as f:
                         compare_elements = f.read().splitlines()
-                        file_elem_tuples = [(os.path.basename(list_path), elem) for elem in
-                                            compare_elements if not elem.startswith("#")]
-                        # add tuples to the set of elements to be compared against list files.
-                        self._compare_set.update(file_elem_tuples)
+                        file_elem_tuples = [elem for elem in compare_elements if not elem.startswith("#")]
+                        file_name = os.path.basename(list_path)
+                        self._compare_sets[file_name] = set(file_elem_tuples)
 
     def __eq__(self, other: 'ListComparisonRule') -> bool:
-        return (other.filter == self._filter) and (self._compare_set == other.compare_set)
+        return (other.filter == self._filter) and (self._compare_sets == other.compare_sets)
 
     def __hash__(self) -> int:
         return hash(repr(self))
 
     @property
-    def compare_set(self) -> set:
-        return self._compare_set
+    def compare_sets(self) -> dict:
+        return self._compare_sets
 
     @property
     def check_field(self) -> str:


### PR DESCRIPTION
The list comparison processor did not make use of the performance of
sets or dictionaries as it was still iterating over every element.
This new implementation uses a slightly different datastructure to
speed up the matching of elements and lists. It now only iterates
over the number of lists given in a rule instead of each element
of all lists. This significantly speeds up the worst case scenario.