### PR TITLE
Fix time measurement for get_next input connector

### DIFF
--- a/logprep/util/time_measurement.py
+++ b/logprep/util/time_measurement.py
@@ -28,7 +28,7 @@ class TimeMeasurement:
             def inner(*args, **kwargs):  # nosemgrep
                 if TimeMeasurement.TIME_MEASUREMENT_ENABLED:
                     caller = args[0]
-                    event = args[1]
+                    first_argument = args[1]
                     begin = time()
                     result = func(*args, **kwargs)
                     end = time()
@@ -39,8 +39,8 @@ class TimeMeasurement:
                         if hasattr(caller.metrics, "update_mean_processing_time_per_event"):
                             caller.metrics.update_mean_processing_time_per_event(processing_time)
 
-                    if TimeMeasurement.APPEND_TO_EVENT:
-                        add_processing_times_to_event(event, processing_time, caller, name)
+                    if TimeMeasurement.APPEND_TO_EVENT and isinstance(first_argument, dict):
+                        add_processing_times_to_event(first_argument, processing_time, caller, name)
                     return result
                 return func(*args, **kwargs)
 

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -16,6 +16,7 @@ from logprep.abc.input import Input
 from logprep.abc.output import Output
 from logprep.factory import Factory
 from logprep.util.helper import camel_to_snake
+from logprep.util.time_measurement import TimeMeasurement
 
 
 class BaseConnectorTestCase(ABC):
@@ -432,6 +433,17 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
         assert test_event == {"any": "content"}
+
+    def test_get_next_returns_event_with_active_time_measurement(self):
+        TimeMeasurement.TIME_MEASUREMENT_ENABLED = True
+        TimeMeasurement.APPEND_TO_EVENT = True
+        return_value = ({"message": "test message"}, b'{"message": "test message"}')
+        self.object._get_event = mock.MagicMock(return_value=return_value)
+        event, _ = self.object.get_next(0.01)
+        assert isinstance(event, dict)
+        assert self.object.metrics.mean_processing_time_per_event > 0
+        TimeMeasurement.TIME_MEASUREMENT_ENABLED = False
+        TimeMeasurement.APPEND_TO_EVENT = False
 
 
 class BaseOutputTestCase(BaseConnectorTestCase):


### PR DESCRIPTION
The `TimeMeasurement.measure_time` decorator was initially designed for processing times of the processors, but was recently also used for the input connectors. If the time measurement was enabled and was configured to append the result to the event it resulted in an error as the input connector method `get_next` does not receive an event as an argument, instead it receives a timeout argument. 

This fix introduces a check if the given argument is a dictionary or not.
Alternative solution would be to check if the `caller` is of type `Input`.

closes #189