### PR TITLE
Refactor Prometheus Metrics

### DIFF
--- a/doc/source/user_manual/configuration/logprep.rst
+++ b/doc/source/user_manual/configuration/logprep.rst
@@ -91,7 +91,6 @@ true/false
 
 Defines if the metrics of each child process should be aggregated to single values or if the metrics
 of the processes should be exported directly per process.
-The aggregation is enabled by default.
 
 targets
 -------
@@ -127,6 +126,7 @@ Example
       period: 10
       enabled: true
       cumulative: true
+      aggregate_processes: false
       targets:
         - prometheus:
             port: 8000

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -12,6 +12,7 @@ from time import time
 from typing import List
 
 import ujson
+
 from logprep.connector.connector_factory import ConnectorFactory
 from logprep.input.input import (
     CriticalInputError,
@@ -24,7 +25,7 @@ from logprep.processor.base.processor import ProcessingWarning, ProcessingWarnin
 from logprep.processor.processor_factory import ProcessorFactory
 from logprep.util.multiprocessing_log_handler import MultiprocessingLogHandler
 from logprep.util.pipeline_profiler import PipelineProfiler
-from logprep.util.processor_stats import StatusTracker
+from logprep.util.processor_stats import StatusTracker, StatusLoggerCollection
 from logprep.util.time_measurement import TimeMeasurement
 
 
@@ -60,7 +61,7 @@ class Pipeline:
         log_handler: Handler,
         lock: Lock,
         shared_dict: dict,
-        status_logger: list = None,
+        status_logger: StatusLoggerCollection = None,
     ):
         if not isinstance(log_handler, Handler):
             raise MustProvideALogHandlerError
@@ -156,7 +157,7 @@ class Pipeline:
         self._continue_iterating = True
 
     def _retrieve_and_process_data(self):
-        event = dict()
+        event = {}
         try:
             self._tracker.print_aggregate()
             event = self._input.get_next(self._timeout)
@@ -270,7 +271,7 @@ class Pipeline:
         self._continue_iterating = False
 
 
-class SharedCounter(object):
+class SharedCounter:
     """A shared counter for multi-processing pipelines."""
 
     CHECKING_PERIOD = 0.5
@@ -345,7 +346,7 @@ class MultiprocessingPipeline(Process, Pipeline):
         lock: Lock,
         shared_dict: dict,
         profile: bool = False,
-        status_logger: List = None,
+        status_logger: StatusLoggerCollection = None,
     ):
         if not isinstance(log_handler, MultiprocessingLogHandler):
             raise MustProvideAnMPLogHandlerError

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -1,28 +1,30 @@
 #!/usr/bin/python3
 """This module can be used to start the logprep."""
+import inspect
 import os
+import sys
+from argparse import ArgumentParser
 from logging import getLogger, Logger, DEBUG, ERROR
 from logging.handlers import TimedRotatingFileHandler
-from argparse import ArgumentParser
-from pathlib import Path
 from os.path import dirname, basename
-import inspect
+from pathlib import Path
 from typing import Optional
 
-import sys
-
-from logprep.runner import Runner
-from logprep.util.schema_and_rule_checker import SchemaAndRuleChecker
-from logprep.util.configuration import Configuration
-from logprep.util.rule_dry_runner import DryRunner
-from logprep.util.auto_rule_tester import AutoRuleTester
-from logprep.util.aggregating_logger import AggregatingLogger
 from logprep.processor.base.rule import Rule
 from logprep.processor.processor_factory import ProcessorFactory
-
-from logprep.util.time_measurement import TimeMeasurement
-from logprep.util.processor_stats import StatsClassesController, StatusLoggerCollection
+from logprep.runner import Runner
+from logprep.util.aggregating_logger import AggregatingLogger
+from logprep.util.auto_rule_tester import AutoRuleTester
+from logprep.util.configuration import Configuration
+from logprep.util.processor_stats import (
+    StatsClassesController,
+    StatusLoggerCollection,
+    ProcessorStats,
+)
 from logprep.util.prometheus_exporter import PrometheusStatsExporter
+from logprep.util.rule_dry_runner import DryRunner
+from logprep.util.schema_and_rule_checker import SchemaAndRuleChecker
+from logprep.util.time_measurement import TimeMeasurement
 
 DEFAULT_LOCATION_CONFIG = "/etc/logprep/pipeline.yml"
 getLogger("filelock").setLevel(ERROR)
