### PR TITLE
Fix init of prometheus multiprocesscollector

### DIFF
--- a/logprep/util/prometheus_exporter.py
+++ b/logprep/util/prometheus_exporter.py
@@ -24,11 +24,10 @@ class PrometheusStatsExporter:
         """
         multi_processing_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
         if multi_processing_dir:
-            multiprocess.MultiProcessCollector(REGISTRY, multi_processing_dir)
-
             if os.path.isdir(multi_processing_dir):
                 shutil.rmtree(multi_processing_dir)
             os.makedirs(multi_processing_dir, exist_ok=True)
+            multiprocess.MultiProcessCollector(REGISTRY, multi_processing_dir)
 
     def _extract_port_from(self, configuration):
         target_configs = configuration.get("targets", [])

--- a/tests/unit/util/test_prometheus_exporter.py
+++ b/tests/unit/util/test_prometheus_exporter.py
@@ -1,6 +1,9 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+# pylint: disable=attribute-defined-outside-init
+import os
 from logging import getLogger
+from unittest import mock
 
 from prometheus_client import Gauge, Info, REGISTRY
 
@@ -10,9 +13,7 @@ from logprep.util.prometheus_exporter import PrometheusStatsExporter
 class TestPrometheusStatsExporter:
     def setup_method(self):
         REGISTRY.__init__()
-
-    def test_correct_setup(self):
-        status_logger_config = {
+        self.status_logger_config = {
             "period": 10,
             "enabled": True,
             "cumulative": True,
@@ -21,7 +22,9 @@ class TestPrometheusStatsExporter:
                 {"file": {"path": "", "rollover_interval": 200, "backup_count": 10}},
             ],
         }
-        exporter = PrometheusStatsExporter(status_logger_config, getLogger("test-logger"))
+
+    def test_correct_setup(self):
+        exporter = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
 
         expected_metrics = {
             "processed",
@@ -40,15 +43,13 @@ class TestPrometheusStatsExporter:
         assert len(missing_keys) == 0, f"following metrics are missing: {missing_keys}"
         assert len(unknown_keys) == 0, f"following metrics are unexpected: {unknown_keys}"
 
-        assert all(
-            [isinstance(exporter.stats[metric_key], Gauge) for metric_key in exporter.stats.keys()]
-        )
+        assert all(isinstance(exporter.stats[metric_key], Gauge) for metric_key in exporter.stats)
 
         assert isinstance(exporter.info_metric, Info)
 
-        assert exporter._port == status_logger_config["targets"][0]["prometheus"]["port"]
+        assert exporter._port == self.status_logger_config["targets"][0]["prometheus"]["port"]
 
-        expected_label = {"interval_in_seconds": f"{status_logger_config['period']}"}
+        expected_label = {"interval_in_seconds": f"{self.status_logger_config['period']}"}
         tracked_tracking_interval = REGISTRY.get_sample_value("tracking_info", expected_label)
         assert tracked_tracking_interval == 1
 
@@ -62,3 +63,48 @@ class TestPrometheusStatsExporter:
         exporter = PrometheusStatsExporter(status_logger_config, getLogger("test-logger"))
 
         assert exporter._port == 8000
+
+    @mock.patch("logprep.util.prometheus_exporter.multiprocess")
+    def test_prepare_multiprocessing_recreates_temp_directory_if_dir_exists_already(
+        self, mock_multiprocess, tmp_path
+    ):
+        multi_proc_dir = tmp_path / "multi_proc_dir"
+        os.makedirs(multi_proc_dir)
+        test_file = os.path.join(multi_proc_dir, "dummy.txt")
+        open(test_file, "w", encoding="utf-8").close()  # pylint: disable=consider-using-with
+
+        with mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": str(multi_proc_dir)}):
+            _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+
+        assert os.path.isdir(multi_proc_dir)
+        assert not os.path.isfile(test_file)
+        mock_multiprocess.assert_has_calls(
+            [mock.call.MultiProcessCollector(REGISTRY, str(multi_proc_dir))]
+        )
+
+    @mock.patch("logprep.util.prometheus_exporter.multiprocess")
+    def test_prepare_multiprocessing_creates_temp_dir_if_dir_does_not_exists(
+        self, mock_multiprocess, tmp_path
+    ):
+        multi_proc_dir = tmp_path / "multi_proc_dir"
+        assert not os.path.isdir(multi_proc_dir)
+
+        with mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": str(multi_proc_dir)}):
+            _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+
+        assert os.path.isdir(multi_proc_dir)
+        mock_multiprocess.assert_has_calls(
+            [mock.call.MultiProcessCollector(REGISTRY, str(multi_proc_dir))]
+        )
+
+    @mock.patch("logprep.util.prometheus_exporter.multiprocess")
+    @mock.patch("logprep.util.prometheus_exporter.os.makedirs")
+    @mock.patch("logprep.util.prometheus_exporter.shutil.rmtree")
+    def test_prepare_multiprocessing_does_not_init_prometheus_if_env_variable_is_missing(
+        self, mock_multiprocess, mock_makedirs, mock_rmtree
+    ):
+        _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+
+        mock_multiprocess.assert_not_called()
+        mock_makedirs.assert_not_called()
+        mock_rmtree.assert_not_called()


### PR DESCRIPTION
The multiprocessorcollector was initialized before the directory was
created. That lead to an error if the directory didn't exist already.
Fixed it by switching the statements and adding more tests for that.