### PR TITLE
Refactor processor factories to use config check

### DIFF
--- a/logprep/processor/datetime_extractor/factory.py
+++ b/logprep/processor/datetime_extractor/factory.py
@@ -2,13 +2,12 @@
 
 from logprep.processor.base.factory import BaseFactory
 from logprep.processor.datetime_extractor.processor import DateTimeExtractor
-from logprep.processor.processor_factory_error import InvalidConfigurationError
 
 
 class DateTimeExtractorFactory(BaseFactory):
     """Create datetime extractor."""
 
-    mandatory_fields = ["type", "generic_rules", "specific_rules", "tree_config"]
+    mandatory_fields = ["generic_rules", "specific_rules", "tree_config"]
 
     @staticmethod
     def create(name: str, configuration: dict, logger) -> DateTimeExtractor:
@@ -19,6 +18,8 @@ class DateTimeExtractorFactory(BaseFactory):
 
     @staticmethod
     def _check_configuration(configuration: dict):
-        for field in DateTimeExtractorFactory.mandatory_fields:
-            if field not in configuration.keys():
-                raise InvalidConfigurationError
+        DateTimeExtractorFactory._check_common_configuration(
+            processor_type="datetime_extractor",
+            existing_items=DateTimeExtractorFactory.mandatory_fields,
+            configuration=configuration,
+        )

--- a/logprep/processor/datetime_extractor/factory.py
+++ b/logprep/processor/datetime_extractor/factory.py
@@ -7,7 +7,7 @@ from logprep.processor.datetime_extractor.processor import DateTimeExtractor
 class DateTimeExtractorFactory(BaseFactory):
     """Create datetime extractor."""
 
-    mandatory_fields = ["generic_rules", "specific_rules", "tree_config"]
+    mandatory_fields = ["generic_rules", "specific_rules"]
 
     @staticmethod
     def create(name: str, configuration: dict, logger) -> DateTimeExtractor:

--- a/logprep/processor/domain_label_extractor/factory.py
+++ b/logprep/processor/domain_label_extractor/factory.py
@@ -7,7 +7,7 @@ from logprep.processor.domain_label_extractor.processor import DomainLabelExtrac
 class DomainLabelExtractorFactory(BaseFactory):
     """Factory used to instantiate DomainLabelExtractor processors."""
 
-    mandatory_fields = ["generic_rules", "specific_rules", "tree_config"]
+    mandatory_fields = ["generic_rules", "specific_rules"]
 
     @staticmethod
     def create(name: str, configuration: dict, logger) -> DomainLabelExtractor:

--- a/logprep/processor/domain_label_extractor/factory.py
+++ b/logprep/processor/domain_label_extractor/factory.py
@@ -2,13 +2,12 @@
 
 from logprep.processor.base.factory import BaseFactory
 from logprep.processor.domain_label_extractor.processor import DomainLabelExtractor
-from logprep.processor.processor_factory_error import InvalidConfigurationError
 
 
 class DomainLabelExtractorFactory(BaseFactory):
     """Factory used to instantiate DomainLabelExtractor processors."""
 
-    mandatory_fields = ["type", "generic_rules", "specific_rules", "tree_config"]
+    mandatory_fields = ["generic_rules", "specific_rules", "tree_config"]
 
     @staticmethod
     def create(name: str, configuration: dict, logger) -> DomainLabelExtractor:
@@ -26,6 +25,8 @@ class DomainLabelExtractorFactory(BaseFactory):
 
     @staticmethod
     def _check_configuration(configuration: dict):
-        for field in DomainLabelExtractorFactory.mandatory_fields:
-            if field not in configuration.keys():
-                raise InvalidConfigurationError
+        DomainLabelExtractorFactory._check_common_configuration(
+            processor_type="domain_label_extractor",
+            existing_items=DomainLabelExtractorFactory.mandatory_fields,
+            configuration=configuration,
+        )