@@ -62,7 +64,9 @@ def _get_status_logger(config: dict, application_logger: Logger) -> StatusLogger
                     "'PROMETHEUS_MULTIPROC_DIR' is missing."
                 )
             else:
-                prometheus_exporter = PrometheusStatsExporter(status_logger_cfg, application_logger)
+                prometheus_exporter = PrometheusStatsExporter(
+                    status_logger_cfg, application_logger, ProcessorStats.metrics
+                )
                 prometheus_exporter.run()
 
     status_logger = StatusLoggerCollection(file_logger, prometheus_exporter)

--- a/logprep/runner.py
+++ b/logprep/runner.py
@@ -4,11 +4,11 @@ import signal
 from ctypes import c_bool
 from logging import Logger, DEBUG
 from multiprocessing import Value, current_process
-from typing import List
 
 from logprep.framework.pipeline_manager import PipelineManager
 from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.multiprocessing_log_handler import MultiprocessingLogHandler
+from logprep.util.processor_stats import StatusLoggerCollection
 
 
 class RunnerError(BaseException):
@@ -104,7 +104,7 @@ class Runner:
         if not bypass_check_to_obtain_non_singleton_instance:
             raise UseGetRunnerToCreateRunnerSingleton
 
-    def set_logger(self, logger: Logger, status_logger: List = None):
+    def set_logger(self, logger: Logger, status_logger: StatusLoggerCollection = None):
         """Setup logging for any "known" errors from any part of the software.
 
         Parameters

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -1,8 +1,10 @@
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+# pylint: disable=attribute-defined-outside-init
+from copy import deepcopy
 from logging import DEBUG, WARNING, ERROR, getLogger
 from multiprocessing import active_children, Lock
 from queue import Empty
-
-from copy import deepcopy
 
 from _pytest.outcomes import fail
 from _pytest.python_api import raises
@@ -25,8 +27,8 @@ from logprep.output.dummy_output import DummyOutput
 from logprep.output.output import FatalOutputError, WarningOutputError, CriticalOutputError
 from logprep.processor.base.processor import BaseProcessor, ProcessingWarning
 from logprep.util.multiprocessing_log_handler import MultiprocessingLogHandler
+from logprep.util.processor_stats import StatsClassesController, StatusLoggerCollection
 from tests.util.testhelpers import AssertEmitsLogMessage
-from logprep.util.processor_stats import StatsClassesController
 
 
 class ConfigurationForTests:
@@ -40,8 +42,8 @@ class ConfigurationForTests:
     timeout = 0.001
     print_processed_period = 600
     lock = Lock()
-    shared_dict = dict()
-    status_logger = [getLogger("Mock")]
+    shared_dict = {}
+    status_logger = StatusLoggerCollection(file_logger=getLogger("Mock"), prometheus_exporter=None)
     counter = SharedCounter()
 
 
@@ -88,10 +90,10 @@ class TestPipeline(ConfigurationForTests):
         )
         self.clear_log_handler_queue()
 
-    def test_fails_if_log_handler_is_not_a_LogHandler(self):
+    def test_fails_if_log_handler_is_not_of_type_loghandler(self):
         for not_a_log_handler in [None, 123, 45.67, TestPipeline()]:
             with raises(MustProvideALogHandlerError):
-                pipeline = Pipeline(
+                _ = Pipeline(
                     self.connector_config,
                     self.pipeline_config,
                     self.status_logger_config,
@@ -155,7 +157,7 @@ class TestPipeline(ConfigurationForTests):
         input_data = [{"test": "1"}, {"test": "2"}, {"test": "3"}]
         pipeline = self.create_pipeline(input_data, ["donothing", "delete", "donothing"])
 
-        for i in range(len(input_data)):
+        for _ in range(len(input_data)):
             pipeline._retrieve_and_process_data()
 
         assert pipeline._pipeline[0].ps.processed_count == 3
@@ -458,7 +460,7 @@ class TestPipeline(ConfigurationForTests):
                 config = {"type": "delete", "i_really_want_to_delete_all_log_events": "I really do"}
             else:
                 raise ValueError("No template for processor " + item)
-            pipeline_config.append({"pipeline%d" % len(pipeline_config): config})
+            pipeline_config.append({f"pipeline{len(pipeline_config)}": config})
 
         StatsClassesController.ENABLED = True
         pipeline = Pipeline(

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -155,9 +155,9 @@ class TestPipeline(ConfigurationForTests):
 
     def test_empty_documents_are_not_forwarded_to_other_processors(self):
         input_data = [{"test": "1"}, {"test": "2"}, {"test": "3"}]
-        pipeline = self.create_pipeline(input_data, ["donothing", "delete", "donothing"])
+        pipeline = self.create_pipeline(input_data.copy(), ["donothing", "delete", "donothing"])
 
-        for _ in range(len(input_data)):
+        for _ in input_data:
             pipeline._retrieve_and_process_data()
 
         assert pipeline._pipeline[0].ps.processed_count == 3

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -1,3 +1,6 @@
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+# pylint: disable=attribute-defined-outside-init
 from logging import WARNING, Logger, INFO, ERROR
 from time import time, sleep
 
@@ -5,8 +8,9 @@ from pytest import raises
 
 from logprep.framework.pipeline import MultiprocessingPipeline
 from logprep.framework.pipeline_manager import PipelineManager, MustSetConfigurationFirstError
-from tests.testdata.metadata import path_to_config
 from logprep.util.configuration import Configuration
+from logprep.util.processor_stats import StatusLoggerCollection
+from tests.testdata.metadata import path_to_config
 from tests.util.testhelpers import AssertEmitsLogMessage, HandlerStub, AssertEmitsLogMessages
 
 
@@ -23,7 +27,7 @@ class MultiprocessingPipelineMock(MultiprocessingPipeline):
         MultiprocessingPipelineMock.process_count += 1
 
     def __repr__(self):
-        return "MultiprocessingLogprepWrapperMock-%d" % self._id
+        return f"MultiprocessingLogprepWrapperMock-{self._id}"
 
     def start(self):
         self.was_started = True
@@ -50,7 +54,9 @@ class TestPipelineManager:
         self.config = Configuration.create_from_yaml(path_to_config)
         self.handler = HandlerStub()
         self.logger = Logger("test")
-        self.status_logger = self.logger
+        self.status_logger = StatusLoggerCollection(
+            file_logger=self.logger, prometheus_exporter=None
+        )
         self.logger.addHandler(self.handler)
 
         self.manager = PipelineManagerForTesting(self.logger, self.status_logger)

--- a/tests/unit/util/test_processor_stats.py
+++ b/tests/unit/util/test_processor_stats.py
@@ -121,7 +121,9 @@ class TestStatusTracker:
             status_logger_config=stats_logger_config,
             status_logger=StatusLoggerCollection(
                 file_logger=logging.getLogger("test-file-metric-logger"),
-                prometheus_exporter=PrometheusStatsExporter(stats_logger_config, self.logger),
+                prometheus_exporter=PrometheusStatsExporter(
+                    stats_logger_config, self.logger, ProcessorStats.metrics
+                ),
             ),
             lock=Lock(),
         )

--- a/tests/unit/util/test_prometheus_exporter.py
+++ b/tests/unit/util/test_prometheus_exporter.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 from prometheus_client import Gauge, REGISTRY
 
+from logprep.util.processor_stats import ProcessorStats
 from logprep.util.prometheus_exporter import PrometheusStatsExporter
 
 
@@ -26,7 +27,9 @@ class TestPrometheusStatsExporter:
         }
 
     def test_correct_setup(self):
-        exporter = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+        exporter = PrometheusStatsExporter(
+            self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+        )
 
         expected_metrics = {
             "logprep_processed",
@@ -45,8 +48,7 @@ class TestPrometheusStatsExporter:
         assert len(unknown_keys) == 0, f"following metrics are unexpected: {unknown_keys}"
 
         assert all(
-            isinstance(exporter.metrics[metric_key], Gauge)
-            for metric_key in exporter.metrics.keys()
+            isinstance(exporter.metrics[metric_key], Gauge) for metric_key in exporter.metrics
         )
 
         assert isinstance(exporter.tracking_interval, Gauge)
@@ -60,7 +62,9 @@ class TestPrometheusStatsExporter:
             "cumulative": True,
             "targets": [{"file": {"path": "", "rollover_interval": 200, "backup_count": 10}}],
         }
-        exporter = PrometheusStatsExporter(status_logger_config, getLogger("test-logger"))
+        exporter = PrometheusStatsExporter(
+            status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+        )
 
         assert exporter._port == 8000
 
@@ -74,7 +78,9 @@ class TestPrometheusStatsExporter:
         open(test_file, "w", encoding="utf-8").close()  # pylint: disable=consider-using-with
 
         with mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": str(multi_proc_dir)}):
-            _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+            _ = PrometheusStatsExporter(
+                self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+            )
 
         assert os.path.isdir(multi_proc_dir)
         assert not os.path.isfile(test_file)
@@ -90,7 +96,9 @@ class TestPrometheusStatsExporter:
         assert not os.path.isdir(multi_proc_dir)
 
         with mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": str(multi_proc_dir)}):
-            _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+            _ = PrometheusStatsExporter(
+                self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+            )
 
         assert os.path.isdir(multi_proc_dir)
         mock_multiprocess.assert_has_calls(
@@ -109,7 +117,9 @@ class TestPrometheusStatsExporter:
                 match="Environment variable 'PROMETHEUS_MULTIPROC_DIR' "
                 "is a file and not a directory",
             ):
-                _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+                _ = PrometheusStatsExporter(
+                    self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+                )
 
     @mock.patch("logprep.util.prometheus_exporter.multiprocess")
     @mock.patch("logprep.util.prometheus_exporter.os.makedirs")
@@ -117,7 +127,9 @@ class TestPrometheusStatsExporter:
     def test_prepare_multiprocessing_does_not_init_prometheus_if_env_variable_is_missing(
         self, mock_multiprocess, mock_makedirs, mock_rmtree
     ):
-        _ = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+        _ = PrometheusStatsExporter(
+            self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+        )
 
         mock_multiprocess.assert_not_called()
         mock_makedirs.assert_not_called()
@@ -126,7 +138,9 @@ class TestPrometheusStatsExporter:
     @mock.patch("logprep.util.prometheus_exporter.start_http_server")
     def test_run_starts_http_server(self, mock_http_server, caplog):
         with caplog.at_level(logging.INFO):
-            exporter = PrometheusStatsExporter(self.status_logger_config, getLogger("test-logger"))
+            exporter = PrometheusStatsExporter(
+                self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
+            )
             exporter.run()
 
         mock_http_server.assert_has_calls([mock.call(exporter._port)])
@@ -140,15 +154,16 @@ class TestPrometheusStatsExporter:
         with mock.patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": str(multi_proc_dir)}):
             with caplog.at_level(logging.DEBUG):
                 exporter = PrometheusStatsExporter(
-                    self.status_logger_config, getLogger("test-logger")
+                    self.status_logger_config, getLogger("test-logger"), ProcessorStats.metrics
                 )
-                metric_test_file_1 = os.path.join(multi_proc_dir, "gauge_5416.db")
-                metric_test_file_2 = os.path.join(multi_proc_dir, "gauge_8742.db")
-                open(metric_test_file_1, "a", encoding="utf-8").close()
-                open(metric_test_file_2, "a", encoding="utf-8").close()
+                metric_file_5416 = multi_proc_dir / "gauge_5416.db"
+                metric_file_8742 = multi_proc_dir / "gauge_8742.db"
+                open(metric_file_5416, "a", encoding="utf-8").close()
+                open(metric_file_8742, "a", encoding="utf-8").close()
 
                 exporter.remove_metrics_from_process(pid=5416)
 
-            assert not os.path.isfile(metric_test_file_1)
-            assert os.path.isfile(metric_test_file_2)
+            assert not os.path.exists(metric_file_5416)
+            assert os.path.exists(metric_file_8742)
+            assert os.path.isfile(metric_file_8742)
             assert "Removed stale metric files: ['gauge_5416.db']" in caplog.text


### PR DESCRIPTION
To improve the visualizations in grafana a few changes have been
made. First and foremost stale metric database files will be removed
now when a pipeline fails. Furthermore, the metrics are prefixed
with 'logprep_' and the label is now called 'component'.
Additionally, the status logger is not stored in a list anymore
but in a namedtuple, which makes the unwrapping easier. Last but
not least a small fix in the documentation was done, variables
renamed and some linting issues fixed.