### PR TITLE
Fix picklingerror in debug

### DIFF
--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -153,7 +153,7 @@ class Processor(Component):
 
         """
         if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
-            self._logger.debug("%s process event %s", self, event)
+            self._logger.debug(f"%s processing event %s", self.describe(), event)
         self._strategy.process(
             event,
             generic_tree=self._generic_tree,

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -153,7 +153,7 @@ class Processor(Component):
 
         """
         if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
-            self._logger.debug(f"%s processing event %s", self.describe(), event)
+            self._logger.debug(f"{self.describe()} processing event {event}")
         self._strategy.process(
             event,
             generic_tree=self._generic_tree,

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -76,6 +76,7 @@ class Pipeline:
         """Mean processing time for one event"""
         _mean_processing_time_sample_counter: int = 0
 
+        # pylint: disable=not-an-iterable
         @property
         def number_of_processed_events(self):
             """Sum of all processed events of all processors"""
@@ -90,6 +91,8 @@ class Pipeline:
         def number_of_errors(self):
             """Sum of all errors of all processors"""
             return np.sum([processor.number_of_errors for processor in self.pipeline])
+
+        # pylint: enable=not-an-iterable
 
         def update_mean_processing_time_per_event(self, new_sample):
             """Updates the mean processing time per event"""

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -207,7 +207,7 @@ class Pipeline:
         self._enable_iteration()
         try:
             if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
-                self._logger.debug("Start iterating (%s)", current_process().name)
+                self._logger.debug(f"Start iterating ({current_process().name})")
             while self._iterate():
                 self._retrieve_and_process_data()
         except SourceDisconnectedError:

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -164,9 +164,9 @@ def main():
     TimeMeasurement.APPEND_TO_EVENT = measure_time_config.get("append_to_event", False)
 
     if logger.isEnabledFor(DEBUG):  # pragma: no cover
-        logger.debug("Metric export enabled: %s", config.get("metrics", {}).get("enabled", False))
-        logger.debug("Time measurement enabled: %s", TimeMeasurement.TIME_MEASUREMENT_ENABLED)
-        logger.debug("Config path: %s", args.config)
+        logger.debug(f'Metric export enabled: {config.get("metrics", {}).get("enabled", False)}')
+        logger.debug(f"Time measurement enabled: {TimeMeasurement.TIME_MEASUREMENT_ENABLED}")
+        logger.debug(f"Config path: {args.config}")
     if args.validate_rules or args.auto_test:
         type_rule_map = get_processor_type_and_rule_class()
         rules_valid = []

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 """This module can be used to start the logprep."""
+# pylint: disable=logging-fstring-interpolation
 import inspect
 import os
 import sys
@@ -140,7 +141,7 @@ def main():
     try:
         AggregatingLogger.setup(config, logger_disabled=args.disable_logging)
         logger = AggregatingLogger.create("Logprep")
-    except BaseException as error:
+    except BaseException as error:  # pylint: disable=broad-except
         getLogger("Logprep").exception(error)
         sys.exit(1)
 
@@ -151,7 +152,7 @@ def main():
             config.verify(logger)
     except InvalidConfigurationError:
         sys.exit(1)
-    except BaseException as error:
+    except BaseException as error:  # pylint: disable=broad-except
         logger.exception(error)
         sys.exit(1)
 


### PR DESCRIPTION
Fix pickling error in debug, but also remove some lazy logging, since the aggregator aggregates the strings ("... %s ...") before they get replaced with variables if it's being used.