### PR TITLE
Add logprep and configuration version to event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tests/testdata/external/
 *.lock
 coverage.xml
 -
+logs
+sql_db_table.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
+## Upcoming Changes
+
+### Breaking 
+
+* Removal of Deprecated Feature: HMAC-Options in the connector consumer options have to be 
+under the subkey `preprocessing`
+
+
 ## Next Release
 
 ### Features
 
 * Add metric for mean processing time per event for the full pipeline, in addition to per processor
 * Add feature to automatically add version information to all events, configured via the 
-`connector > consumer` configuration
+`connector > consumer > preprocessing` configuration
 
 ### Improvements
+
+* Move the config hmac options to the new subkey `preprocessing`, maintain backward compatibility, 
+but mark old version as deprecated.
+
 ### Bugfixes
 
 * Fix performance of the metrics tracking. Due to a store metrics statement at the wrong position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 
 * Add metric for mean processing time per event for the full pipeline, in addition to per processor
+* Add feature to automatically add version information to all events, configured via the 
+`connector > consumer` configuration
 
 ### Improvements
 ### Bugfixes

--- a/doc/source/user_manual/configuration/connector.rst
+++ b/doc/source/user_manual/configuration/connector.rst
@@ -61,6 +61,29 @@ hmac configuration is given at the end of this page.
 The hmac itself will be calculated with python's :code:`hashlib.sha256` algorithm and the compression is based on the
 :code:`zlib` library.
 
+Furthermore it is possible to automatically add the logprep version and the used configuration
+version to every processed event.
+This helps to keep track of the processing of the events when the configuration is changing often.
+To enable adding the versions to each event the keyword :code:`version_info_target_field` has to be
+set under the field :code:`preprocessing`.
+The example at the bottom of this page includes this configuration.
+If the field :code:`preprocessing` and :code:`version_info_target_field` is not present then no
+version information is added to the event.
+The following json shows a snippet of an event with the added version information.
+
+..  code-block:: json
+    :linenos:
+    :caption: Example event with version information
+
+    {
+        "Any": "regular event information",
+        "version_info": {
+            "logprep": "3.0.0",
+            "configuration": "1"
+        },
+        ...
+    }
+
 
 producer
 --------
@@ -91,7 +114,7 @@ Example
 
 ..  code-block:: yaml
     :linenos:
-    :caption: Logprep configuration (with optional hmac settings)
+    :caption: Logprep configuration (with optional settings)
 
     connector:
       type: confluentkafka
@@ -103,6 +126,8 @@ Example
         auto_commit: on
         session_timeout: 6000
         offset_reset_policy: smallest
+        preprocessing:
+          version_info_target_field: version_info
         hmac:
           target: <RAW_MSG>
           key: secret-key

--- a/doc/source/user_manual/configuration/connector.rst
+++ b/doc/source/user_manual/configuration/connector.rst
@@ -141,7 +141,7 @@ Example
         session_timeout: 6000
         offset_reset_policy: smallest
         preprocessing:
-          version_info_target_field: version_info
+          version_info_target_field: Version_info
           hmac:
             target: <RAW_MSG>
             key: secret-key

--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -142,7 +142,10 @@ class ConfluentKafka(Input, Output):
                 "session_timeout": 6000,
                 "offset_reset_policy": "smallest",
                 "enable_auto_offset_store": enable_auto_offset_store,
