### PR TITLE
Add config error handling for pex and collection of exceptions

### DIFF
--- a/logprep/processor/processor_factory.py
+++ b/logprep/processor/processor_factory.py
@@ -89,13 +89,13 @@ class ProcessorFactory:
         if len(configuration) != 1:
             raise NotExactlyOneEntryInConfigurationError
 
-        _, config_section = ProcessorFactory._get_name_and_section(configuration)
+        name, config_section = ProcessorFactory._get_name_and_section(configuration)
 
         if not isinstance(config_section, dict):
             raise InvalidConfigSpecificationError
 
         if "type" not in config_section:
-            raise NoTypeSpecifiedError()
+            raise NoTypeSpecifiedError(processor_name=name)
 
     @staticmethod
     def _get_name_and_section(configuration: dict) -> Tuple[str, dict]:

--- a/logprep/processor/processor_factory_error.py
+++ b/logprep/processor/processor_factory_error.py
@@ -26,8 +26,11 @@ class InvalidConfigSpecificationError(InvalidConfigurationError):
 class NoTypeSpecifiedError(InvalidConfigurationError):
     """Raise if the processor type specification is missing."""
 
-    def __init__(self):
-        super().__init__("The processor type specification is missing")
+    def __init__(self, processor_name=None):
+        message = "The processor type specification is missing"
+        if processor_name:
+            message += f" for processor with name '{processor_name}'"
+        super().__init__(message)
 
 
 class UnknownProcessorTypeError(ProcessorFactoryError):

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -15,7 +15,7 @@ from logprep.processor.processor_factory import ProcessorFactory
 from logprep.runner import Runner
 from logprep.util.aggregating_logger import AggregatingLogger
 from logprep.util.auto_rule_tester import AutoRuleTester
