### PR TITLE
Fix metric tracking performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Next Release
 
 ### Features
+
+* Add metric for mean processing time per event for the full pipeline, in addition to per processor
+
 ### Improvements
 ### Bugfixes
+
+* Fix performance of the metrics tracking. Due to a store metrics statement at the wrong position
+the logprep performance was dramatically decreased when tracking metrics was activated.
+
 ### Breaking
 
 ## v3.0.0

--- a/logprep/metrics/metric_exposer.py
+++ b/logprep/metrics/metric_exposer.py
@@ -36,9 +36,9 @@ class MetricExposer:
         if not self.output_targets:
             return
 
-        self._store_metrics(metrics)
         if self._time_to_expose():
             if self._aggregate_processes:
+                self._store_metrics(metrics)
                 self._expose_aggregated_metrics_from_shared_dict()
             else:
                 self._send_to_output(metrics.expose())

--- a/logprep/metrics/metric_targets.py
+++ b/logprep/metrics/metric_targets.py
@@ -28,6 +28,7 @@ def get_metric_targets(config: dict, logger: Logger) -> MetricTargets:
     metric_configs = config.get("metrics", {})
 
     if not metric_configs.get("enabled", False):
+        logger.info("Metric tracking is disabled via config")
         return MetricTargets(None, None)
 
     target_configs = metric_configs.get("targets", [])

--- a/tests/unit/metrics/test_metric_exposer.py
+++ b/tests/unit/metrics/test_metric_exposer.py
@@ -130,9 +130,7 @@ class TestMetricExposer:
         expose_aggregate_mock.assert_called()
 
     @mock.patch("logprep.metrics.metric_exposer.MetricExposer._send_to_output")
-    def test_expose_calls_send_to_output_if_no_aggregation_is_configured(
-        self, send_to_output_mock
-    ):
+    def test_expose_calls_send_to_output_if_no_aggregation_is_configured(self, send_to_output_mock):
         config = self.config.copy()
         config["aggregate_processes"] = False
         self.exposer = MetricExposer(config, self.metric_targets, self.shared_dict, Lock())

--- a/tests/unit/metrics/test_metric_exposer.py
+++ b/tests/unit/metrics/test_metric_exposer.py
@@ -129,10 +129,9 @@ class TestMetricExposer:
         store_metrics_mock.assert_called()
         expose_aggregate_mock.assert_called()
 
-    @mock.patch("logprep.metrics.metric_exposer.MetricExposer._store_metrics")
     @mock.patch("logprep.metrics.metric_exposer.MetricExposer._send_to_output")
     def test_expose_calls_send_to_output_if_no_aggregation_is_configured(
-        self, store_metrics_mock, send_to_output_mock
+        self, send_to_output_mock
     ):
         config = self.config.copy()
         config["aggregate_processes"] = False
@@ -140,7 +139,6 @@ class TestMetricExposer:
         self.exposer._timer = Value(c_double, time() - self.config["period"])
         mock_metrics = mock.MagicMock()
         self.exposer.expose(mock_metrics)
-        store_metrics_mock.assert_called()
         send_to_output_mock.assert_called()
         mock_metrics.expose.assert_called()
 

--- a/tests/unit/metrics/test_metric_targets.py
+++ b/tests/unit/metrics/test_metric_targets.py
@@ -232,7 +232,7 @@ class TestMetricFileTarget:
                         },
                     },
                     "logprep_pipeline_kafka_offset": 0.0,
-                    'logprep_pipeline_mean_processing_time_per_event': 0.0,
+                    "logprep_pipeline_mean_processing_time_per_event": 0.0,
                     "logprep_pipeline_number_of_processed_events": 0.0,
                     "logprep_pipeline_number_of_warnings": 0.0,
                     "logprep_pipeline_number_of_errors": 0.0,

--- a/tests/unit/metrics/test_metric_targets.py
+++ b/tests/unit/metrics/test_metric_targets.py
@@ -232,6 +232,7 @@ class TestMetricFileTarget:
                         },
                     },
                     "logprep_pipeline_kafka_offset": 0.0,
+                    'logprep_pipeline_mean_processing_time_per_event': 0.0,
                     "logprep_pipeline_number_of_processed_events": 0.0,
                     "logprep_pipeline_number_of_warnings": 0.0,
                     "logprep_pipeline_number_of_errors": 0.0,


### PR DESCRIPTION
The call to store metrics was executed for every processed event.
It is only needed to be executed when the time to expose the metrics
has passed and only if the processes should be aggregated. If metrics
can be exposed independently then the shared dict is not used.