### PR TITLE
Add python 3.7 to 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           black --check --diff --config ./pyproject.toml .
 
       - name: lint changed and added files
+        if: steps.changed-files.outputs.all_changed_files
         run: |
           pylint --rcfile=.pylintrc --fail-under 9.5 ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,19 @@ jobs:
   build-pex:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
 
-      - uses: actions/cache@v2
-        id: cache
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          path: |
-            /opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/ansible
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/virtualenv
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/pex
-          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_dev.txt') }}
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install ansible
@@ -60,12 +54,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -87,15 +86,21 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Get changed python files
         id: changed-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Get changed python files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,25 +9,19 @@ jobs:
   build-pex:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
 
-      - uses: actions/cache@v2
-        id: cache
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          path: |
-            /opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/ansible
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/virtualenv
-            /opt/hostedtoolcache/Python/3.6.15/x64/bin/pex
-          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_dev.txt') }}
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install ansible
@@ -58,12 +52,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -85,15 +84,21 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: §{{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Get changed python files
         id: changed-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,7 @@ jobs:
           black --check --diff --config ./pyproject.toml .
 
       - name: lint changed and added files
+        if: steps.changed-files.outputs.all_changed_files
         run: |
           pylint --rcfile=.pylintrc --fail-under 9.5 ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: §{{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Get changed python files

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Details about the rule language and how to write rules for the processors can be
 
 ### Installation
 
-Python 3.6 should be present on the system.
+Python should be present on the system, currently supported are the versions 3.6 - 3.9.
 All packages required for Logprep must be installed.
 For this, the following command can be executed from within the project root directory: 
   
@@ -239,25 +239,31 @@ Tests are started by executing `tox` in the project root directory.
 This creates a virtual test environment and executes tests within it.
 
 Multiple different test environments were defined for tox.
-Those can be executed via:
+Those can be executed via: `tox -e [name of the test environment]`.
+For Example:
 
 ```
-tox -e [name of the test environment]
+tox -e py36-all
 ```
+
+This runs all tests, calculates the test coverage and evaluates the code quality for the python 
+3.6 version.
+
+Multiple environments can be tested within one call: 
+
+```
+tox -e py36-all -e py37-all -e py38-all -e py39-all
+```
+
+If you want to run them in parallel attach the option `-p`.
+This can lead to side effects in I/O operations though, like concurrences in writing or reading
+files.
  
 An overview of the test environments can be obtained by executing:
 
 ```
 tox -av
 ```
-
-Example:
-
-```
-tox -e all
-```
-
-This runs all tests, calculates the test coverage and evaluates the code quality.
 
 In case the requirements change, the test environments must be rebuilt with the parameter `-r`:
 
@@ -370,7 +376,7 @@ Building the documentation is done by executing the following command from withi
 the project root directory:
 
 ```
-tox -e docs
+tox -e py36-docs
 ```
 
 A HTML documentation can be then found in `doc/_build/html/index.html`.

--- a/requirements.in
+++ b/requirements.in
@@ -2,12 +2,12 @@ luqum
 jsonref
 pyyaml
 ruamel.yaml
-confluent-kafka==1.5.0
+confluent-kafka==1.8.2
 pycryptodome
 urlextract
 tldextract
 geoip2
-ujson==3.1.0
+ujson==4.3.0
 pygrok
 colorama
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==2.0.10
     #   requests
 colorama==0.4.4
     # via -r requirements.in
-confluent-kafka==1.5.0
+confluent-kafka==1.8.2
     # via -r requirements.in
 filelock==3.4.1
     # via
@@ -100,7 +100,7 @@ typing-extensions==4.0.1
     #   arrow
     #   async-timeout
     #   yarl
-ujson==3.1.0
+ujson==4.3.0
     # via -r requirements.in
 uritools==3.0.2
     # via urlextract

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,7 +40,7 @@ charset-normalizer==2.0.10
     #   requests
 colorama==0.4.4
     # via -r requirements.txt
-confluent-kafka==1.5.0
+confluent-kafka==1.8.2
     # via -r requirements.txt
 coverage[toml]==6.2
     # via pytest-cov
@@ -179,7 +179,7 @@ typing-extensions==4.0.1
     #   importlib-metadata
     #   pylint
     #   yarl
-ujson==3.1.0
+ujson==4.3.0
     # via -r requirements.txt
 uritools==3.0.2
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = unit
-
+envlist = py{36,37,38,39}
+minversion = 3.6
 
 [testenv]
-basepython = python3.6
 deps = -rrequirements_dev.txt
 
 
-[testenv:unit]
+[testenv:py{36,37,38,39}-unit]
 description = Run unit-tests
 usedevelop = True
 deps = {[testenv]deps}
@@ -15,7 +14,7 @@ commands =
     pytest  -vv tests/unit {posargs}
 
 
-[testenv:acceptance]
+[testenv:py{36,37,38,39}-acceptance]
 description = Run acceptance-tests
 usedevelop = True
 deps =
@@ -25,7 +24,7 @@ commands =
     pytest  -vv -s tests/acceptance {posargs}
 
 
-[testenv:lint]
+[testenv:py{36,37,38,39}-lint]
 description = Run pylint to determine code-quality
 usedevelop = True
 deps = pylint
@@ -35,7 +34,7 @@ commands =
     - pylint logprep
 
 
-[testenv:docs]
+[testenv:py{36,37,38,39}-docs]
 description = Build sphinx HTML documentation
 changedir = doc
 usedevelop = True
@@ -49,7 +48,7 @@ commands =
     make clean html
 
 
-[testenv:all]
+[testenv:py{36,37,38,39}-all]
 description = Run all tests with coverage and lint
 usedevelop = True
 deps =


### PR DESCRIPTION
Adjusts python requirements to allow for higher versions,
while still maintaining support for python 3.6. 
With that update also the tox environments such that the tests
can be run against all python versions. And also update the
github actions in order to continuously test logprep against the 
different versions.