### PR TITLE
Change release destination to official pypi server

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -32,5 +32,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ To install Logprep you have three options:
 
 This option is recommended if you just want to use the latest release of logprep.
 ```
-pip install -i https://test.pypi.org/simple/ logprep
+pip install logprep
 ```
 
 **2. Option:** Installation via Git Repository:
@@ -324,13 +324,14 @@ PYTHONPATH="." python3 logprep/run_logprep.py $CONFIG
 
 Where `$CONFIG` is the path to a configuration file (see the documentation about the 
 [configuration](https://logprep.readthedocs.io/en/latest/user_manual/configuration/index.html)).
+The next sections all assume an installation via pip
 
 ### Verifying Configuration
 
 The following command can be executed to verify the configuration file without having to run Logprep:
 
 ```
-PYTHONPATH="." python3 logprep/run_logprep.py --verify-config $CONFIG
+logprep --verify-config $CONFIG
 ```
 
 Where `$CONFIG` is the path to a configuration file (see the documentation about the 
@@ -341,13 +342,14 @@ Where `$CONFIG` is the path to a configuration file (see the documentation about
 The following command can be executed to validate the schema and the rules:
 
 ```
-PYTHONPATH="." python3 logprep/run_logprep.py --validate-rules $CONFIG
+logprep --validate-rules $CONFIG
 ```
 
 Where `$CONFIG` is the path to a configuration file (see the documentation about the 
 [configuration](https://logprep.readthedocs.io/en/latest/user_manual/configuration/index.html)).
 
-Alternatively, the validation can be performed directly:
+Alternatively, the validation can be performed directly. Assuming you have cloned the repository 
+from git. 
 
 ```
 PYTHONPATH="." python3 logprep/util/schema_and_rule_checker.py --labeling-schema $LABELING_SCHEMA --labeling-rules $LABELING_RULES

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -11,7 +11,7 @@ This option is recommended if you just want to use the latest release of logprep
 
 ..  code-block:: bash
 
-    pip install -i https://test.pypi.org/simple/ logprep
+    pip install logprep
 
 **2. Option:** Installation via Git Repository:
 


### PR DESCRIPTION
With these changes applied logprep will be automatically 
distributed to the official pypi servers. The documentation
changes consider the new install and run procedures.