-from logprep.util.configuration import Configuration
+from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.processor_stats import (
     StatsClassesController,
     StatusLoggerCollection,
@@ -138,7 +138,14 @@ def main():
     """Start the logprep runner."""
     args = _parse_arguments()
     config = Configuration().create_from_yaml(args.config)
-    config.verify(getLogger("Temporary Logger"))
+    temporary_logger = getLogger("Temporary Logger")
+    try:
+        config.verify(temporary_logger)
+    except InvalidConfigurationError:
+        sys.exit(1)
+    except BaseException as error:
+        temporary_logger.exception(error)
+        sys.exit(1)
 
     for plugin_dir in config.get("plugin_directories", []):
         sys.path.insert(0, plugin_dir)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -208,7 +208,7 @@ class Configuration(dict):
                         self._verify_status_logger_file_target(target["file"])
                     else:
                         raise InvalidStatusLoggerConfigurationError(
-                            f"Unknown target " f"'{current_target}'"
+                            f"Unknown target '{current_target}'"
                         )
                 except InvalidConfigurationError as error:
                     errors.append(error)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -96,7 +96,7 @@ class Configuration(dict):
             Configuration object based on dictionary.
 
         """
-        with open(path, "r") as file:
+        with open(path, "r", encoding="utf-8") as file:
             yaml_configuration = safe_load(file)
         config = Configuration()
         config.update(yaml_configuration)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -105,6 +105,15 @@ class Configuration(dict):
 
     def verify(self, logger: Logger):
         """Verify the configuration."""
+        errors = self._perform_verfification_and_get_errors(logger)
+        self._print_errors(errors)
+
+        for error in errors:
+            raise error
+
+    def _perform_verfification_and_get_errors(
+        self, logger: Logger
+    ) -> List[InvalidConfigurationError]:
         errors = []
         try:
             self._verify_required_keys_exist()
@@ -127,11 +136,7 @@ class Configuration(dict):
                 self._verify_status_logger()
             except InvalidConfigurationError as error:
                 errors.append(error)
-
-        self._print_errors(errors)
-
-        for error in errors:
-            raise error
+        return errors
 
     def _verify_required_keys_exist(self):
         required_keys = ["process_count", "timeout"]

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -1,7 +1,9 @@
 """This module is used to create the configuration for the runner."""
 
 from logging import Logger
+from typing import List
 
+from colorama import Fore
 from yaml import safe_load
 
 from logprep.connector.connector_factory import ConnectorFactory
@@ -11,6 +13,7 @@ from logprep.processor.processor_factory_error import (
     UnknownProcessorTypeError,
     InvalidConfigurationError as FactoryInvalidConfigurationError,
 )
+from logprep.util.helper import print_fcolor
 
 
 class InvalidConfigurationError(BaseException):
@@ -23,6 +26,14 @@ class InvalidConfigurationError(BaseException):
             super().__init__(f"Invalid Configuration: {message}")
         else:
             super().__init__("Invalid Configuration.")
+
+
+class InvalidConfigurationErrors(InvalidConfigurationError):
+    """Raise for multiple Configuration related exceptions."""
+
+    def __init__(self, errors: List[InvalidConfigurationError]):
+        self.errors = errors
+        super().__init__("\n".join([str(error) for error in self.errors]))
 
 
 class RequiredConfigurationKeyMissingError(InvalidConfigurationError):
@@ -94,28 +105,60 @@ class Configuration(dict):
 
     def verify(self, logger: Logger):
         """Verify the configuration."""
-        self._verify_required_keys_exist()
-        self._verify_values_make_sense()
-        self._verify_connector()
-        self._verify_pipeline(logger)
+        errors = []
+        try:
+            self._verify_required_keys_exist()
+        except InvalidConfigurationError as error:
+            errors.append(error)
+        try:
+            self._verify_values_make_sense()
+        except InvalidConfigurationError as error:
+            errors.append(error)
+        try:
+            self._verify_connector()
+        except InvalidConfigurationError as error:
+            errors.append(error)
+        try:
+            self._verify_pipeline(logger)
+        except InvalidConfigurationError as error:
+            errors.append(error)
         if self.get("status_logger", dict()):
-            self._verify_status_logger()
+            try:
+                self._verify_status_logger()
+            except InvalidConfigurationError as error:
+                errors.append(error)
+
+        self._print_errors(errors)
+
+        for error in errors:
+            raise error
 
     def _verify_required_keys_exist(self):
-        required_keys = ["process_count", "connector", "timeout", "pipeline"]
+        required_keys = ["process_count", "timeout"]
 
+        errors = []
         for key in required_keys:
             if key not in self:
-                raise RequiredConfigurationKeyMissingError(key)
+                errors.append(RequiredConfigurationKeyMissingError(key))
+        if errors:
+            raise InvalidConfigurationErrors(errors)
 
     def _verify_values_make_sense(self):
-        if self["process_count"] < 1:
-            raise InvalidConfigurationError(
-                message=f"Process count must be an integer of one or larger, not: "
-                f'{self["process_count"]}'
+        errors = []
+        if "process_count" in self and self["process_count"] < 1:
+            errors.append(
+                InvalidConfigurationError(
+                    message=f"Process count must be an integer of one or larger, not: "
+                    f'{self["process_count"]}'
+                )
             )
-        if not self["pipeline"]:
-            raise InvalidConfigurationError(message='"pipeline" must contain at least one item!')
+        if "pipeline" in self and not self["pipeline"]:
+            errors.append(
+                InvalidConfigurationError(message='"pipeline" must contain at least one item!')
+            )
+
+        if errors:
+            raise InvalidConfigurationErrors(errors)
 
     def _verify_connector(self):
         try:
@@ -127,41 +170,61 @@ class Configuration(dict):
 
     def _verify_pipeline(self, logger: Logger):
         try:
+            errors = []
             for processor_config in self["pipeline"]:
-                ProcessorFactory.create(processor_config, logger)
-        except (FactoryInvalidConfigurationError, UnknownProcessorTypeError) as error:
-            raise InvalidProcessorConfigurationError(str(error)) from error
+                try:
+                    ProcessorFactory.create(processor_config, logger)
+                except (FactoryInvalidConfigurationError, UnknownProcessorTypeError) as error:
+                    errors.append(InvalidProcessorConfigurationError(str(error)))
+            if errors:
+                raise InvalidConfigurationErrors(errors)
+        except KeyError as error:
+            raise RequiredConfigurationKeyMissingError("pipeline") from error
 
     def _verify_status_logger(self):
-        required_keys = ["enabled", "period", "cumulative", "aggregate_processes", "targets"]
+        if self.get("status_logger"):
+            errors = []
+            required_keys = ["enabled", "period", "cumulative", "aggregate_processes", "targets"]
 
-        for key in required_keys:
-            if key not in self["status_logger"]:
-                raise RequiredConfigurationKeyMissingError(f"status_logger > {key}")
+            for key in required_keys:
+                if key not in self["status_logger"]:
+                    errors.append(RequiredConfigurationKeyMissingError(f"status_logger > {key}"))
 
-        targets = self.get("status_logger").get("targets")
+            targets = self.get("status_logger").get("targets", [])
 
-        if not targets:
-            raise InvalidStatusLoggerConfigurationError("At least one target has to be configured")
-
-        for target in targets:
-            current_target = list(target.keys())[0]
-            if current_target == "prometheus":
-                self._verify_status_logger_prometheus_target(target["prometheus"])
-            elif current_target == "file":
-                self._verify_status_logger_file_target(target["file"])
-            else:
-                raise InvalidStatusLoggerConfigurationError(
-                    f"Unknown target " f"'{current_target}'"
+            if not targets:
+                errors.append(
+                    InvalidStatusLoggerConfigurationError(
+                        "At least one target has to be configured"
+                    )
                 )
 
-    def _verify_status_logger_prometheus_target(self, target_config):
+            for target in targets:
+                current_target = list(target.keys())[0]
+                try:
+                    if current_target == "prometheus":
+                        self._verify_status_logger_prometheus_target(target["prometheus"])
+                    elif current_target == "file":
+                        self._verify_status_logger_file_target(target["file"])
+                    else:
+                        raise InvalidStatusLoggerConfigurationError(
+                            f"Unknown target " f"'{current_target}'"
+                        )
+                except InvalidConfigurationError as error:
+                    errors.append(error)
+
+            if errors:
+                raise InvalidConfigurationErrors(errors)
+
+    @staticmethod
+    def _verify_status_logger_prometheus_target(target_config):
         if target_config is None or not target_config.get("port"):
             raise RequiredConfigurationKeyMissingError(
                 "status_logger > targets > " "prometheus > port"
             )
 
-    def _verify_status_logger_file_target(self, target_config):
+    @staticmethod
+    def _verify_status_logger_file_target(target_config):
         required_keys = {"path", "rollover_interval", "backup_count"}
         given_keys = set(target_config.keys())
         missing_keys = required_keys.difference(given_keys)
@@ -172,3 +235,8 @@ class Configuration(dict):
                 f"status_logger file target are missing: "
                 f"{missing_keys}"
             )
+
+    @staticmethod
+    def _print_errors(errors: List[BaseException]):
+        for error in errors:
+            print_fcolor(Fore.RED, str(error))

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -12,6 +12,7 @@ from logprep.util.configuration import (
     Configuration,
     InvalidStatusLoggerConfigurationError,
     RequiredConfigurationKeyMissingError,
+    InvalidConfigurationErrors,
 )
 
 logger = getLogger()
@@ -197,7 +198,11 @@ class TestConfiguration:
         status_logger_config = deepcopy(self.config)
         status_logger_config.update(status_logger_config_dict)
         if raised_error is not None:
-            with pytest.raises(raised_error):
+            try:
                 status_logger_config._verify_status_logger()
+            except InvalidConfigurationErrors as error:
+                assert any(
+                    (type(error) == raised_error for error in error.errors)
+                ), f"No '{raised_error.__name__}' raised for test case '{test_case}'!"
         else:
             status_logger_config._verify_status_logger()

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+# pylint: disable=max-line-length
 
 from copy import deepcopy
 from logging import getLogger
@@ -208,7 +209,6 @@ class TestConfiguration:
         else:
             status_logger_config._verify_status_logger()
 
-    # nosemgrep: string-concat-in-list
     @pytest.mark.parametrize(
         "test_case, config_dict, raised_errors",
         [
@@ -252,8 +252,7 @@ class TestConfiguration:
                 [
                     (
                         InvalidProcessorConfigurationError,
-                        "Invalid processor config: Item generic_rules is missing in 'labeler' "
-                        "configuration",
+                        "Invalid processor config: Item generic_rules is missing in 'labeler' configuration",
                     )
                 ],
             ),
@@ -286,8 +285,7 @@ class TestConfiguration:
                 [
                     (
                         InvalidConfigurationError,
-                        "Invalid Configuration: Process count must be an integer of one or larger, "
-                        "not: 0",
+                        "Invalid Configuration: Process count must be an integer of one or larger, not: 0",
                     ),
                 ],
             ),
@@ -306,7 +304,6 @@ class TestConfiguration:
         else:
             config._verify_status_logger()
 
-    # nosemgrep: string-concat-in-list
     @pytest.mark.parametrize(
         "test_case, config_dict, raised_errors",
         [
@@ -350,8 +347,7 @@ class TestConfiguration:
                 [
                     (
                         InvalidProcessorConfigurationError,
-                        "Invalid processor config: Item generic_rules is missing in 'labeler' "
-                        "configuration",
+                        "Invalid processor config: Item generic_rules is missing in 'labeler' configuration",
                     )
                 ],
             ),
@@ -384,13 +380,11 @@ class TestConfiguration:
                 [
                     (
                         InvalidConfigurationError,
-                        "Invalid Configuration: Process count must be an integer of one or larger, "
-                        "not: 0",
+                        "Invalid Configuration: Process count must be an integer of one or larger, not: 0",
                     ),
                     (
                         InvalidProcessorConfigurationError,
-                        "Invalid processor config: The processor type specification is missing for "
-                        "processor with name 'some_processor_name'",
+                        "Invalid processor config: The processor type specification is missing for processor with name 'some_processor_name'",
                     ),
                 ],
             ),

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -208,6 +208,7 @@ class TestConfiguration:
         else:
             status_logger_config._verify_status_logger()
 
+    # nosemgrep: string-concat-in-list
     @pytest.mark.parametrize(
         "test_case, config_dict, raised_errors",
         [
@@ -305,6 +306,7 @@ class TestConfiguration:
         else:
             config._verify_status_logger()
 
+    # nosemgrep: string-concat-in-list
     @pytest.mark.parametrize(
         "test_case, config_dict, raised_errors",
         [


### PR DESCRIPTION
For issues #96 and #97. Makes logprep print out feedback on configuration errors even if it is executed via pex. Collects multiple errors before printing them.