### PR TITLE
Fix selective extractor output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Before, there was permanently one connection per multiprocessing pipeline active
 only one connection per Logprep instance active when accessing the database. 
 
 ### Bugfixes
+
+* Fix SelectiveExtractor output. The internal extracted list wasn't cleared between each event, 
+leading to duplication in the output of the processor. Now the events are cleared such that only
+the result of the current event is returned.
+
 ### Breaking
 
 ## v3.1.0

--- a/logprep/processor/selective_extractor/processor.py
+++ b/logprep/processor/selective_extractor/processor.py
@@ -50,6 +50,7 @@ class SelectiveExtractor(Processor):
         self._filtered_events = []
 
     def process(self, event: dict) -> tuple:
+        self._filtered_events = []
         super().process(event)
         if self._filtered_events:
             return self._filtered_events

--- a/tests/unit/processor/selective_extractor/test_selective_extractor.py
+++ b/tests/unit/processor/selective_extractor/test_selective_extractor.py
@@ -125,3 +125,11 @@ class TestSelectiveExtractor(BaseProcessorTestCase):
                 break
         else:
             assert False, f"other.message not in {result}"
+
+    def test_process_clears_internal_filtered_events_list_before_every_event(self):
+        assert len(self.object._filtered_events) == 0
+        document = {"message": "test_message", "other": {"message": "my message value"}}
+        _ = self.object.process(document)
+        assert len(self.object._filtered_events) == 1
+        _ = self.object.process(document)
+        assert len(self.object._filtered_events) == 1


### PR DESCRIPTION
The internal extracted list wasn't cleared between each event,
leading to duplication in the output of the processor. Now the
events are cleared such that only the result of the current event is
returned.