### PR TITLE
Add debug statement for github action

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -9,16 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish release to PyPi
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
-        with:
-          semver_only: true
+      - name: debug github.ref
+        run: |
+          echo The github ref is: "${{ github.ref }}"
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ steps.get-latest-tag.outputs.tag }}
+          ref: ${{ github.ref }}
 
       - name: Initialize Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
According to the [github action release ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) documentation the github ref already has the tag of the release. Adjusted the pipeline such that the github ref is used directly. Includes also a debug statement just in case, if successful then I will remove the statement in an additional pull-request. 