-                "preprocessing": {"version_info_target_field": ""},
+                "preprocessing": {
+                    "version_info_target_field": None,
+                    "hmac": {"target": "", "key": "", "output_field": ""},
+                },
                 "hmac": {"target": "", "key": "", "output_field": ""},
             },
             "producer": {
@@ -213,41 +216,52 @@ class ConfluentKafka(Input, Output):
 
         """
 
-        valid_hmac_options = set(self._config.get("consumer", {}).get("hmac", {}).keys())
-
-        for key in new_options:
-            if key not in self._config:
-                raise UnknownOptionError(f"Unknown Option: {key}")
-            if isinstance(new_options[key], dict):
-                for subkey in new_options[key]:
-                    if subkey not in self._config[key]:
-                        raise UnknownOptionError(f"Unknown Option: {key}/{subkey}")
-                    self._config[key][subkey] = new_options[key][subkey]
-
-        # validate hmac subfields
         if new_options.get("consumer", {}).get("hmac", None) is not None:
-            new_hmac_options_keys = set(new_options.get("consumer", {}).get("hmac").keys())
-            unknown_options = new_hmac_options_keys.difference(valid_hmac_options)
-            if unknown_options:
-                raise UnknownOptionError(f"Unknown Hmac Options: {unknown_options}")
+            if "preprocessing" not in new_options["consumer"]:
+                new_options["consumer"]["preprocessing"] = {}
+            new_options["consumer"]["preprocessing"]["hmac"] = new_options["consumer"]["hmac"]
 
-            missing_options = valid_hmac_options.difference(new_hmac_options_keys)
-            if missing_options:
-                raise InvalidConfigurationError(f"Hmac option(s) missing: {missing_options}")
+        self._config = self.update_default_configuration(self._config.copy(), new_options)
 
-            for key in valid_hmac_options:
-                config_value = self._config["consumer"]["hmac"][key]
-                if not isinstance(config_value, str):
-                    raise InvalidConfigurationError(
-                        f"Hmac option '{key}' has wrong type: '{type(config_value)}', "
-                        f"expected 'str'"
-                    )
-                if len(config_value) == 0:
-                    raise InvalidConfigurationError(
-                        f"Hmac option '{key}' is empty: '{config_value}'"
-                    )
-
+        hmac_options = new_options.get("consumer", {}).get("preprocessing", {}).get("hmac", {})
+        if hmac_options:
+            self._validate_hmac_options(hmac_options)
             self._add_hmac = True
+
+    def update_default_configuration(self, default_options, user_options):
+        """Iterate recursively over the default options and set the values from the user options"""
+        if not isinstance(default_options, dict):
+            return user_options
+        for key in user_options.keys():
+            if key not in default_options:
+                raise UnknownOptionError(f"Unknown Option: {key}")
+            default_options[key] = self.update_default_configuration(
+                default_options[key], user_options[key]
+            )
+        return default_options
+
+    def _validate_hmac_options(self, hmac_options):
+        valid_hmac_options = set(
+            self._config.get("consumer", {}).get("preprocessing", {}).get("hmac", {}).keys()
+        )
+
+        new_hmac_options_keys = set(hmac_options)
+        unknown_options = new_hmac_options_keys.difference(valid_hmac_options)
+        if unknown_options:
+            raise UnknownOptionError(f"Unknown Hmac Options: {unknown_options}")
+        missing_options = valid_hmac_options.difference(new_hmac_options_keys)
+        if missing_options:
+            raise InvalidConfigurationError(f"Hmac option(s) missing: {missing_options}")
+
+        for key in valid_hmac_options:
+            config_value = self._config["consumer"]["preprocessing"]["hmac"][key]
+            if not isinstance(config_value, str):
+                raise InvalidConfigurationError(
+                    f"Hmac option '{key}' has wrong type: '{type(config_value)}', "
+                    f"expected 'str'"
+                )
+            if len(config_value) == 0:
+                raise InvalidConfigurationError(f"Hmac option '{key}' is empty: '{config_value}'")
 
     def get_next(self, timeout: float) -> Optional[dict]:
         """Get next document from Kafka.
@@ -287,7 +301,7 @@ class ConfluentKafka(Input, Output):
             event_dict = json.loads(raw_event.decode("utf-8"))
 
             if self._add_hmac:
-                hmac_target_field_name = self._config["consumer"]["hmac"]["target"]
+                hmac_target_field_name = self._config["consumer"]["preprocessing"]["hmac"]["target"]
                 event_dict = self._add_hmac_to(event_dict, hmac_target_field_name, raw_event)
 
             if isinstance(event_dict, dict):
@@ -340,7 +354,7 @@ class ConfluentKafka(Input, Output):
         if hmac_target_field_name == "<RAW_MSG>":
             received_orig_message = raw_event
             hmac = HMAC(
-                key=self._config["consumer"]["hmac"]["key"].encode(),
+                key=self._config["consumer"]["preprocessing"]["hmac"]["key"].encode(),
                 msg=raw_event,
                 digestmod=hashlib.sha256,
             ).hexdigest()
@@ -350,7 +364,7 @@ class ConfluentKafka(Input, Output):
             if received_orig_message is not None:
                 received_orig_message = received_orig_message.encode()
                 hmac = HMAC(
-                    key=self._config["consumer"]["hmac"]["key"].encode(),
+                    key=self._config["consumer"]["preprocessing"]["hmac"]["key"].encode(),
                     msg=received_orig_message,
                     digestmod=hashlib.sha256,
                 ).hexdigest()
@@ -372,12 +386,15 @@ class ConfluentKafka(Input, Output):
 
         # add hmac result to the original event
         add_was_successful = add_field_to(
-            event_dict, self._config["consumer"]["hmac"]["output_field"], hmac_output
+            event_dict,
+            self._config["consumer"]["preprocessing"]["hmac"]["output_field"],
+            hmac_output,
         )
         if not add_was_successful:
+            output_field = self._config["consumer"]["preprocessing"]["hmac"]["output_field"]
             self.store_failed(
                 f"Couldn't add the hmac to the input event as the desired output "
-                f"field '{self._config['consumer']['hmac']['output_field']}' already exist.",
+                f"field '{output_field}' already exist.",
                 event_dict,
                 event_dict,
             )

--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -215,7 +215,8 @@ class ConfluentKafka(Input, Output):
             Raises if an option is invalid.
 
         """
-
+        # DEPRECATION: HMAC-Option: Remove this if with next major version update, check also the
+        # self._config dict in this class's init method
         if new_options.get("consumer", {}).get("hmac", None) is not None:
             if "preprocessing" not in new_options["consumer"]:
                 new_options["consumer"]["preprocessing"] = {}

--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -1,5 +1,6 @@
 """This module contains functionality that allows to establish a connection with kafka."""
 import hashlib
+import json
 from base64 import b64encode
 from copy import deepcopy
 from datetime import datetime
@@ -8,7 +9,6 @@ from socket import getfqdn
 from typing import List, Optional
 from zlib import compress
 
-import json
 from confluent_kafka import Consumer, Producer
 
 from logprep.connector.connector_factory_error import InvalidConfigurationError
@@ -142,6 +142,7 @@ class ConfluentKafka(Input, Output):
                 "session_timeout": 6000,
                 "offset_reset_policy": "smallest",
                 "enable_auto_offset_store": enable_auto_offset_store,
+                "preprocessing": {"version_info_target_field": ""},
                 "hmac": {"target": "", "key": "", "output_field": ""},
             },
             "producer": {

--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -247,11 +247,7 @@ class ConfluentKafka(Input, Output):
             self._config.get("consumer", {}).get("preprocessing", {}).get("hmac", {}).keys()
         )
 
-        new_hmac_options_keys = set(hmac_options)
-        unknown_options = new_hmac_options_keys.difference(valid_hmac_options_keys)
-        if unknown_options:
-            raise UnknownOptionError(f"Unknown Hmac Options: {unknown_options}")
-        missing_options = valid_hmac_options_keys.difference(new_hmac_options_keys)
+        missing_options = valid_hmac_options_keys.difference(hmac_options)
         if missing_options:
             raise InvalidConfigurationError(f"Hmac option(s) missing: {missing_options}")
 

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -101,7 +101,7 @@ class Pipeline:
     def __init__(
         self,
         pipeline_index: int,
-        logprep_config: dict,
+        config: dict,
         counter: "SharedCounter",
         log_handler: Handler,
         lock: Lock,
@@ -110,11 +110,7 @@ class Pipeline:
     ):
         if not isinstance(log_handler, Handler):
             raise MustProvideALogHandlerError
-        self._logprep_config = logprep_config
-        self._connector_config = self._logprep_config.get("connector")
-        self._pipeline_config = self._logprep_config.get("pipeline")
-        self._timeout = self._logprep_config.get("timeout")
-        self._metrics_config = self._logprep_config.get("metrics", {})
+        self._config = config
         self._log_handler = log_handler
         self._logger = None
 
@@ -126,14 +122,14 @@ class Pipeline:
         self._processing_counter = counter
 
         self._metrics_exposer = MetricExposer(
-            self._metrics_config, metric_targets, shared_dict, lock
+            self._config.get("metrics", {}), metric_targets, shared_dict, lock
         )
         self._metric_labels = {"pipeline": f"pipeline-{pipeline_index}"}
         self.metrics = self.PipelineMetrics(labels=self._metric_labels)
 
         self._event_version_information = {
-            "logprep": get_versions()["version"],
-            "configuration": self._logprep_config.get("version", "unset"),
+            "logprep": get_versions().get("version"),
+            "configuration": self._config.get("version", "unset"),
         }
 
     def _setup(self):
@@ -145,7 +141,7 @@ class Pipeline:
         if self._logger.isEnabledFor(DEBUG):
             self._logger.debug(f"Building '{current_process().name}'")
         self._pipeline = []
-        for entry in self._pipeline_config:
+        for entry in self._config.get("pipeline"):
             processor_name = list(entry.keys())[0]
             entry[processor_name]["metric_labels"] = self._metric_labels
             processor = ProcessorFactory.create(entry, self._logger)
@@ -160,7 +156,7 @@ class Pipeline:
     def _create_connectors(self):
         if self._logger.isEnabledFor(DEBUG):
             self._logger.debug(f"Creating connectors ({current_process().name})")
-        self._input, self._output = ConnectorFactory.create(self._connector_config)
+        self._input, self._output = ConnectorFactory.create(self._config.get("connector"))
         if self._logger.isEnabledFor(DEBUG):
             self._logger.debug(
                 f"Created input connector '{self._input.describe_endpoint()}' "
@@ -217,7 +213,7 @@ class Pipeline:
         event = {}
         try:
             self._metrics_exposer.expose(self.metrics)
-            event = self._input.get_next(self._timeout)
+            event = self._input.get_next(self._config.get("timeout"))
 
             try:
                 self.metrics.kafka_offset = self._input.current_offset
@@ -258,7 +254,7 @@ class Pipeline:
                 self._output.store_failed(msg, error.raw_input, {})
 
     def _preprocess_event(self, event):
-        consumer_config = self._connector_config.get("consumer", {})
+        consumer_config = self._config.get("connector").get("consumer", {})
         preprocessing_config = consumer_config.get("preprocessing", {})
         if preprocessing_config.get("version_info_target_field"):
             self._add_version_information_to_event(event, preprocessing_config)
@@ -404,7 +400,7 @@ class MultiprocessingPipeline(Process, Pipeline):
     def __init__(
         self,
         pipeline_index: int,
-        logprep_config: dict,
+        config: dict,
         log_handler: Handler,
         lock: Lock,
         shared_dict: dict,
@@ -413,14 +409,14 @@ class MultiprocessingPipeline(Process, Pipeline):
         if not isinstance(log_handler, MultiprocessingLogHandler):
             raise MustProvideAnMPLogHandlerError
 
-        self._profile = logprep_config.get("profile_pipelines", False)
-        print_processed_period = logprep_config.get("print_processed_period", 300)
+        self._profile = config.get("profile_pipelines", False)
+        print_processed_period = config.get("print_processed_period", 300)
         self.processed_counter.setup(print_processed_period, log_handler)
 
         Pipeline.__init__(
             self,
             pipeline_index=pipeline_index,
-            logprep_config=logprep_config,
+            config=config,
             counter=self.processed_counter,
             log_handler=log_handler,
             lock=lock,

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -132,15 +132,10 @@ class PipelineManager:
 
         self._logger.info("Created new pipeline")
         return MultiprocessingPipeline(
-            index,
-            self._configuration["connector"],
-            self._configuration["pipeline"],
-            self._configuration.get("metrics", {}),
-            self._configuration["timeout"],
-            self._log_handler,
-            self._configuration.get("print_processed_period", 300),
-            self._lock,
-            self._shared_dict,
-            profile=self._configuration.get("profile_pipelines", False),
+            pipeline_index=index,
+            logprep_config=self._configuration,
+            log_handler=self._log_handler,
+            lock=self._lock,
+            shared_dict=self._shared_dict,
             metric_targets=self.metric_targets,
         )

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -133,7 +133,7 @@ class PipelineManager:
         self._logger.info("Created new pipeline")
         return MultiprocessingPipeline(
             pipeline_index=index,
-            logprep_config=self._configuration,
+            config=self._configuration,
             log_handler=self._log_handler,
             lock=self._lock,
             shared_dict=self._shared_dict,

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -139,7 +139,7 @@ class Configuration(dict):
         except InvalidConfigurationError as error:
             errors.append(error)
         try:
-            self._verify_connector()
+            self._verify_connector(logger)
         except InvalidConfigurationError as error:
             errors.append(error)
         try:
@@ -180,7 +180,14 @@ class Configuration(dict):
         if errors:
             raise InvalidConfigurationErrors(errors)
 
-    def _verify_connector(self):
+    def _verify_connector(self, logger):
+        if self.get("connector", {}).get("consumer", {}).get("hmac", {}):
+            logger.warning(
+                "Deprecated configuration format: The hmac options have to be under the key "
+                "'preprocessing'. The hmac options under the key 'consumer' will be removed "
+                "in a future release; version=4.0.0"
+            )
+
         try:
             _, _ = ConnectorFactory.create(self["connector"])
         except ConnectorFactoryError as error:

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -181,11 +181,13 @@ class Configuration(dict):
             raise InvalidConfigurationErrors(errors)
 
     def _verify_connector(self, logger):
+        # DEPRECATION: HMAC-Option: Remove this if with next major version update
         if self.get("connector", {}).get("consumer", {}).get("hmac", {}):
             logger.warning(
-                "Deprecated configuration format: The hmac options have to be under the key "
-                "'preprocessing'. The hmac options under the key 'consumer' will be removed "
-                "in a future release; version=4.0.0"
+                "[Deprecation]: you are currently using a configuration format that will be "
+                "outdated in the next major release (version 4.0.0). The hmac options will move "
+                "from the keyword 'consumer' to the subkey 'preprocessing', consider changing to "
+                "the new config format. [Expires with logprep=4.0.0]"
             )
 
         try:

--- a/tests/acceptance/test_full_message_pass_with_hmac.py
+++ b/tests/acceptance/test_full_message_pass_with_hmac.py
@@ -1,13 +1,13 @@
 # pylint: disable=missing-docstring
 # pylint: disable=wrong-import-order
 # pylint: disable=no-self-use
+import json
 from unittest.mock import patch
 
 import pytest
-import json
 
-from tests.acceptance.util import mock_kafka_and_run_pipeline, get_default_logprep_config
 from logprep.util.json_handling import dump_config_as_file
+from tests.acceptance.util import mock_kafka_and_run_pipeline, get_default_logprep_config
 
 
 @pytest.fixture(name="config")
@@ -28,6 +28,40 @@ def fixture_config():
 
 class TestFullHMACPassTest:
     def test_full_message_pass_with_hmac(self, tmp_path, config):
+        config_path = str(tmp_path / "generated_config.yml")
+        dump_config_as_file(config_path, config)
+
+        with patch(
+            "logprep.connector.connector_factory.ConnectorFactory.create"
+        ) as mock_connector_factory:
+            input_test_event = {"test": "message"}
+            expected_output_event = {
+                "test": "message",
+                "hmac": {
+                    "hmac": "5a77054b5f1d9ea60000520a4e2cf661e7a11de4205ca70c6977fc8040076a6e",
+                    "compressed_base64": "eJyrVipJLS5RslLKTS0uTkxPVaoFADwCBmA=",
+                },
+            }
+
+            kafka_output_file = mock_kafka_and_run_pipeline(
+                config, input_test_event, mock_connector_factory, tmp_path
+            )
+
+            # read logprep kafka output from mocked kafka file producer
+            with open(kafka_output_file, "r", encoding="utf-8") as output_file:
+                outputs = output_file.readlines()
+                assert len(outputs) == 1, "Expected only one default kafka output"
+
+                target, event = outputs[0].split(" ", maxsplit=1)
+                event = json.loads(event)
+                assert target == "test_input_processed"
+                assert event == expected_output_event
+
+    def test_full_message_pass_with_new_hmac_config_position(self, tmp_path, config):
+        config["connector"]["consumer"]["preprocessing"] = {
+            "hmac": config["connector"]["consumer"]["hmac"]
+        }
+        del config["connector"]["consumer"]["hmac"]
         config_path = str(tmp_path / "generated_config.yml")
         dump_config_as_file(config_path, config)
 

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -98,17 +98,13 @@ def mock_kafka_and_run_pipeline(config, input_test_event, mock_connector_factory
     mock_connector_factory.return_value = (kafka, kafka)
 
     # Create, setup and execute logprep pipeline
-    pipeline_index = 1
     pipeline = Pipeline(
-        pipeline_index,
-        config["connector"],
-        config["pipeline"],
-        {},
-        config["timeout"],
-        SharedCounter(),
-        Handler(),
-        Lock(),
-        {},
+        pipeline_index=1,
+        logprep_config=config,
+        counter=SharedCounter(),
+        log_handler=Handler(),
+        lock=Lock(),
+        shared_dict={},
     )
     pipeline._setup()
     pipeline._retrieve_and_process_data()

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -62,10 +62,6 @@ def get_test_output(config_path):
     return parsed_test_output
 
 
-def assert_result_equal_expected(config, expected_output, tmp_path):
-    ...
-
-
 class SingleMessageConsumerJsonMock:
     def __init__(self, record):
         self.record = json.dumps(record, separators=(",", ":"))
@@ -100,7 +96,7 @@ def mock_kafka_and_run_pipeline(config, input_test_event, mock_connector_factory
     # Create, setup and execute logprep pipeline
     pipeline = Pipeline(
         pipeline_index=1,
-        logprep_config=config,
+        config=config,
         counter=SharedCounter(),
         log_handler=Handler(),
         lock=Lock(),

--- a/tests/unit/connector/test_confluent_kafka.py
+++ b/tests/unit/connector/test_confluent_kafka.py
@@ -1,6 +1,7 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
 # pylint: disable=no-self-use
+import json
 from base64 import b64decode
 from copy import deepcopy
 from datetime import datetime
@@ -9,7 +10,6 @@ from math import isclose
 from socket import getfqdn
 from zlib import decompress
 
-import json
 from pytest import fail, raises
 
 from logprep.connector.confluent_kafka import (
@@ -659,9 +659,7 @@ class TestConfluentKafka:
 
         # add additional unknown option and test for error message
         config["consumer"]["hmac"] = {"unknown": "option"}
-        with raises(
-            InvalidConfigurationError, match=r"Confluent Kafka: Unknown Hmac Options: {'unknown'}"
-        ):
+        with raises(InvalidConfigurationError, match=r"Confluent Kafka: Unknown Option: unknown"):
             _ = ConfluentKafkaFactory.create_from_configuration(config)
 
     def test_get_next_with_broken_hmac_config(self):

--- a/tests/unit/connector/test_confluent_kafka.py
+++ b/tests/unit/connector/test_confluent_kafka.py
@@ -747,20 +747,6 @@ class TestConfluentKafka:
         new_config = kafka.update_default_configuration(default_config, user_config)
         assert new_config == default_config
 
-    def test_update_default_configuration_raises_error_on_overwriting_all_subfields(self):
-        default_config = {
-            "option": {"with": {"multiple": "layers", "foo": "bar"}},
-            "another": "option",
-        }
-        user_config = {"option": "dsfv"}
-        config = deepcopy(TestConfluentKafkaFactory.valid_configuration)
-        kafka = ConfluentKafkaFactory.create_from_configuration(config)
-        with raises(
-            UnknownOptionError,
-            match="Wrong Option type for 'dsfv'. Got <class 'str'>, expected <class 'dict'>.",
-        ):
-            _ = kafka.update_default_configuration(default_config, user_config)
-
     def test_update_default_configuration_raises_error_on_wrong_type(self):
         default_config = {
             "option": 12.2,

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -67,7 +67,7 @@ class TestPipeline(ConfigurationForTests):
 
         self.pipeline = Pipeline(
             pipeline_index=1,
-            logprep_config=self.logprep_config,
+            config=self.logprep_config,
             counter=self.counter,
             log_handler=self.log_handler,
             lock=self.lock,
@@ -80,7 +80,7 @@ class TestPipeline(ConfigurationForTests):
             with raises(MustProvideALogHandlerError):
                 _ = Pipeline(
                     pipeline_index=1,
-                    logprep_config=self.logprep_config,
+                    config=self.logprep_config,
                     counter=self.counter,
                     log_handler=not_a_log_handler,
                     lock=self.lock,
@@ -134,7 +134,7 @@ class TestPipeline(ConfigurationForTests):
         assert len(self.pipeline._pipeline) == 0
         input_data = [{"do_not_delete": "1"}, {"delete_me": "2"}, {"do_not_delete": "3"}]
         connector_config = {"type": "dummy", "input": input_data}
-        self.pipeline._connector_config = connector_config
+        self.pipeline._config["connector"] = connector_config
         self.pipeline._setup()
         delete_config = {
             "type": "delete",
@@ -194,7 +194,7 @@ class TestPipeline(ConfigurationForTests):
         input_data = [{"test": "1"}, {"test": "2"}, {"test": "3"}]
         expected_output_data = deepcopy(input_data)
         connector_config = {"type": "dummy", "input": input_data}
-        self.pipeline._connector_config = connector_config
+        self.pipeline._config["connector"] = connector_config
         self.pipeline._setup()
         self.pipeline.run()
         assert self.pipeline._output.events == expected_output_data
@@ -285,7 +285,7 @@ class TestPipeline(ConfigurationForTests):
     def test_processor_warning_error_is_logged_but_processing_continues(self, mock_warning, _):
         input_data = [{"order": 0}, {"order": 1}]
         connector_config = {"type": "dummy", "input": input_data}
-        self.pipeline._connector_config = connector_config
+        self.pipeline._config["connector"] = connector_config
         self.pipeline._create_logger()
         self.pipeline._create_connectors()
         error_mock = mock.MagicMock()
@@ -310,7 +310,7 @@ class TestPipeline(ConfigurationForTests):
     ):
         input_data = [{"order": 0}, {"order": 1}]
         connector_config = {"type": "dummy", "input": input_data}
-        self.pipeline._connector_config = connector_config
+        self.pipeline._config["connector"] = connector_config
         self.pipeline._create_logger()
         self.pipeline._create_connectors()
         error_mock = mock.MagicMock()
@@ -515,7 +515,7 @@ class TestPipeline(ConfigurationForTests):
 
     def test_pipeline_preprocessing_adds_versions_if_configured(self, _):
         preprocessing_config = {"version_info_target_field": "version_info"}
-        self.pipeline._connector_config = {"consumer": {"preprocessing": preprocessing_config}}
+        self.pipeline._config["connector"] = {"consumer": {"preprocessing": preprocessing_config}}
         test_event = {"any": "content"}
         self.pipeline._preprocess_event(test_event)
         target_field = preprocessing_config.get("version_info_target_field")
@@ -526,7 +526,7 @@ class TestPipeline(ConfigurationForTests):
 
     def test_pipeline_preprocessing_does_not_add_versions_if_not_configured(self, _):
         preprocessing_config = {"something": "random"}
-        self.pipeline._connector_config = {"consumer": {"preprocessing": preprocessing_config}}
+        self.pipeline._config["connector"] = {"consumer": {"preprocessing": preprocessing_config}}
         test_event = {"any": "content"}
         self.pipeline._preprocess_event(test_event)
         assert test_event == {"any": "content"}
@@ -548,7 +548,7 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
             with raises(MustProvideAnMPLogHandlerError):
                 MultiprocessingPipeline(
                     pipeline_index=1,
-                    logprep_config=self.logprep_config,
+                    config=self.logprep_config,
                     log_handler=not_a_log_handler,
                     lock=self.lock,
                     shared_dict=self.shared_dict,
@@ -558,7 +558,7 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
         try:
             MultiprocessingPipeline(
                 pipeline_index=1,
-                logprep_config=self.logprep_config,
+                config=self.logprep_config,
                 log_handler=self.log_handler,
                 lock=self.lock,
                 shared_dict=self.shared_dict,
@@ -571,7 +571,7 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
         children_running = self.start_and_stop_pipeline(
             MultiprocessingPipeline(
                 pipeline_index=1,
-                logprep_config=self.logprep_config,
+                config=self.logprep_config,
                 log_handler=self.log_handler,
                 lock=self.lock,
                 shared_dict=self.shared_dict,
@@ -584,7 +584,7 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
         children_running = self.start_and_stop_pipeline(
             MultiprocessingPipeline(
                 pipeline_index=1,
-                logprep_config=self.logprep_config,
+                config=self.logprep_config,
                 log_handler=self.log_handler,
                 lock=self.lock,
                 shared_dict=self.shared_dict,
@@ -597,7 +597,7 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
     def test_enable_iteration_sets_iterate_to_true_stop_to_false(self):
         pipeline = MultiprocessingPipeline(
             pipeline_index=1,
-            logprep_config=self.logprep_config,
+            config=self.logprep_config,
             log_handler=self.log_handler,
             lock=self.lock,
             shared_dict=self.shared_dict,

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -9,6 +9,7 @@ from unittest import mock
 from _pytest.outcomes import fail
 from _pytest.python_api import raises
 
+from logprep._version import get_versions
 from logprep.abc import Processor
 from logprep.framework.pipeline import (
     MultiprocessingPipeline,
@@ -35,15 +36,15 @@ from logprep.util.multiprocessing_log_handler import MultiprocessingLogHandler
 
 
 class ConfigurationForTests:
-    connector_config = {"type": "dummy", "input": [{"test": "empty"}]}
-    pipeline_config = [{"mock_processor1": {"proc": "conf"}}, {"mock_processor2": {"proc": "conf"}}]
-    metrics_config = {
-        "period": 300,
-        "enabled": False,
+    logprep_config = {
+        "version": 1,
+        "timeout": 0.001,
+        "print_processed_period": 600,
+        "connector": {"type": "dummy", "input": [{"test": "empty"}]},
+        "pipeline": [{"mock_processor1": {"proc": "conf"}}, {"mock_processor2": {"proc": "conf"}}],
+        "metrics": {"period": 300, "enabled": False},
     }
     log_handler = MultiprocessingLogHandler(WARNING)
-    timeout = 0.001
-    print_processed_period = 600
     lock = Lock()
     shared_dict = {}
     metric_targets = MetricTargets(file_target=getLogger("Mock"), prometheus_target=None)
@@ -64,34 +65,27 @@ class TestPipeline(ConfigurationForTests):
     def setup_method(self):
         self._check_failed_stored = None
 
-        pipeline_index = 1
         self.pipeline = Pipeline(
-            pipeline_index,
-            self.connector_config,
-            self.pipeline_config,
-            self.metrics_config,
-            self.timeout,
-            self.counter,
-            self.log_handler,
-            self.lock,
-            self.shared_dict,
-            self.metric_targets,
+            pipeline_index=1,
+            logprep_config=self.logprep_config,
+            counter=self.counter,
+            log_handler=self.log_handler,
+            lock=self.lock,
+            shared_dict=self.shared_dict,
+            metric_targets=self.metric_targets,
         )
 
     def test_fails_if_log_handler_is_not_of_type_loghandler(self, _):
         for not_a_log_handler in [None, 123, 45.67, TestPipeline()]:
             with raises(MustProvideALogHandlerError):
-                pipeline_index = 1
                 _ = Pipeline(
-                    pipeline_index,
-                    self.connector_config,
-                    self.pipeline_config,
-                    self.metrics_config,
-                    self.timeout,
-                    self.counter,
-                    not_a_log_handler,
-                    self.lock,
-                    self.shared_dict,
+                    pipeline_index=1,
+                    logprep_config=self.logprep_config,
+                    counter=self.counter,
+                    log_handler=not_a_log_handler,
+                    lock=self.lock,
+                    shared_dict=self.shared_dict,
+                    metric_targets=self.metric_targets,
                 )
 
     def test_setup_builds_pipeline(self, mock_create):
@@ -134,7 +128,7 @@ class TestPipeline(ConfigurationForTests):
 
         self.pipeline._retrieve_and_process_data()
 
-        assert self.pipeline._input.last_timeout == self.timeout
+        assert self.pipeline._input.last_timeout == self.logprep_config.get("timeout")
 
     def test_empty_documents_are_not_forwarded_to_other_processors(self, _):
         assert len(self.pipeline._pipeline) == 0
@@ -519,6 +513,31 @@ class TestPipeline(ConfigurationForTests):
         self.pipeline.metrics.pipeline = [mock_metrics_one, mock_metrics_two]
         assert self.pipeline.metrics.number_of_errors == 2
 
+    def test_pipeline_preprocessing_adds_versions_if_configured(self, _):
+        preprocessing_config = {"version_info_target_field": "version_info"}
+        self.pipeline._connector_config = {"consumer": {"preprocessing": preprocessing_config}}
+        test_event = {"any": "content"}
+        self.pipeline._preprocess_event(test_event)
+        target_field = preprocessing_config.get("version_info_target_field")
+        assert target_field in test_event
+        assert test_event.get(target_field, {}).get("logprep") == get_versions()["version"]
+        expected_config_version = self.logprep_config["version"]
+        assert test_event.get(target_field, {}).get("configuration") == expected_config_version
+
+    def test_pipeline_preprocessing_does_not_add_versions_if_not_configured(self, _):
+        preprocessing_config = {"something": "random"}
+        self.pipeline._connector_config = {"consumer": {"preprocessing": preprocessing_config}}
+        test_event = {"any": "content"}
+        self.pipeline._preprocess_event(test_event)
+        assert test_event == {"any": "content"}
+
+    def test_pipeline_preprocessing_does_not_add_versions_if_target_field_exists_already(self, _):
+        preprocessing_config = {"version_info_target_field": "version_info"}
+        self.pipeline._connector_config = {"consumer": {"preprocessing": preprocessing_config}}
+        test_event = {"any": "content", "version_info": "something random"}
+        self.pipeline._preprocess_event(test_event)
+        assert test_event == {"any": "content", "version_info": "something random"}
+
 
 class TestMultiprocessingPipeline(ConfigurationForTests):
     def setup_class(self):
@@ -527,68 +546,48 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
     def test_fails_if_log_handler_is_not_a_multiprocessing_log_handler(self):
         for not_a_log_handler in [None, 123, 45.67, TestMultiprocessingPipeline()]:
             with raises(MustProvideAnMPLogHandlerError):
-                pipeline_index = 1
                 MultiprocessingPipeline(
-                    pipeline_index,
-                    {},
-                    [{}],
-                    self.metrics_config,
-                    self.timeout,
-                    not_a_log_handler,
-                    self.print_processed_period,
-                    self.lock,
-                    self.shared_dict,
+                    pipeline_index=1,
+                    logprep_config=self.logprep_config,
+                    log_handler=not_a_log_handler,
+                    lock=self.lock,
+                    shared_dict=self.shared_dict,
                 )
 
     def test_does_not_fail_if_log_handler_is_a_multiprocessing_log_handler(self):
         try:
-            pipeline_index = 1
             MultiprocessingPipeline(
-                pipeline_index,
-                self.connector_config,
-                self.pipeline_config,
-                self.metrics_config,
-                self.timeout,
-                self.log_handler,
-                self.print_processed_period,
-                self.lock,
-                self.shared_dict,
+                pipeline_index=1,
+                logprep_config=self.logprep_config,
+                log_handler=self.log_handler,
+                lock=self.lock,
+                shared_dict=self.shared_dict,
             )
         except MustProvideAnMPLogHandlerError:
             fail("Must not raise this error for a correct handler!")
 
     def test_creates_a_new_process(self):
         children_before = active_children()
-        pipeline_index = 1
         children_running = self.start_and_stop_pipeline(
             MultiprocessingPipeline(
-                pipeline_index,
-                self.connector_config,
-                self.pipeline_config,
-                self.metrics_config,
-                self.timeout,
-                self.log_handler,
-                self.print_processed_period,
-                self.lock,
-                self.shared_dict,
+                pipeline_index=1,
+                logprep_config=self.logprep_config,
+                log_handler=self.log_handler,
+                lock=self.lock,
+                shared_dict=self.shared_dict,
             )
         )
 
         assert len(children_running) == (len(children_before) + 1)
 
     def test_stop_terminates_the_process(self):
-        pipeline_index = 1
         children_running = self.start_and_stop_pipeline(
             MultiprocessingPipeline(
-                pipeline_index,
-                self.connector_config,
-                self.pipeline_config,
-                self.metrics_config,
-                self.timeout,
-                self.log_handler,
-                self.print_processed_period,
-                self.lock,
-                self.shared_dict,
+                pipeline_index=1,
+                logprep_config=self.logprep_config,
+                log_handler=self.log_handler,
+                lock=self.lock,
+                shared_dict=self.shared_dict,
             )
         )
         children_after = active_children()
@@ -596,17 +595,12 @@ class TestMultiprocessingPipeline(ConfigurationForTests):
         assert len(children_after) == (len(children_running) - 1)
 
     def test_enable_iteration_sets_iterate_to_true_stop_to_false(self):
-        pipeline_index = 1
         pipeline = MultiprocessingPipeline(
-            pipeline_index,
-            self.connector_config,
-            self.pipeline_config,
-            self.metrics_config,
-            self.timeout,
-            self.log_handler,
-            self.print_processed_period,
-            self.lock,
-            self.shared_dict,
+            pipeline_index=1,
+            logprep_config=self.logprep_config,
+            log_handler=self.log_handler,
+            lock=self.lock,
+            shared_dict=self.shared_dict,
         )
         assert not pipeline._iterate()
 

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -458,10 +458,10 @@ class TestConfiguration:
             config._verify_connector(getLogger("test-logger"))
 
             expected_warning_message = (
-                "Deprecated configuration format: The hmac options have "
-                "to be under the key 'preprocessing'. The hmac options "
-                "under the key 'consumer' will be removed in a future "
-                "release; version=4.0.0"
+                "[Deprecation]: you are currently using a configuration format that will be "
+                "outdated in the next major release (version 4.0.0). The hmac options will move "
+                "from the keyword 'consumer' to the subkey 'preprocessing', consider changing to "
+                "the new config format. [Expires with logprep=4.0.0]"
             )
             assert len(caplog.messages) == 1
             assert expected_warning_message == caplog.messages[0]

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=line-too-long
-
+import logging
 from copy import deepcopy
 from logging import getLogger
 
@@ -445,3 +445,36 @@ class TestConfiguration:
             assert errors_set == raised_errors, f"For test case '{test_case}'!"
         else:
             config._verify_metrics_config()
+
+    def test_set_option_raises_deprecation_warning_on_old_hmac_option_position(self, caplog):
+        config = deepcopy(self.config)
+        config["connector"]["consumer"]["hmac"] = {
+            "target": "foo",
+            "key": "bar",
+            "output_field": "bu",
+        }
+
+        with caplog.at_level(logging.WARNING):
+            config._verify_connector(getLogger("test-logger"))
+
+            expected_warning_message = (
+                "Deprecated configuration format: The hmac options have "
+                "to be under the key 'preprocessing'. The hmac options "
+                "under the key 'consumer' will be removed in a future "
+                "release; version=4.0.0"
+            )
+            assert len(caplog.messages) == 1
+            assert expected_warning_message == caplog.messages[0]
+
+    def test_set_option_does_not_raise_deprecation_warning_on_new_hmac_option_position(
+        self, caplog
+    ):
+        config = deepcopy(self.config)
+        config["connector"]["consumer"]["preprocessing"] = {
+            "hmac": {"target": "foo", "key": "bar", "output_field": "bu"}
+        }
+
+        with caplog.at_level(logging.WARNING):
+            config._verify_connector(logger)
+
+        assert len(caplog.messages) == 0


### PR DESCRIPTION
This enables the pipeline to automatically add version information
to all events independent of the pipeline configuration.
This pull request also refactors the initialization of pipeline and 
multiprocessing pipeline objects. Furthermore it introduces a 
`preprocessing` config field to the connector consumer options. 
The already existing hmac options were moved under this new 
field while maintaining backwards capabilities. Meaning the hmac
can now be configured in two places. The old place under the
field `consumer` will lead to a deprecation warning, indicating a 
removal in the next major release. 

In an additional pull request the hmac implementation should also
move away from the connector and into the pipeline such that it is
an connector independent feature. 