### PR TITLE
Allow normalizer to write grok_failure fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ under the subkey `preprocessing`
 
 ### Features
 
-* Normalizer can now write grok failure fields to an event when no grok pattern matches
+* Normalizer can now write grok failure fields to an event when no grok pattern matches and if `failure_target_field` is specified
 
 ### Improvements
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ under the subkey `preprocessing`
 
 ### Features
 
-* Normalizer can now write add grok failure fields to an event when no grok pattern matches
+* Normalizer can now write grok failure fields to an event when no grok pattern matches
 
 ### Improvements
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ under the subkey `preprocessing`
 
 ### Features
 
-* Normalizer can now write grok failure fields to an event when no grok pattern matches and if `failure_target_field` is specified
+* Normalizer can now write grok failure fields to an event when no grok pattern matches and if 
+`failure_target_field` is specified in the configuration
 
 ### Improvements
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ under the subkey `preprocessing`
 ## Next Release
 
 ### Features
+
+* Normalizer can now write add grok failure fields to an event when no grok pattern matches
+
 ### Improvements
 ### Bugfixes
 ### Breaking

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -324,9 +324,9 @@ The normalizer would produce the following output event:
     }
 
 If the grok field is a subfield somewhere inside the event, then the keys of the grok_failure object
-would contain the path to this subfield separated by :code:`>`.
+will contain the path to this subfield separated by :code:`>`.
 This helps in identifying the original source field to which the grok pattern was applied to.
