### PR TITLE
Add more informative domain label extractor tags

### DIFF
--- a/doc/source/user_manual/configuration/processor.rst
+++ b/doc/source/user_manual/configuration/processor.rst
@@ -325,8 +325,9 @@ has to be given with :code:`file:///path/to/file.dat`.
 tagging_field_name
 ~~~~~~~~~~~~~~~~~~
 
-Optional configuration field that defines into which field in the event the error indication 'unrecognized_domain'
-should be written to. If this field is not present it defaults to 'tags'.
+Optional configuration field that defines into which field in the event the informational tags should be written to.
+If this field is not present it defaults to :code:`tags`. More about the tags can be found in the introduction of the
+:ref:`intro_domain_label_extractor`.
 
 List Comparison Enricher
 ------------------------

--- a/doc/source/user_manual/introduction.rst
+++ b/doc/source/user_manual/introduction.rst
@@ -66,12 +66,18 @@ Domain Resolver
 
 The domain resolver is a processor that can resolve domains inside a defined field.
 
+.. _intro_domain_label_extractor:
+
 Domain Label Extractor
 ----------------------
 
-The domain label extractor is a processor that splits a domain into it's corresponding labels like registered_domain,
-top_level_domain and subdomain. If instead an IP is given in the target field nothing is done. If neither a domain nor
-ip address can be recognized a tag 'unrecognized_domain' will be added to a configurable tag field in the event.
+The domain label extractor is a processor that splits a domain into it's corresponding labels like
+:code:`registered_domain`, :code:`top_level_domain` and :code:`subdomain`. If instead an IP is given in the target field
+an informational tag is added to the configured tags field. If neither a domain nor an ip address can be recognized an
+invalid error tag will be be added to the tag field in the event. The added tags contain each the target field name that
+was checked by the configured rule, such that it is possible to distinguish between different domain fields in one
+event. For example for the target field :code:`url.domain` following tags could be added:
+:code:`invalid_domain_in_url_domain` and :code:`ip_in_url_domain`
 
 List Comparison Enricher
 ------------------------

--- a/logprep/processor/domain_label_extractor/processor.py
+++ b/logprep/processor/domain_label_extractor/processor.py
@@ -178,14 +178,18 @@ class DomainLabelExtractor(RuleBasedProcessor):
                 try:
                     # check if ip address is ipv4
                     socket.inet_aton(labels.domain)
+                    event[self._tagging_field_name] = event.get(self._tagging_field_name, []) + \
+                                                      [f"ip_in_{rule.target_field.replace('.', '_')}"]
                 except OSError:
                     try:
                         # check if ip address is ipv6
                         socket.inet_pton(socket.AF_INET6, labels.domain)
+                        event[self._tagging_field_name] = event.get(self._tagging_field_name, []) + \
+                                                          [f"ip_in_{rule.target_field.replace('.', '_')}"]
                     except OSError:
                         # if it's neither ipv4 nor ipv6 then add error tag
                         event[self._tagging_field_name] = event.get(self._tagging_field_name, []) + \
-                                                          ["unrecognized_domain"]
+                                                          [f"invalid_domain_in_{rule.target_field.replace('.', '_')}"]
 
     def events_processed_count(self):
         return self._events_processed

--- a/tests/testdata/unit/domain_label_extractor/rules/domain_label_extractor.json
+++ b/tests/testdata/unit/domain_label_extractor/rules/domain_label_extractor.json
@@ -12,4 +12,11 @@
     "output_field": "extracted.domain.info"
   },
   "description": ""
+},{
+  "filter": "source",
+  "domain_label_extractor": {
+    "target_field": "source.domain",
+    "output_field": "source"
+  },
+  "description": ""
 }]


### PR DESCRIPTION
The previous tags only included one error tag when no domain was
recognized. With this commit tags will also be added when an IP
address was found in the target field. Now the added tags also
include the target field name such that it is possible to
distinguish between different fields and tags.