### PR TITLE
refactor list comparison tests to use base class

### DIFF
--- a/logprep/processor/list_comparison/factory.py
+++ b/logprep/processor/list_comparison/factory.py
@@ -17,11 +17,11 @@ class ListComparisonFactory(BaseFactory):
 
         list_comparison = ListComparison(name, configuration.get('tree_config'),
                                          configuration.get('list_search_base_path'), logger)
-        list_comparison.add_rules_from_directory(configuration['rules'])
+        list_comparison.add_rules_from_directory(configuration['specific_rules'], configuration['generic_rules'])
 
         return list_comparison
 
     @staticmethod
     def _check_configuration(configuration: dict):
-        ListComparisonFactory._check_common_configuration('list_comparison', ['rules'],
+        ListComparisonFactory._check_common_configuration('list_comparison', ['specific_rules', 'generic_rules'], 
                                                           configuration)

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -70,16 +70,6 @@ class ListComparison(RuleBasedProcessor):
         self.ps = ProcessorStats()
         self._specific_tree = RuleTree(config_path=tree_config)
         self._generic_tree = RuleTree(config_path=tree_config)
-        self._events_processed = 0
-
-    def events_processed_count(self) -> int:
-        """Return the count of documents processed by a specific instance.
-
-        This is used for diagnostics.
-
-        """
-
-        return self._events_processed
 
     # pylint: disable=arguments-differ
     def add_rules_from_directory(
@@ -162,7 +152,7 @@ class ListComparison(RuleBasedProcessor):
             idx = self._specific_tree.get_rule_id(rule)
             self.ps.update_per_rule(idx, processing_time)
 
-        self._events_processed += 1
+        self.ps.increment_processed_count()
 
     def _apply_rules(self, event, rule):
         """

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -3,14 +3,19 @@ This module contains functionality for checking if values exist or not exist in 
 black- and whitelisting capabilities.
 """
 from logging import Logger, DEBUG
+from logprep.framework.rule_tree.rule_tree import RuleTree
+from logprep.framework import rule_tree
 from multiprocessing import current_process
 from os import walk
 from os.path import isdir, realpath, join
 from time import time
 from typing import List, Optional
 
-from logprep.processor.base.exceptions import (NotARulesDirectoryError, InvalidRuleDefinitionError,
-                                               InvalidRuleFileError)
+from logprep.processor.base.exceptions import (
+    NotARulesDirectoryError,
+    InvalidRuleDefinitionError,
+    InvalidRuleFileError,
+)
 from logprep.processor.base.processor import RuleBasedProcessor
 from logprep.processor.list_comparison.rule import ListComparisonRule
 from logprep.util.helper import add_field_to
@@ -22,16 +27,18 @@ class ListComparisonError(BaseException):
     """Base class for ListComparison related exceptions."""
 
     def __init__(self, name: str, message: str):
-        super().__init__(f'ListComparison ({name}): {message}')
+        super().__init__(f"ListComparison ({name}): {message}")
 
 
 class DuplicationError(ListComparisonError):
     """Raise if field already exists."""
 
     def __init__(self, name: str, skipped_fields: List[str]):
-        message = 'The following fields could not be written, because ' \
-                  'one or more subfields existed and could not be extended: '
-        message += ' '.join(skipped_fields)
+        message = (
+            "The following fields could not be written, because "
+            "one or more subfields existed and could not be extended: "
+        )
+        message += " ".join(skipped_fields)
 
         super().__init__(name, message)
 
@@ -39,8 +46,13 @@ class DuplicationError(ListComparisonError):
 class ListComparison(RuleBasedProcessor):
     """Resolve values in documents by referencing a mapping list."""
 
-    def __init__(self, name: str, tree_config: str, list_search_base_path: Optional[str],
-                 logger: Logger):
+    def __init__(
+        self,
+        name: str,
+        tree_config: str,
+        list_search_base_path: Optional[str],
+        logger: Logger,
+    ):
         """
         Initializes the list_comparison processor.
 
@@ -56,41 +68,52 @@ class ListComparison(RuleBasedProcessor):
         super().__init__(name, tree_config, logger)
         self._list_search_base_dir = list_search_base_path
         self.ps = ProcessorStats()
+        self._specific_tree = RuleTree(config_path=tree_config)
+        self._generic_tree = RuleTree(config_path=tree_config)
+        self._events_processed = 0
+
+    def events_processed_count(self) -> int:
+        """Return the count of documents processed by a specific instance.
+
+        This is used for diagnostics.
+
+        """
+
+        return self._events_processed
 
     # pylint: disable=arguments-differ
-    def add_rules_from_directory(self, rule_paths: List[str]):
-        """
-        Collect rules from given directory.
-
-        Parameters
-        ----------
-        rules_paths : List[str]
-            Path to the directory containing list_comparison rules.
-
-        """
-        for path in rule_paths:
-            if not isdir(realpath(path)):
-                raise NotARulesDirectoryError(self._name, path)
-
-            for root, _, files in walk(path):
-                json_files = []
-                for file in files:
-                    if (file.endswith('.json') or file.endswith('.yml')) and not file.endswith('_test.json'):
-                        json_files.append(file)
-                for file in json_files:
-                    rules = self._load_rules_from_file(join(root, file))
-                    for rule in rules:
-                        self._tree.add_rule(rule, self._logger)
-
+    def add_rules_from_directory(
+        self, specific_rules_dirs: List[str], generic_rules_dirs: List[str]
+    ):
+        for specific_rules_dir in specific_rules_dirs:
+            rule_paths = self._list_json_files_in_directory(specific_rules_dir)
+            for rule_path in rule_paths:
+                rules = ListComparisonRule.create_rules_from_file(rule_path)
+                for rule in rules:
+                    self._specific_tree.add_rule(rule, self._logger)
+        for generic_rules_dir in generic_rules_dirs:
+            rule_paths = self._list_json_files_in_directory(generic_rules_dir)
+            for rule_path in rule_paths:
+                rules = ListComparisonRule.create_rules_from_file(rule_path)
+                for rule in rules:
+                    self._generic_tree.add_rule(rule, self._logger)
         if self._logger.isEnabledFor(DEBUG):
-            self._logger.debug(f'{self.describe()} loaded {self._tree.rule_counter} rules '
-                               f'({current_process().name})')
-
-        self.ps.setup_rules([None] * self._tree.rule_counter)
+            self._logger.debug(
+                f"{self.describe()} loaded {self._specific_tree.rule_counter} "
+                f"specific rules ({current_process().name})"
+            )
+            self._logger.debug(
+                f"{self.describe()} loaded {self._generic_tree.rule_counter} generic rules "
+                f"({current_process().name})"
+            )
+        self.ps.setup_rules(
+            [None] * self._generic_tree.rule_counter
+            + [None] * self._specific_tree.rule_counter
+        )
 
     # pylint: enable=arguments-differ
 
-    def _load_rules_from_file(self, path: str):
+    def _load_rules_from_file(self, list_comparison_path: str):
         """
         Collect rule(s) from a given file.
 
@@ -99,20 +122,19 @@ class ListComparison(RuleBasedProcessor):
         path : str
             Path to the file containing a list_comparison rule.
 
-        """        
+        """
         try:
-            rules = ListComparisonRule.create_rules_from_file(path)
-            for rule in rules:
-                rule.init_list_comparison(self._list_search_base_dir)
-            return rules
+            return ListComparisonRule.create_rules_from_file(list_comparison_path)
         except InvalidRuleDefinitionError as error:
-            raise InvalidRuleFileError(self._name, path, str(error)) from error
+            raise InvalidRuleFileError(
+                self._name, list_comparison_path, str(error)
+            ) from error
 
     def describe(self) -> str:
         """Return name of given processor instance."""
-        return f'ListComparison ({self._name})'
+        return f"ListComparison ({self._name})"
 
-    @TimeMeasurement.measure_time('list_comparison')
+    @TimeMeasurement.measure_time("list_comparison")
     def process(self, event: dict):
         """
         Process log message.
@@ -122,23 +144,30 @@ class ListComparison(RuleBasedProcessor):
         event : dict
             Current event log message to be processed.
 
-        """         
+        """
 
         self._event = event
 
-        for rule in self._tree.get_matching_rules(event):
+        for rule in self._generic_tree.get_matching_rules(event):
             begin = time()
             self._apply_rules(event, rule)
-            processing_time = float('{:.10f}'.format(time() - begin))
-            idx = self._tree.get_rule_id(rule)
+            processing_time = float("{:.10f}".format(time() - begin))
+            idx = self._generic_tree.get_rule_id(rule)
             self.ps.update_per_rule(idx, processing_time)
 
-        self.ps.increment_processed_count()
+        for rule in self._specific_tree.get_matching_rules(event):
+            begin = time()
+            self._apply_rules(event, rule)
+            processing_time = float("{:.10f}".format(time() - begin))
+            idx = self._specific_tree.get_rule_id(rule)
+            self.ps.update_per_rule(idx, processing_time)
+
+        self._events_processed += 1
 
     def _apply_rules(self, event, rule):
         """
-        Apply matching rule to given log event. 
-        In the process of doing so, add the result of comparing 
+        Apply matching rule to given log event.
+        In the process of doing so, add the result of comparing
         the log with a given list to the specified subfield. This subfield will contain
         a list of list comparison results that might be based on multiple rules.
 
@@ -146,15 +175,15 @@ class ListComparison(RuleBasedProcessor):
         ----------
         event : dict
             Log message being processed.
-        rule : 
+        rule :
             Currently applied list comparison rule.
 
-        """ 
+        """
 
         comparison_result, comparison_key = self._list_comparison(rule, event)
 
         if comparison_result is not None:
-            output_field = rule.list_comparison_output_field+"."+comparison_key
+            output_field = f"{ rule.list_comparison_output_field }.{ comparison_key }"
             field_possible = add_field_to(event, output_field, comparison_result, True)
             if not field_possible:
                 raise DuplicationError(self._name, [output_field])

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -12,28 +12,33 @@ from ruamel.yaml import YAML
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import Rule, InvalidRuleDefinitionError
 
-yaml = YAML(typ='safe', pure=True)
+yaml = YAML(typ="safe", pure=True)
 
 
 class ListComparisonRuleError(InvalidRuleDefinitionError):
     """Base class for ListComparison rule related exceptions."""
 
     def __init__(self, message: str):
-        super().__init__(f'ListComparison rule ({message})')
+        super().__init__(f"ListComparison rule ({message})")
 
 
 class InvalidListComparisonDefinition(ListComparisonRuleError):
     """Raise if ListComparison definition invalid."""
 
     def __init__(self, definition):
-        message = f'The following ListComparison definition is invalid: {definition}'
+        message = f"The following ListComparison definition is invalid: {definition}"
         super().__init__(message)
 
 
 class ListComparisonRule(Rule):
     """Check if documents match a filter."""
 
-    allowed_cfg_fields = ["list_file_paths", "check_field", "output_field", "list_search_base_path"]
+    allowed_cfg_fields = [
+        "list_file_paths",
+        "check_field",
+        "output_field",
+        "list_search_base_path",
+    ]
 
     def __init__(self, filter_rule: FilterExpression, list_comparison_cfg: dict):
         """
@@ -45,7 +50,7 @@ class ListComparisonRule(Rule):
             Given lucene filter expression as a representation of the rule's logic.
         list_comparison_cfg: dict
             Configuration fields from a given pipeline that refer to the processor instance.
-        """ 
+        """
         super().__init__(filter_rule)
 
         self._check_field = list_comparison_cfg["check_field"]
@@ -53,23 +58,27 @@ class ListComparisonRule(Rule):
 
         self._compare_sets = dict()
         self._config = list_comparison_cfg
+        self.init_list_comparison()
 
-    def init_list_comparison(self, list_search_base_path: Optional[str]):
+    def init_list_comparison(self):
         for key in self._config.keys():
-            if key.endswith('_paths'):
+            if key.endswith("_paths"):
                 file_paths = self._config[key]
                 for list_path in file_paths:
-                    if list_search_base_path is not None and not os.path.isabs(list_path):
-                        list_path = os.path.join(list_search_base_path, list_path)
-                    # iterate over all files specified in rule
-                    with open(list_path, 'r') as f:
+                    with open(list_path, "r") as f:
                         compare_elements = f.read().splitlines()
-                        file_elem_tuples = [elem for elem in compare_elements if not elem.startswith("#")]
+                        file_elem_tuples = [
+                            elem
+                            for elem in compare_elements
+                            if not elem.startswith("#")
+                        ]
                         file_name = os.path.basename(list_path)
                         self._compare_sets[file_name] = set(file_elem_tuples)
 
-    def __eq__(self, other: 'ListComparisonRule') -> bool:
-        return (other.filter == self._filter) and (self._compare_sets == other.compare_sets)
+    def __eq__(self, other: "ListComparisonRule") -> bool:
+        return (other.filter == self._filter) and (
+            self._check_field == other.check_field
+        )
 
     def __hash__(self) -> int:
         return hash(repr(self))
@@ -87,28 +96,12 @@ class ListComparisonRule(Rule):
         return self._list_comparison_output_field
 
     @staticmethod
-    def _create_from_dict(rule: dict) -> 'ListComparisonRule':
-        ListComparisonRule._check_rule_validity(rule, 'list_comparison')
+    def _create_from_dict(rule: dict) -> "ListComparisonRule":
+        ListComparisonRule._check_rule_validity(rule, "list_comparison")
         ListComparisonRule._check_if_valid(rule)
 
         filter_expression = Rule._create_filter_expression(rule)
-        return ListComparisonRule(filter_expression, rule['list_comparison'])
-
-    @classmethod
-    def create_rules_from_file(cls, path: str) -> list:
-        """Create a rule from a file."""
-        with open(path, 'r') as file:
-            rule_data = list(yaml.load_all(file)) if path.endswith('.yml') else load(file)
-
-        if not isinstance(rule_data, list):
-            raise InvalidRuleDefinitionError
-
-        rules = [cls._create_from_dict(rule) for rule in rule_data]
-
-        for rule in rules:
-            rule.file_name = os.path.splitext(os.path.basename(path))[0]
-
-        return rules
+        return ListComparisonRule(filter_expression, rule["list_comparison"])
 
     @staticmethod
     def _check_if_valid(rule: dict):
@@ -120,31 +113,51 @@ class ListComparisonRule(Rule):
         rule : dict
             Current rule to be checked for configuration or field reference problems.
 
-        """ 
-        list_comparison_cfg = rule['list_comparison']
+        """
+        list_comparison_cfg = rule["list_comparison"]
 
         # check if the three needed config fields exist
-        if not len([key for key in list_comparison_cfg.keys() if key in ListComparisonRule.allowed_cfg_fields]) <= 4:
+        if (
+            not len(
+                [
+                    key
+                    for key in list_comparison_cfg.keys()
+                    if key in ListComparisonRule.allowed_cfg_fields
+                ]
+            )
+            <= 4
+        ):
             raise InvalidListComparisonDefinition(
                 f"Allowed config fields are: {', '.join(ListComparisonRule.allowed_cfg_fields)}, and of them"
-                f" only one path field should be present.")
+                f" only one path field should be present."
+            )
 
         # check if config contains unknown fields
-        unknown_config_fields = [key for key in list_comparison_cfg.keys() if key not in ListComparisonRule.allowed_cfg_fields]
+        unknown_config_fields = [
+            key
+            for key in list_comparison_cfg.keys()
+            if key not in ListComparisonRule.allowed_cfg_fields
+        ]
         if len(unknown_config_fields) > 0:
-            raise InvalidListComparisonDefinition(f"Unknown fields were given: {', '.join(unknown_config_fields)}")
+            raise InvalidListComparisonDefinition(
+                f"Unknown fields were given: {', '.join(unknown_config_fields)}"
+            )
 
         # check validity of given fields
         for key in list_comparison_cfg.keys():
             # only check if paths are part of the configuration
             if key in ["list_file_paths"]:
                 if len(list_comparison_cfg[key]) == 0:
-                    raise InvalidListComparisonDefinition(f"The rule should have at least one list configured")
+                    raise InvalidListComparisonDefinition(
+                        f"The rule should have at least one list configured"
+                    )
 
                 # iterate over all given files
                 for path in list_comparison_cfg[key]:
                     if not isinstance(path, str) and not os.path.isfile(path):
-                        raise InvalidListComparisonDefinition(f"{path} is not a existing file.")
+                        raise InvalidListComparisonDefinition(
+                            f"{path} is not a existing file."
+                        )
 
             if key == "check_field":
                 if not isinstance(list_comparison_cfg[key], str):

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -58,13 +58,15 @@ class ListComparisonRule(Rule):
 
         self._compare_sets = dict()
         self._config = list_comparison_cfg
-        self.init_list_comparison()
+        self.init_list_comparison(self._config.get("list_search_base_path"))
 
-    def init_list_comparison(self):
+    def init_list_comparison(self, list_search_base_path: Optional[str]):
         for key in self._config.keys():
             if key.endswith("_paths"):
                 file_paths = self._config[key]
                 for list_path in file_paths:
+                    if list_search_base_path is not None and not os.path.isabs(list_path):
+                        list_path = os.path.join(list_search_base_path, list_path)
                     with open(list_path, "r") as f:
                         compare_elements = f.read().splitlines()
                         file_elem_tuples = [

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -52,7 +52,6 @@ class Normalizer(RuleBasedProcessor):
         self.ps = ProcessorStats()
 
         self._name = name
-        self._events_processed = 0
         self._event = None
         self._conflicting_fields = []
 
@@ -82,15 +81,6 @@ class Normalizer(RuleBasedProcessor):
                 self._html_replace_fields = yaml.load(file)
 
         self.add_rules_from_directory(specific_rules_dirs, generic_rules_dirs)
-
-    def events_processed_count(self) -> int:
-        """Return the count of documents processed by a specific instance.
-
-        This is used for diagnostics.
-
-        """
-
-        return self._events_processed
 
     # pylint: disable=arguments-differ
     def add_rules_from_directory(
@@ -134,7 +124,6 @@ class Normalizer(RuleBasedProcessor):
         self._apply_rules()
         if self._count_grok_pattern_matches:
             self._write_grok_matches()
-        self._events_processed += 1
 
         self.ps.increment_processed_count()
         try:

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -83,6 +83,15 @@ class Normalizer(RuleBasedProcessor):
 
         self.add_rules_from_directory(specific_rules_dirs, generic_rules_dirs)
 
+    def events_processed_count(self) -> int:
+        """Return the count of documents processed by a specific instance.
+
+        This is used for diagnostics.
+
+        """
+
+        return self._events_processed
+
     # pylint: disable=arguments-differ
     def add_rules_from_directory(
         self, specific_rules_dirs: List[str], generic_rules_dirs: List[str]
@@ -125,6 +134,7 @@ class Normalizer(RuleBasedProcessor):
         self._apply_rules()
         if self._count_grok_pattern_matches:
             self._write_grok_matches()
+        self._events_processed += 1
 
         self.ps.increment_processed_count()
         try:

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -49,7 +49,6 @@ class Pseudonymizer(RuleBasedProcessor):
         self._hash_salt = hash_salt
         self._hasher = SHA256Hasher()
         self._encrypter = DualPKCS1HybridEncrypter()
-        self._events_processed = 0
 
         self._pseudonyms_topic = pseudonyms_topic
 
@@ -74,15 +73,6 @@ class Pseudonymizer(RuleBasedProcessor):
                             max_timedelta=self._cache_max_timedelta)
         self._tld_extractor = TLDExtract(suffix_list_urls=[self._tld_list])
         self._load_regex_mapping(self._regex_mapping_path)
-
-    def events_processed_count(self) -> int:
-        """Return the count of documents processed by a specific instance.
-
-        This is used for diagnostics.
-
-        """
-
-        return self._events_processed
 
     def _load_regex_mapping(self, regex_mapping_path: str):
         with open(regex_mapping_path, 'r') as file:
@@ -123,7 +113,6 @@ class Pseudonymizer(RuleBasedProcessor):
                 pseudonym['@timestamp'] = event['@timestamp']
 
         self.ps.increment_processed_count()
-        self._events_processed += 1
         return (pseudonyms, self._pseudonyms_topic) if pseudonyms != [] else None
 
     def shut_down(self):

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -49,6 +49,7 @@ class Pseudonymizer(RuleBasedProcessor):
         self._hash_salt = hash_salt
         self._hasher = SHA256Hasher()
         self._encrypter = DualPKCS1HybridEncrypter()
+        self._events_processed = 0
 
         self._pseudonyms_topic = pseudonyms_topic
 
@@ -73,6 +74,15 @@ class Pseudonymizer(RuleBasedProcessor):
                             max_timedelta=self._cache_max_timedelta)
         self._tld_extractor = TLDExtract(suffix_list_urls=[self._tld_list])
         self._load_regex_mapping(self._regex_mapping_path)
+
+    def events_processed_count(self) -> int:
+        """Return the count of documents processed by a specific instance.
+
+        This is used for diagnostics.
+
+        """
+
+        return self._events_processed
 
     def _load_regex_mapping(self, regex_mapping_path: str):
         with open(regex_mapping_path, 'r') as file:
@@ -113,6 +123,7 @@ class Pseudonymizer(RuleBasedProcessor):
                 pseudonym['@timestamp'] = event['@timestamp']
 
         self.ps.increment_processed_count()
+        self._events_processed += 1
         return (pseudonyms, self._pseudonyms_topic) if pseudonyms != [] else None
 
     def shut_down(self):

--- a/tests/testdata/unit/list_comparison/rules/generic/user_check.json
+++ b/tests/testdata/unit/list_comparison/rules/generic/user_check.json
@@ -3,7 +3,7 @@
   "list_comparison": {
     "check_field": "user",
     "output_field": "user_results",
-    "list_file_paths": ["../lists/user_list.txt"]
+    "list_file_paths": ["tests/testdata/unit/list_comparison/lists/user_list.txt"]
   },
   "description": ""
 },{
@@ -12,8 +12,8 @@
     "check_field": "system",
     "output_field": "user_and_system_results",
     "list_file_paths": [
-      "../lists/user_list.txt",
-      "../lists/system_list.txt"
+      "tests/testdata/unit/list_comparison/lists/user_list.txt",
+      "tests/testdata/unit/list_comparison/lists/system_list.txt"
     ]
   },
   "description": ""
@@ -23,8 +23,8 @@
     "check_field": "channel.type",
     "output_field": "channel_results",
     "list_file_paths": [
-      "../lists/user_list.txt",
-      "../lists/system_list.txt"
+      "tests/testdata/unit/list_comparison/lists/user_list.txt",
+      "tests/testdata/unit/list_comparison/lists/system_list.txt"
     ]
   },
   "description": ""
@@ -34,7 +34,7 @@
     "check_field": "user",
     "output_field": "dotted.user_results",
     "list_file_paths": [
-      "../lists/user_list.txt"
+      "tests/testdata/unit/list_comparison/lists/user_list.txt"
     ]
   },
   "description": ""
@@ -44,7 +44,18 @@
     "check_field": "user",
     "output_field": "more.than.dotted.user_results",
     "list_file_paths": [
-      "../lists/user_list.txt"
+      "tests/testdata/unit/list_comparison/lists/user_list.txt"
+    ]
+  },
+  "description": ""
+},
+{
+  "filter": "event_id",
+  "list_comparison": {
+    "check_field": "event_id",
+    "output_field": "more.than.dotted.user_results",
+    "list_file_paths": [
+      "tests/testdata/unit/list_comparison/lists/user_list.txt"
     ]
   },
   "description": ""

--- a/tests/testdata/unit/list_comparison/rules/specific/user_check_specific.json
+++ b/tests/testdata/unit/list_comparison/rules/specific/user_check_specific.json
@@ -1,0 +1,9 @@
+[{
+  "filter": "irrelevant",
+  "list_comparison": {
+    "check_field": "user2",
+    "output_field": "user_results",
+    "list_file_paths": ["tests/testdata/unit/list_comparison/lists/user_list.txt"]
+  },
+  "description": ""
+}]

--- a/tests/unit/processor/base.py
+++ b/tests/unit/processor/base.py
@@ -3,13 +3,15 @@
 import json
 import re
 from abc import ABC, abstractmethod
+from encodings import utf_8
 from logging import getLogger
 
 import pytest
 
 
 from logprep.framework.rule_tree.rule_tree import RuleTree
-from logprep.processor.base.processor import ProcessingWarning, RuleBasedProcessor
+from logprep.processor.base.processor import (ProcessingWarning,
+                                              RuleBasedProcessor)
 
 
 class BaseProcessorTestCase(ABC):

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -1,161 +1,210 @@
 from logging import getLogger
 
 import pytest
+from tests.unit.processor.base import BaseProcessorTestCase
 
 from logprep.processor.list_comparison.processor import DuplicationError
 
-pytest.importorskip('logprep.processor.list_comparison')
+pytest.importorskip("logprep.processor.list_comparison")
 
 from logprep.processor.list_comparison.factory import ListComparisonFactory
 
 logger = getLogger()
-rules_dir = 'tests/testdata/unit/list_comparison/rules'
 
 
-@pytest.fixture()
-def list_comparison():
-    config = {
-        'type': 'list_comparison',
-        'rules': [rules_dir],
-        'tree_config': 'tests/testdata/unit/shared_data/tree_config.json',
-        'list_search_base_path': rules_dir
+class TestListComparison(BaseProcessorTestCase):
+    CONFIG = {
+        "type": "list_comparison",
+        "specific_rules": ["tests/testdata/unit/list_comparison/rules/specific"],
+        "generic_rules": ["tests/testdata/unit/list_comparison/rules/generic"],
+        "tree_config": "tests/testdata/unit/shared_data/tree_config.json",
     }
+    factory = ListComparisonFactory
 
-    list_comparison = ListComparisonFactory.create('test-list-comparison', config, logger)
-    return list_comparison
+    @property
+    def generic_rules_dirs(self):
+        return self.CONFIG["generic_rules"]
 
+    @property
+    def specific_rules_dirs(self):
+        return self.CONFIG["specific_rules"]
 
-class TestListComparison:
-    def test_element_in_list(self, list_comparison):
+    def test_element_in_list(self):
         # Tests if user Franz is in user list
-        assert list_comparison.ps.processed_count == 0
-        document = {'user': 'Franz'}
+        assert self.object.events_processed_count() == 0
+        document = {"user": "Franz"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('user_results', {}).get('in_list') is not []
-        assert document.get('user_results', {}).get('not_in_list') is None
+        assert self.object._event.get("user_results") is not None
+        assert isinstance(self.object._event.get("user_results"), dict)
+        assert document.get('user_results').get('in_list') is not None
+        assert document.get("user_results").get("not_in_list") is None
 
-    def test_element_not_in_list(self, list_comparison):
+    def test_element_not_in_list(self):
         # Test if user Charlotte is not in user list
-        assert list_comparison.ps.processed_count == 0
-        document = {'user': 'Charlotte'}
+        assert self.object.events_processed_count() == 0
+        document = {"user": "Charlotte"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('user_results', {}).get('not_in_list') is not []
-        assert document.get('user_results', {}).get('in_list') is None
+        assert document.get("user_results", {}).get("not_in_list") is not []
+        assert document.get("user_results", {}).get("in_list") is None
 
-    def test_element_in_two_lists(self, list_comparison):
+    def test_element_in_two_lists(self):
         # Tests if the system name Franz appears in two lists, username Mark is in no list
-        assert list_comparison.ps.processed_count == 0
-        document = {'user': 'Mark', 'system': "Franz"}
+        assert self.object.events_processed_count() == 0
+        document = {"user": "Mark", "system": "Franz"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert len(document.get('user_results', {}).get('not_in_list')) is 1
-        assert document.get('user_results', {}).get('in_list') is None
-        assert len(document.get('user_and_system_results', {}).get('in_list')) is 2
-        assert document.get('user_and_system_results', {}).get('not_in_list') is None
+        assert len(document.get("user_results", {}).get("not_in_list")) is 1
+        assert document.get("user_results", {}).get("in_list") is None
+        assert len(document.get("user_and_system_results", {}).get("in_list")) is 2
+        assert document.get("user_and_system_results", {}).get("not_in_list") is None
 
-    def test_element_not_in_two_lists(self, list_comparison):
+    def test_element_not_in_two_lists(self):
         # Tests if the system Gamma does not appear in two lists, and username Mark is also not in list
-        assert list_comparison.ps.processed_count == 0
-        document = {'user': 'Mark', 'system': "Gamma"}
+        assert self.object.events_processed_count() == 0
+        document = {"user": "Mark", "system": "Gamma"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert len(document.get('user_and_system_results', {}).get('not_in_list')) is 2
-        assert document.get('user_and_system_results', {}).get('in_list') is None
-        assert len(document.get('user_results', {}).get('not_in_list')) is 1
-        assert document.get('user_results', {}).get('in_list') is None
+        assert len(document.get("user_and_system_results", {}).get("not_in_list")) is 2
+        assert document.get("user_and_system_results", {}).get("in_list") is None
+        assert len(document.get("user_results", {}).get("not_in_list")) is 1
+        assert document.get("user_results", {}).get("in_list") is None
 
-    def test_two_lists_with_one_matched(self, list_comparison):
-        assert list_comparison.ps.processed_count == 0
-        document = {'system': 'Alpha', 'user': 'Charlotte'}
+    def test_two_lists_with_one_matched(self):
+        assert self.object.events_processed_count() == 0
+        document = {"system": "Alpha", "user": "Charlotte"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('user_results', {}).get('not_in_list') is not []
-        assert document.get('user_results', {}).get('in_list') is None
-        assert document.get('user_and_system_results', {}).get('not_in_list') is None
-        assert document.get('user_and_system_results', {}).get('in_list') is not []
+        assert document.get("user_results", {}).get("not_in_list") is not []
+        assert document.get("user_results", {}).get("in_list") is None
+        assert document.get("user_and_system_results", {}).get("not_in_list") is None
+        assert document.get("user_and_system_results", {}).get("in_list") is not []
 
-    def test_dotted_output_field(self, list_comparison):
+    def test_dotted_output_field(self):
         # tests if outputting list_comparison results to dotted fields works
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz'}
+        assert self.object.events_processed_count() == 0
+        document = {"dot_channel": "test", "user": "Franz"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('dotted', {}).get('user_results', {}).get('not_in_list') is None
-        assert document.get('dotted', {}).get('user_results', {}).get('in_list') is not []
+        assert (
+            document.get("dotted", {}).get("user_results", {}).get("not_in_list")
+            is None
+        )
+        assert (
+            document.get("dotted", {}).get("user_results", {}).get("in_list") is not []
+        )
 
-    def test_deep_dotted_output_field(self, list_comparison):
+    def test_deep_dotted_output_field(self):
         # tests if outputting list_comparison results to dotted fields works
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz'}
+        assert self.object.events_processed_count() == 0
+        document = {"dot_channel": "test", "user": "Franz"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('more', {}).get('than', {}).get('dotted', {}).get('user_results', {}).get('not_in_list') is None
-        assert document.get('more', {}).get('than', {}).get('dotted', {}).get('user_results', {}).get('not_in_list') is not []
+        assert (
+            document.get("more", {})
+            .get("than", {})
+            .get("dotted", {})
+            .get("user_results", {})
+            .get("not_in_list")
+            is None
+        )
+        assert (
+            document.get("more", {})
+            .get("than", {})
+            .get("dotted", {})
+            .get("user_results", {})
+            .get("not_in_list")
+            is not []
+        )
 
-    def test_extend_dotted_output_field(self, list_comparison):
+    def test_extend_dotted_output_field(self):
         # tests if list_comparison properly extends lists already present in output fields.
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz',
-                    'dotted': {'user_results': {'in_list': ['already_present']}}}
+        assert self.object.events_processed_count() == 0
+        document = {
+            "dot_channel": "test",
+            "user": "Franz",
+            "dotted": {"user_results": {"in_list": ["already_present"]}},
+        }
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('dotted', {}).get('user_results', {}).get('not_in_list') is None
-        assert len(document.get('dotted', {}).get('user_results', {}).get('in_list')) == 2
+        assert (
+            document.get("dotted", {}).get("user_results", {}).get("not_in_list")
+            is None
+        )
+        assert (
+            len(document.get("dotted", {}).get("user_results", {}).get("in_list")) == 2
+        )
 
-    def test_dotted_parent_field_exists_but_subfield_doesnt(self, list_comparison):
+    def test_dotted_parent_field_exists_but_subfield_doesnt(self):
         # tests if list_comparison properly extends lists already present in output fields.
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz',
-                    'dotted': {'preexistent_output_field': {'in_list': ['already_present']}}}
+        assert self.object.events_processed_count() == 0
+        document = {
+            "dot_channel": "test",
+            "user": "Franz",
+            "dotted": {"preexistent_output_field": {"in_list": ["already_present"]}},
+        }
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert document.get('dotted', {}).get('user_results', {}).get('not_in_list') is None
-        assert len(document.get('dotted', {}).get('user_results', {}).get('in_list')) == 1
-        assert len(document.get('dotted', {}).get('preexistent_output_field', {}).get('in_list')) == 1
+        assert (
+            document.get("dotted", {}).get("user_results", {}).get("not_in_list")
+            is None
+        )
+        assert (
+            len(document.get("dotted", {}).get("user_results", {}).get("in_list")) == 1
+        )
+        assert (
+            len(
+                document.get("dotted", {})
+                .get("preexistent_output_field", {})
+                .get("in_list")
+            )
+            == 1
+        )
 
-    def test_dotted_wrong_type(self, list_comparison):
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz',
-                    'dotted': "dotted_Franz"}
+    def test_dotted_wrong_type(self):
+        assert self.object.events_processed_count() == 0
+        document = {"dot_channel": "test", "user": "Franz", "dotted": "dotted_Franz"}
 
         with pytest.raises(DuplicationError):
-            list_comparison.process(document)
+            self.object.process(document)
 
-    def test_intermediate_output_field_is_wrong_type(self, list_comparison):
-        assert list_comparison.ps.processed_count == 0
-        document = {'dot_channel': 'test', 'user': 'Franz',
-                    'dotted': {'user_results': ['do_not_look_here']}}
+    def test_intermediate_output_field_is_wrong_type(self):
+        assert self.object.events_processed_count() == 0
+        document = {
+            "dot_channel": "test",
+            "user": "Franz",
+            "dotted": {"user_results": ["do_not_look_here"]},
+        }
 
         with pytest.raises(DuplicationError):
-            list_comparison.process(document)
+            self.object.process(document)
 
-    def test_check_in_dotted_subfield(self, list_comparison):
-        assert list_comparison.ps.processed_count == 0
-        document = {'channel': {'type': 'fast'}}
+    def test_check_in_dotted_subfield(self):
+        assert self.object.events_processed_count() == 0
+        document = {"channel": {"type": "fast"}}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert len(document.get('channel_results', {}).get('not_in_list')) is 2
-        assert document.get('channel_results', {}).get('in_list') is None
+        assert len(document.get("channel_results", {}).get("not_in_list")) is 2
+        assert document.get("channel_results", {}).get("in_list") is None
 
-    def test_ignore_comment_in_list(self, list_comparison):
+    def test_ignore_comment_in_list(self):
         # Tests for a comment inside a list, but as a field inside a document to check
         # if the comment is actually ignored
-        assert list_comparison.ps.processed_count == 0
-        document = {'user': '# This is a doc string for testing'}
+        assert self.object.events_processed_count() == 0
+        document = {"user": "# This is a doc string for testing"}
 
-        list_comparison.process(document)
+        self.object.process(document)
 
-        assert len(document.get('user_results', {}).get('not_in_list')) is 1
-        assert document.get('user_results', {}).get('in_list') is None
+        assert len(document.get("user_results", {}).get("not_in_list")) is 1
+        assert document.get("user_results", {}).get("in_list") is None

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -18,6 +18,7 @@ class TestListComparison(BaseProcessorTestCase):
         "specific_rules": ["tests/testdata/unit/list_comparison/rules/specific"],
         "generic_rules": ["tests/testdata/unit/list_comparison/rules/generic"],
         "tree_config": "tests/testdata/unit/shared_data/tree_config.json",
+        "list_search_base_path": "./"
     }
     factory = ListComparisonFactory
 

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -31,7 +31,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_element_in_list(self):
         # Tests if user Franz is in user list
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"user": "Franz"}
 
         self.object.process(document)
@@ -43,7 +43,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_element_not_in_list(self):
         # Test if user Charlotte is not in user list
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"user": "Charlotte"}
 
         self.object.process(document)
@@ -53,7 +53,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_element_in_two_lists(self):
         # Tests if the system name Franz appears in two lists, username Mark is in no list
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"user": "Mark", "system": "Franz"}
 
         self.object.process(document)
@@ -65,7 +65,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_element_not_in_two_lists(self):
         # Tests if the system Gamma does not appear in two lists, and username Mark is also not in list
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"user": "Mark", "system": "Gamma"}
 
         self.object.process(document)
@@ -76,7 +76,7 @@ class TestListComparison(BaseProcessorTestCase):
         assert document.get("user_results", {}).get("in_list") is None
 
     def test_two_lists_with_one_matched(self):
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"system": "Alpha", "user": "Charlotte"}
 
         self.object.process(document)
@@ -88,7 +88,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_dotted_output_field(self):
         # tests if outputting list_comparison results to dotted fields works
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"dot_channel": "test", "user": "Franz"}
 
         self.object.process(document)
@@ -103,7 +103,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_deep_dotted_output_field(self):
         # tests if outputting list_comparison results to dotted fields works
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"dot_channel": "test", "user": "Franz"}
 
         self.object.process(document)
@@ -127,7 +127,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_extend_dotted_output_field(self):
         # tests if list_comparison properly extends lists already present in output fields.
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {
             "dot_channel": "test",
             "user": "Franz",
@@ -146,7 +146,7 @@ class TestListComparison(BaseProcessorTestCase):
 
     def test_dotted_parent_field_exists_but_subfield_doesnt(self):
         # tests if list_comparison properly extends lists already present in output fields.
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {
             "dot_channel": "test",
             "user": "Franz",
@@ -172,14 +172,14 @@ class TestListComparison(BaseProcessorTestCase):
         )
 
     def test_dotted_wrong_type(self):
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"dot_channel": "test", "user": "Franz", "dotted": "dotted_Franz"}
 
         with pytest.raises(DuplicationError):
             self.object.process(document)
 
     def test_intermediate_output_field_is_wrong_type(self):
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {
             "dot_channel": "test",
             "user": "Franz",
@@ -190,7 +190,7 @@ class TestListComparison(BaseProcessorTestCase):
             self.object.process(document)
 
     def test_check_in_dotted_subfield(self):
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"channel": {"type": "fast"}}
 
         self.object.process(document)
@@ -201,7 +201,7 @@ class TestListComparison(BaseProcessorTestCase):
     def test_ignore_comment_in_list(self):
         # Tests for a comment inside a list, but as a field inside a document to check
         # if the comment is actually ignored
-        assert self.object.events_processed_count() == 0
+        assert self.object.ps.processed_count == 0
         document = {"user": "# This is a doc string for testing"}
 
         self.object.process(document)

--- a/tests/unit/processor/list_comparison/test_list_comparison_rule.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison_rule.py
@@ -1,0 +1,81 @@
+from logprep.filter.lucene_filter import LuceneFilter
+
+import pytest
+
+pytest.importorskip("logprep.processor.list_comparison")
+
+from unittest import mock
+from logprep.processor.list_comparison.rule import ListComparisonRule
+
+
+@pytest.fixture()
+def specific_rule_definition():
+    return {
+        "filter": "user",
+        "list_comparison": {
+            "check_field": "user",
+            "output_field": "user_results",
+            "list_file_paths": [
+                "tests/testdata/unit/list_comparison/lists/user_list.txt"
+            ],
+        },
+        "description": "",
+    }
+
+
+class TestListComparisonRule:
+    def test_rules_are_equal(self, specific_rule_definition):
+        rule1 = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        rule2 = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        assert rule1 == rule2
+
+    def test_rules_are_not_equal(self, specific_rule_definition):
+        rule = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        rule_diff_check_field = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        rule_diff_filter = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        rule_diff_check_field._check_field = ["diff_field"]
+        rule_diff_filter._filter = ["diff_user"]
+
+        assert rule != rule_diff_check_field
+        assert rule != rule_diff_filter
+        assert rule_diff_check_field != rule_diff_filter
+
+    def test_compare_set_not_empty_for_valid_rule_def(self, specific_rule_definition):
+        self.rule = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+
+        assert self.rule._compare_sets is not None
+        assert isinstance(self.rule._compare_sets, dict)
+        assert len(self.rule._compare_sets.keys()) > 0
+
+    @mock.patch(
+        "logprep.processor.list_comparison.rule.ListComparisonRule.init_list_comparison"
+    )
+    def test_init_compare_sets_is_called(self, mock_method, specific_rule_definition):
+        rule = ListComparisonRule(
+            LuceneFilter.create(specific_rule_definition["filter"]),
+            specific_rule_definition["list_comparison"],
+        )
+        mock_method.assert_called()


### PR DESCRIPTION
Refactor to use base class for list comparison tests. Part of a refactoring for all processors to use generic and specific rules.