--- a/logprep/processor/labeler/factory.py
+++ b/logprep/processor/labeler/factory.py
@@ -14,6 +14,8 @@ class LabelerFactory(BaseFactory):
     processor_type = Labeler
     rule_type = LabelingRule
 
+    mandatory_fields = ["generic_rules", "specific_rules", "tree_config",  "schema"]
+
     @staticmethod
     def create(name: str, configuration: dict, logger: Logger) -> Labeler:
         """Create a labeler."""
@@ -31,7 +33,7 @@ class LabelerFactory(BaseFactory):
     def _check_configuration(configuration: dict):
         LabelerFactory._check_common_configuration(
             processor_type="labeler",
-            existing_items=["schema"],
+            existing_items=LabelerFactory.mandatory_fields,
             configuration=configuration,
         )
 

--- a/logprep/processor/labeler/factory.py
+++ b/logprep/processor/labeler/factory.py
@@ -14,7 +14,7 @@ class LabelerFactory(BaseFactory):
     processor_type = Labeler
     rule_type = LabelingRule
 
-    mandatory_fields = ["generic_rules", "specific_rules", "tree_config",  "schema"]
+    mandatory_fields = ["generic_rules", "specific_rules",  "schema"]
 
     @staticmethod
     def create(name: str, configuration: dict, logger: Logger) -> Labeler:

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor_factory.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor_factory.py
@@ -1,35 +1,31 @@
+# pylint: disable=protected-access
+# pylint: disable=missing-docstring
+# pylint: disable=attribute-defined-outside-init
 import copy
+from logging import getLogger
 from pathlib import Path
-import pytest
 
-from tests.unit.processor.base import BaseProcessorTestCase
+import pytest
 
 pytest.importorskip("logprep.processor.domain_label_extractor")
 
-from logging import getLogger
 
-from logprep.processor.base.processor import RuleBasedProcessor, ProcessingWarning
 from logprep.processor.processor_factory_error import InvalidConfigurationError
-from logprep.processor.domain_label_extractor.rule import (
-    DomainLabelExtractorRule,
-    InvalidDomainLabelExtractorDefinition,
-)
 from logprep.processor.domain_label_extractor.factory import DomainLabelExtractorFactory
 from logprep.processor.domain_label_extractor.processor import (
     DomainLabelExtractor,
-    DuplicationError,
 )
 
 logger = getLogger()
-rel_tld_list_path = "tests/testdata/external/public_suffix_list.dat"
-tld_list = f"file://{Path().absolute().joinpath(rel_tld_list_path).as_posix()}"
+REL_TLD_LIST_PATH = "tests/testdata/external/public_suffix_list.dat"
+tld_list = f"file://{Path().absolute().joinpath(REL_TLD_LIST_PATH).as_posix()}"
 
 
 class TestDomainLabelExtractorFactory:
     REQUIRED_CONFIG_FIELDS = {
         "type": "domain_label_extractor",
         "generic_rules": ["tests/testdata/unit/domain_label_extractor/rules/generic"],
-        "specific_rules": ["tests/testdata/unit/domain_label_extractor/rules/specific"]
+        "specific_rules": ["tests/testdata/unit/domain_label_extractor/rules/specific"],
     }
 
     def test_create(self):

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor_factory.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor_factory.py
@@ -29,8 +29,7 @@ class TestDomainLabelExtractorFactory:
     REQUIRED_CONFIG_FIELDS = {
         "type": "domain_label_extractor",
         "generic_rules": ["tests/testdata/unit/domain_label_extractor/rules/generic"],
-        "specific_rules": ["tests/testdata/unit/domain_label_extractor/rules/specific"],
-        "tree_config": "tests/testdata/unit/shared_data/tree_config.json",
+        "specific_rules": ["tests/testdata/unit/domain_label_extractor/rules/specific"]
     }
 
     def test_create(self):


### PR DESCRIPTION
The processors datetime extractor, domain label extractor and
labeler weren't using the check_common_configuration method.
This is aligned in this pull request.