### PR TITLE
Remove no longer existing labeler exceptions from schema validator

### DIFF
--- a/logprep/util/schema_and_rule_checker.py
+++ b/logprep/util/schema_and_rule_checker.py
@@ -21,13 +21,7 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.base.rule import Rule
 from logprep.processor.base.processor import BaseProcessor
-from logprep.processor.labeler.labeling_schema import (
-    LabelingSchema,
-    InvalidLabelingSchemaFileError,
-    DuplicateLabelInCategoryError,
-    CategoryWithoutDesciptionInSchemaError,
-    LabelWithoutDesciptionInSchemaError,
-)
+from logprep.processor.labeler.labeling_schema import LabelingSchema, InvalidLabelingSchemaFileError
 from logprep.filter.lucene_filter import LuceneFilterError
 
 
@@ -183,12 +177,7 @@ class SchemaAndRuleChecker:
     def _validate_schema_definition(self, path_schema: str) -> LabelingSchema:
         try:
             schema = LabelingSchema.create_from_file(path_schema)
-        except (
-            InvalidLabelingSchemaFileError,
-            DuplicateLabelInCategoryError,
-            CategoryWithoutDesciptionInSchemaError,
-            LabelWithoutDesciptionInSchemaError,
-        ) as error:
+        except InvalidLabelingSchemaFileError as error:
             self.errors.append(str(error))
         else:
             return schema

--- a/tests/unit/util/test_schema_and_rule_checker.py
+++ b/tests/unit/util/test_schema_and_rule_checker.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-docstring
+from logprep.util.schema_and_rule_checker import SchemaAndRuleChecker
+
+
+class TestSchemaAndRuleChecker:
+    def test_init(self):
+        rule_checker = SchemaAndRuleChecker()
+        assert isinstance(rule_checker.errors, list)
+        assert len(rule_checker.errors) == 0


### PR DESCRIPTION
Remove no longer existing labeler exceptions from schema validator

* The schema validation for the labeler should no longer cause import errors.