-An grok failure output example would look like:
+A grok failure output example would look like:
 
 ..  code-block:: json
     :linenos:

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -271,7 +271,7 @@ The following example would normalize :code:`some_field_with_an_ip: "1.2.3.4 123
 
 As Grok pattern are only applied when they match a given input string it is sometimes desired to
 know when none of the given pattern matches.
-This is helpful in identifying new unknown events that are not correctly covered by the current
+This is helpful in identifying new, unknown or reconfigured log sources that are not correctly covered by the current
 rule set.
 To activate the output of this information it is required to add the field
 :code:`failure_target_field` to the grok rule.

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -295,7 +295,7 @@ If this is applied to an event which has the field :code:`some_field_with_an_ip`
 is not matched by any grok-filter then the :code:`grok_failure` field will be added.
 This failure field will contain a subfield which identifies the grok target field as well as the
 first 100 characters of the fields content.
-By adding the failure information as an separate object it is possible to add more failures to it
+By adding the failure information as a separate object it is possible to add more failures to it
 in case many different grok rules exist and multiple events are not matched by any grok pattern.
 
 Given this example event:

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -270,8 +270,8 @@ class Normalizer(Processor):
 
     def _write_grok_failure_field(self, event, rule, source_field, source_value):
         """
-        If grok pattern exist and are configured with a failure target field, then write the source
-        field and the first 100 characters in the event.
+        If grok patterns exist and are configured with a failure target field, then add the source
+        field and the first 100 characters of the grok patterns' target field to the event.
         """
         if not rule.grok.items():
             return

--- a/logprep/processor/normalizer/rule.py
+++ b/logprep/processor/normalizer/rule.py
@@ -1,8 +1,8 @@
 """This module is used to get documents that match a normalization filter."""
 
+import re
 from typing import Union, Dict, List
 
-import re
 from pygrok import Grok
 
 from logprep.filter.expression.filter_expression import FilterExpression
@@ -47,7 +47,7 @@ class GrokWrapper:
 
     grok_delimiter_pattern = re.compile(GROK_DELIMITER)
 
-    def __init__(self, patterns: Union[str, List[str]], **kwargs):
+    def __init__(self, patterns: Union[str, List[str]], failure_target_field=None, **kwargs):
         if isinstance(patterns, str):
             self._grok_list = [Grok(f"^{patterns}$", **kwargs)]
         else:
@@ -55,6 +55,7 @@ class GrokWrapper:
             self._grok_list = [Grok(pattern_item, **kwargs) for pattern_item in patterns]
 
         self._match_cnt_initialized = False
+        self.failure_target_field = failure_target_field
 
     def match(self, text: str, pattern_matches: dict = None) -> Dict[str, str]:
         """Match string via grok using delimiter and count matches if enabled."""
@@ -72,7 +73,7 @@ class GrokWrapper:
                 for key, value in matches.items():
                     dotted_matches[self.grok_delimiter_pattern.sub(".", key)] = value
                 return dotted_matches
-        return dict()
+        return {}
 
 
 class NormalizerRule(Rule):
@@ -91,36 +92,50 @@ class NormalizerRule(Rule):
         self._parse_normalizations(normalizations)
 
     def _parse_normalizations(self, normalizations):
-        for src, norm in normalizations.items():
-            if isinstance(norm, dict) and norm.get("grok"):
-                norm["grok"] = [norm["grok"]] if isinstance(norm["grok"], str) else norm["grok"]
-                for idx, grok in enumerate(norm["grok"]):
-                    patterns = self.extract_field_pattern.findall(grok)
-                    for pattern in patterns:
-                        if len(pattern) >= 2:
-                            sub_fields = re.findall(self.sub_fields_pattern, pattern[1])
-                            if sub_fields:
-                                mutable_pattern = list(pattern)
-                                mutable_pattern[1] = GROK_DELIMITER.join(
-                                    (sub_field[1] for sub_field in sub_fields)
-                                )
-                                to_replace = re.escape(r"%{" + r":".join(pattern))
-                                transformed_fields_names = "%{" + ":".join(mutable_pattern)
-                                norm["grok"][idx] = re.sub(
-                                    to_replace, transformed_fields_names, norm["grok"][idx]
-                                )
-                    self._grok.update(
-                        {
-                            src: GrokWrapper(
-                                norm["grok"],
-                                custom_patterns_dir=NormalizerRule.additional_grok_patterns,
-                            )
-                        }
-                    )
-            elif isinstance(norm, dict) and norm.get("timestamp"):
-                self._timestamps.update({src: norm})
+        for source_field, normalization in normalizations.items():
+            if isinstance(normalization, dict) and normalization.get("grok"):
+                self._extract_grok_pattern(normalization, source_field)
+            elif isinstance(normalization, dict) and normalization.get("timestamp"):
+                self._timestamps.update({source_field: normalization})
             else:
-                self._substitutions.update({src: norm})
+                self._substitutions.update({source_field: normalization})
+
+    def _extract_grok_pattern(self, normalization, source_field):
+        """Checks the rule file for grok pattern, reformats them and adds them to self._grok"""
+        if isinstance(normalization["grok"], str):
+            normalization["grok"] = [normalization["grok"]]
+        for idx, grok in enumerate(normalization["grok"]):
+            patterns = self.extract_field_pattern.findall(grok)
+            self._reformat_grok_pattern(idx, normalization, patterns)
+            failure_target_field = normalization.get("failure_target_field")
+            self._grok.update(
+                {
+                    source_field: GrokWrapper(
+                        patterns=normalization["grok"],
+                        custom_patterns_dir=NormalizerRule.additional_grok_patterns,
+                        failure_target_field=failure_target_field,
+                    )
+                }
+            )
+
+    def _reformat_grok_pattern(self, idx, normalization, patterns):
+        """
+        Changes the grok pattern format by removing the square brackets and introducing
+        the GROK_DELIMITER.
+        """
+        for pattern in patterns:
+            if len(pattern) >= 2:
+                sub_fields = re.findall(self.sub_fields_pattern, pattern[1])
+                if sub_fields:
+                    mutable_pattern = list(pattern)
+                    mutable_pattern[1] = GROK_DELIMITER.join(
+                        (sub_field[1] for sub_field in sub_fields)
+                    )
+                    to_replace = re.escape(r"%{" + r":".join(pattern))
+                    transformed_fields_names = "%{" + ":".join(mutable_pattern)
+                    normalization["grok"][idx] = re.sub(
+                        to_replace, transformed_fields_names, normalization["grok"][idx]
+                    )
 
     def __eq__(self, other: "NormalizerRule") -> bool:
         return (
@@ -159,33 +174,43 @@ class NormalizerRule(Rule):
                 if len(value) != 3:
                     raise InvalidNormalizationDefinition(value)
             if isinstance(value, dict):
-
-                if any([key for key in value.keys() if key not in ("grok", "timestamp")]):
-                    raise InvalidNormalizationDefinition(value)
-
+                NormalizerRule._validate_allowed_keys(value)
                 if "grok" in value.keys():
-                    grok = value["grok"]
-                    if not grok:
-                        raise InvalidNormalizationDefinition(value)
-                    if isinstance(grok, list):
-                        if any([not isinstance(pattern, str) for pattern in grok]):
-                            raise InvalidNormalizationDefinition(value)
-                    try:
-                        GrokWrapper(
-                            grok, custom_patterns_dir=NormalizerRule.additional_grok_patterns
-                        )
-                    except Exception as error:
-                        raise InvalidGrokDefinition(grok) from error
-
+                    NormalizerRule._validate_grok(value)
                 if "timestamp" in value.keys():
-                    timestamp = value.get("timestamp")
-                    if not timestamp:
-                        raise InvalidNormalizationDefinition(value)
-                    if not isinstance(timestamp.get("destination"), str):
-                        raise InvalidTimestampDefinition(timestamp)
-                    if not isinstance(timestamp.get("source_formats"), list):
-                        raise InvalidTimestampDefinition(timestamp)
-                    if not isinstance(timestamp.get("source_timezone"), str):
-                        raise InvalidTimestampDefinition(timestamp)
-                    if not isinstance(timestamp.get("destination_timezone"), str):
-                        raise InvalidTimestampDefinition(timestamp)
+                    NormalizerRule._validate_timestamp(value)
+
+    @staticmethod
+    def _validate_allowed_keys(value):
+        allowed_keys = ["grok", "timestamp", "failure_target_field"]
+        if any(key for key in value.keys() if key not in allowed_keys):
+            raise InvalidNormalizationDefinition(value)
+
+    @staticmethod
+    def _validate_grok(value):
+        grok = value["grok"]
+        if not grok:
+            raise InvalidNormalizationDefinition(value)
+        if isinstance(grok, list):
+            if any(not isinstance(pattern, str) for pattern in grok):
+                raise InvalidNormalizationDefinition(value)
+        try:
+            GrokWrapper(
+                grok, custom_patterns_dir=NormalizerRule.additional_grok_patterns
+            )
+        except Exception as error:
+            raise InvalidGrokDefinition(grok) from error
+
+    @staticmethod
+    def _validate_timestamp(value):
+        timestamp = value.get("timestamp")
+        if not timestamp:
+            raise InvalidNormalizationDefinition(value)
+        if not isinstance(timestamp.get("destination"), str):
+            raise InvalidTimestampDefinition(timestamp)
+        if not isinstance(timestamp.get("source_formats"), list):
+            raise InvalidTimestampDefinition(timestamp)
+        if not isinstance(timestamp.get("source_timezone"), str):
+            raise InvalidTimestampDefinition(timestamp)
+        if not isinstance(timestamp.get("destination_timezone"), str):
+            raise InvalidTimestampDefinition(timestamp)

--- a/logprep/processor/normalizer/rule.py
+++ b/logprep/processor/normalizer/rule.py
@@ -195,9 +195,7 @@ class NormalizerRule(Rule):
             if any(not isinstance(pattern, str) for pattern in grok):
                 raise InvalidNormalizationDefinition(value)
         try:
-            GrokWrapper(
-                grok, custom_patterns_dir=NormalizerRule.additional_grok_patterns
-            )
+            GrokWrapper(grok, custom_patterns_dir=NormalizerRule.additional_grok_patterns)
         except Exception as error:
             raise InvalidGrokDefinition(grok) from error
 

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=too-many-lines
+# pylint: disable=line-too-long
 import calendar
 import copy
 import json
@@ -109,7 +110,7 @@ class TestNormalizer(BaseProcessorTestCase):
             }
         }
         self.object.process(document)
-        assert "test1" not in document.get("test_normalized", dict())
+        assert "test1" not in document.get("test_normalized", {})
 
     def test_add_field_without_conflicts(self):
         event = {"host": {"ip": "127.0.0.1"}, "client": {"port": 22222}}
@@ -526,6 +527,41 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event.get("port") == 1234
         assert event.get("some")
         assert event["some"].get("ip") == "123.123.123.123"
+
+    def test_normalization_from_grok_writes_grok_failure_no_grok_pattern_matches_and_if_configured(
+        self,
+    ):
+        event = {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234"},
+            }
+        }
+
+        rule = {
+            "filter": "winlog.event_id: 123456789",
+            "normalize": {
+                "winlog.event_data.normalize me!": {
+                    "grok": [
+                        "%{IP:some_ip_1} %{NUMBER:port_1:int} foo",
+                        "%{IP:some_ip_2} %{NUMBER:port_2:int} bar",
+                    ],
+                    "failure_target_field": "grok_failure",
+                }
+            },
+        }
+
+        self._load_specific_rule(rule)
+        self.object.process(event)
+
+        assert event.get("some_ip_1") is None
+        assert event.get("port_1") is None
+        assert event.get("some_ip_2") is None
+        assert event.get("port_2") is None
+        assert event.get("grok_failure") == {
+            "winlog>event_data>normalize me!": "123.123.123.123 1234"
+        }
 
     def test_normalization_from_grok_onto_existing(self):
         event = {
@@ -1014,7 +1050,6 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event == expected
 
     def test_normalization_with_grok_pattern_count(self):
-        config = copy.deepcopy(self.CONFIG)
         temp_path = tempfile.mkdtemp()
         config = deepcopy(self.CONFIG)
 

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -528,7 +528,38 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event.get("some")
         assert event["some"].get("ip") == "123.123.123.123"
 
-    def test_normalization_from_grok_writes_grok_failure_no_grok_pattern_matches_and_if_configured(
+    def test_normalization_from_grok_writes_grok_failure_if_no_grok_pattern_matches_and_if_configured(
+        self,
+    ):
+        event = {
+            "grok_me": "123.123.123.123 1234"
+        }
+
+        rule = {
+            "filter": "grok_me",
+            "normalize": {
+                "grok_me": {
+                    "grok": [
+                        "%{IP:some_ip_1} %{NUMBER:port_1:int} foo",
+                        "%{IP:some_ip_2} %{NUMBER:port_2:int} bar",
+                    ],
+                    "failure_target_field": "grok_failure",
+                }
+            },
+        }
+
+        self._load_specific_rule(rule)
+        self.object.process(event)
+
+        assert event.get("some_ip_1") is None
+        assert event.get("port_1") is None
+        assert event.get("some_ip_2") is None
+        assert event.get("port_2") is None
+        assert event.get("grok_failure") == {
+            "grok_me": "123.123.123.123 1234"
+        }
+
+    def test_normalization_from_grok_writes_grok_failure_for_nested_fields(
         self,
     ):
         event = {
@@ -560,6 +591,41 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event.get("some_ip_2") is None
         assert event.get("port_2") is None
         assert event.get("grok_failure") == {
+            "winlog>event_data>normalize me!": "123.123.123.123 1234"
+        }
+
+    def test_normalization_from_grok_writes_grok_failure_to_dotted_subfield(
+        self,
+    ):
+        event = {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234"},
+            }
+        }
+
+        rule = {
+            "filter": "winlog.event_id: 123456789",
+            "normalize": {
+                "winlog.event_data.normalize me!": {
+                    "grok": [
+                        "%{IP:some_ip_1} %{NUMBER:port_1:int} foo",
+                        "%{IP:some_ip_2} %{NUMBER:port_2:int} bar",
+                    ],
+                    "failure_target_field": "winlog.event_data.grok_failure",
+                }
+            },
+        }
+
+        self._load_specific_rule(rule)
+        self.object.process(event)
+
+        assert event.get("some_ip_1") is None
+        assert event.get("port_1") is None
+        assert event.get("some_ip_2") is None
+        assert event.get("port_2") is None
+        assert event.get("winlog", {}).get("event_data", {}).get("grok_failure") == {
             "winlog>event_data>normalize me!": "123.123.123.123 1234"
         }
 

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -531,9 +531,7 @@ class TestNormalizer(BaseProcessorTestCase):
     def test_normalization_from_grok_writes_grok_failure_if_no_grok_pattern_matches_and_if_configured(
         self,
     ):
-        event = {
-            "grok_me": "123.123.123.123 1234"
-        }
+        event = {"grok_me": "123.123.123.123 1234"}
 
         rule = {
             "filter": "grok_me",
@@ -555,9 +553,7 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event.get("port_1") is None
         assert event.get("some_ip_2") is None
         assert event.get("port_2") is None
-        assert event.get("grok_failure") == {
-            "grok_me": "123.123.123.123 1234"
-        }
+        assert event.get("grok_failure") == {"grok_me": "123.123.123.123 1234"}
 
     def test_normalization_from_grok_writes_grok_failure_for_nested_fields(
         self,


### PR DESCRIPTION
In case no grok pattern of a rule matches it is now possible to
automatically add a grok failure fields which will contain the grok
target field as well as the first 100 characters of the pattern that
should have been matched.

This pull-request does also some refactoring and lint fixes.