### PR TITLE
Fix crash from not initialized class variable in sql adder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Fix processor initialization in auto rule tester
 * Fix generation of RST-Docs
+* Fix crashes of the generic adder if sql-based rules are processed without having set the sql config 
 
 ### Breaking 
 

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -108,9 +108,9 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    __slots__ = ["_db_connector"]
+    __slots__ = ["_db_connector", "_db_table"]
 
-    _db_table: dict = None
+    _db_table: dict
     """Dict containing table from SQL database"""
 
     _db_connector: MySQLConnector
@@ -133,10 +133,7 @@ class GenericAdder(Processor):
 
         sql_config = configuration.sql_config
         self._db_connector = MySQLConnector(sql_config, logger) if sql_config else None
-
-        if GenericAdder._db_table is None:
-            GenericAdder._db_table = self._db_connector.get_data() if self._db_connector else None
-        self._db_table = GenericAdder._db_table
+        self._db_table = self._db_connector.get_data() if self._db_connector else None
 
     def _apply_rules(self, event: dict, rule: GenericAdderRule):
         """Apply a matching generic adder rule to the event.

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -108,9 +108,9 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    __slots__ = ["_db_connector", "_db_table"]
+    __slots__ = ["_db_connector"]
 
-    _db_table: dict
+    _db_table: dict = None
     """Dict containing table from SQL database"""
 
     _db_connector: MySQLConnector

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -76,6 +76,9 @@ class TestGenericAdder(BaseProcessorTestCase):
     def specific_rules_dirs(self):
         return self.CONFIG.get("specific_rules")
 
+    def test_db_table_is_none(self):
+        assert self.object._db_table is None
+
     def test_add_generic_fields(self):
         assert self.object.metrics.number_of_processed_events == 0
         expected = {
@@ -468,6 +471,9 @@ class TestGenericAdderProcessorSQLWithAddedTarget(BaseProcessorTestCase):
     @property
     def specific_rules_dirs(self):
         return self.CONFIG.get("specific_rules")
+
+    def test_db_table_is_not_none(self):
+        assert self.object._db_table is not None
 
     def test_sql_database_adds_target_field(self):
         expected = {


### PR DESCRIPTION
Not initializing "_db_table" in the processor of the generic adder has led to some unexpected crashes if the SQL adder was disabled, but rules that utilize SQL where processed.

It was changed so that it's initialized with "None" again and it was changed to be an instance variable.
Furthermore, some unit tests that prevent this issue from happening again where added.

See #138.