### PR TITLE
Fix init of the generic adder rule trees

### DIFF
--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -46,8 +46,8 @@ class GenericAdder(RuleBasedProcessor):
         generic_rules_dirs = configuration.get("generic_rules")
         super().__init__(name, tree_config, logger)
         self.ps = ProcessorStats()
-        self._generic_tree = RuleTree(tree_config)
-        self._specific_tree = RuleTree(tree_config)
+        self._generic_tree = RuleTree(config_path=tree_config)
+        self._specific_tree = RuleTree(config_path=tree_config)
         self.add_rules_from_directory(
             generic_rules_dirs=generic_rules_dirs,
             specific_rules_dirs=specific_rules_dirs,

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -46,8 +46,6 @@ class GenericAdder(RuleBasedProcessor):
         generic_rules_dirs = configuration.get("generic_rules")
         super().__init__(name, tree_config, logger)
         self.ps = ProcessorStats()
-        self._generic_tree = RuleTree(config_path=tree_config)
-        self._specific_tree = RuleTree(config_path=tree_config)
         self.add_rules_from_directory(
             generic_rules_dirs=generic_rules_dirs,
             specific_rules_dirs=specific_rules_dirs,


### PR DESCRIPTION
The tree_config path was given as a positional argument resulting
in being interpreted as a Node instead of the proper config path