### PR TITLE
Fix preprocessor config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ under the subkey `preprocessing`
 ### Features
 ### Improvements
 ### Bugfixes
+
+* Fix config validation of the preprocessor `version_info_target_field`.
+
 ### Breaking
 
 ## v3.2.0

--- a/logprep/connector/confluent_kafka.py
+++ b/logprep/connector/confluent_kafka.py
@@ -143,7 +143,7 @@ class ConfluentKafka(Input, Output):
                 "offset_reset_policy": "smallest",
                 "enable_auto_offset_store": enable_auto_offset_store,
                 "preprocessing": {
-                    "version_info_target_field": None,
+                    "version_info_target_field": "",
                     "hmac": {"target": "", "key": "", "output_field": ""},
                 },
                 "hmac": {"target": "", "key": "", "output_field": ""},

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -256,7 +256,7 @@ class Pipeline:
     def _preprocess_event(self, event):
         consumer_config = self._logprep_config.get("connector").get("consumer", {})
         preprocessing_config = consumer_config.get("preprocessing", {})
-        if preprocessing_config.get("version_info_target_field", "") != "":
+        if preprocessing_config.get("version_info_target_field"):
             self._add_version_information_to_event(event, preprocessing_config)
 
     def _add_version_information_to_event(self, event: dict, preprocessing_config: dict):

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -256,7 +256,7 @@ class Pipeline:
     def _preprocess_event(self, event):
         consumer_config = self._logprep_config.get("connector").get("consumer", {})
         preprocessing_config = consumer_config.get("preprocessing", {})
-        if preprocessing_config.get("version_info_target_field"):
+        if preprocessing_config.get("version_info_target_field", "") != "":
             self._add_version_information_to_event(event, preprocessing_config)
 
     def _add_version_information_to_event(self, event: dict, preprocessing_config: dict):

--- a/tests/acceptance/test_preprocessors.py
+++ b/tests/acceptance/test_preprocessors.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from logprep._version import get_versions
 from logprep.util.json_handling import dump_config_as_file
 from tests.acceptance.util import mock_kafka_and_run_pipeline, get_default_logprep_config
 
@@ -26,7 +27,7 @@ def fixture_config():
     return get_default_logprep_config(pipeline)
 
 
-class TestFullHMACPassTest:
+class TestFullHMACPass:
     def test_full_message_pass_with_hmac(self, tmp_path, config):
         config_path = str(tmp_path / "generated_config.yml")
         dump_config_as_file(config_path, config)
@@ -62,6 +63,78 @@ class TestFullHMACPassTest:
             "hmac": config["connector"]["consumer"]["hmac"]
         }
         del config["connector"]["consumer"]["hmac"]
+        config_path = str(tmp_path / "generated_config.yml")
+        dump_config_as_file(config_path, config)
+
+        with patch(
+            "logprep.connector.connector_factory.ConnectorFactory.create"
+        ) as mock_connector_factory:
+            input_test_event = {"test": "message"}
+            expected_output_event = {
+                "test": "message",
+                "hmac": {
+                    "hmac": "5a77054b5f1d9ea60000520a4e2cf661e7a11de4205ca70c6977fc8040076a6e",
+                    "compressed_base64": "eJyrVipJLS5RslLKTS0uTkxPVaoFADwCBmA=",
+                },
+            }
+
+            kafka_output_file = mock_kafka_and_run_pipeline(
+                config, input_test_event, mock_connector_factory, tmp_path
+            )
+
+            # read logprep kafka output from mocked kafka file producer
+            with open(kafka_output_file, "r", encoding="utf-8") as output_file:
+                outputs = output_file.readlines()
+                assert len(outputs) == 1, "Expected only one default kafka output"
+
+                target, event = outputs[0].split(" ", maxsplit=1)
+                event = json.loads(event)
+                assert target == "test_input_processed"
+                assert event == expected_output_event
+
+
+class TestVersionInfoTargetField:
+    def test_version_info_target_field_will_be_added_if_configured(self, tmp_path, config):
+        config["connector"]["consumer"]["preprocessing"] = {
+            "version_info_target_field": "version_info"
+        }
+        config_path = str(tmp_path / "generated_config.yml")
+        dump_config_as_file(config_path, config)
+
+        with patch(
+            "logprep.connector.connector_factory.ConnectorFactory.create"
+        ) as mock_connector_factory:
+            input_test_event = {"test": "message"}
+            expected_output_event = {
+                "test": "message",
+                "hmac": {
+                    "hmac": "5a77054b5f1d9ea60000520a4e2cf661e7a11de4205ca70c6977fc8040076a6e",
+                    "compressed_base64": "eJyrVipJLS5RslLKTS0uTkxPVaoFADwCBmA=",
+                },
+                "version_info": {
+                    "logprep": get_versions().get("version"),
+                    "configuration": "unset",
+                },
+            }
+
+            kafka_output_file = mock_kafka_and_run_pipeline(
+                config, input_test_event, mock_connector_factory, tmp_path
+            )
+
+            # read logprep kafka output from mocked kafka file producer
+            with open(kafka_output_file, "r", encoding="utf-8") as output_file:
+                outputs = output_file.readlines()
+                assert len(outputs) == 1, "Expected only one default kafka output"
+
+                target, event = outputs[0].split(" ", maxsplit=1)
+                event = json.loads(event)
+                assert target == "test_input_processed"
+                assert event == expected_output_event
+
+    def test_version_info_target_field_will_not_be_added_if_not_configured(self, tmp_path, config):
+        consumer_config = config.get("connector", {}).get("consumer", {})
+        preprocessing_config = consumer_config.get("preprocessing", {})
+        assert preprocessing_config.get("version_info_target_field") is None
         config_path = str(tmp_path / "generated_config.yml")
         dump_config_as_file(config_path, config)
 


### PR DESCRIPTION
The unit tests for the preprocessor which adds version information to
an event didn't cover the config validation. This pull-requests adds
acceptances tests to test a full message pass with the preprocessor
activated and fixes a config validation error.