### PR TITLE
fix keyerror for message with setted _op_type field

### DIFF
--- a/logprep/connector/elasticsearch/output.py
+++ b/logprep/connector/elasticsearch/output.py
@@ -225,9 +225,11 @@ class ElasticsearchOutput(Output):
         """
         error_documents = []
         for bulk_error in error.errors:
-            error_info = bulk_error.get("index", {})
-            data = error_info.get("data")
-            reason = f'{error_info["error"]["type"]}: {error_info["error"]["reason"]}'
+            _, error_info = bulk_error.popitem()
+            data = error_info.get("data") if "data" in error_info else None
+            error_type = error_info.get("error").get("type")
+            error_reason = error_info.get("error").get("reason")
+            reason = f"{error_type}: {error_reason}"
             error_document = self._build_failed_index_document(data, reason)
             self._add_dates(error_document)
             error_documents.append(error_document)

--- a/logprep/connector/opensearch/output.py
+++ b/logprep/connector/opensearch/output.py
@@ -122,7 +122,7 @@ class OpensearchOutput(ElasticsearchOutput):
             data = error_info.get("data") if "data" in error_info else None
             error_type = error_info.get("error").get("type")
             error_reason = error_info.get("error").get("reason")
-            reason = f'{error_type}: {error_reason}'
+            reason = f"{error_type}: {error_reason}"
             error_document = self._build_failed_index_document(data, reason)
             self._add_dates(error_document)
             error_documents.append(error_document)

--- a/logprep/connector/opensearch/output.py
+++ b/logprep/connector/opensearch/output.py
@@ -118,9 +118,11 @@ class OpensearchOutput(ElasticsearchOutput):
         """
         error_documents = []
         for bulk_error in error.errors:
-            error_info = bulk_error.get("index", {})
-            data = error_info.get("data")
-            reason = f'{error_info["error"]["type"]}: {error_info["error"]["reason"]}'
+            _, error_info = bulk_error.popitem()
+            data = error_info.get("data") if "data" in error_info else None
+            error_type = error_info.get("error").get("type")
+            error_reason = error_info.get("error").get("reason")
+            reason = f'{error_type}: {error_reason}'
             error_document = self._build_failed_index_document(data, reason)
             self._add_dates(error_document)
             error_documents.append(error_document)

--- a/tests/unit/connector/test_opensearch_output.py
+++ b/tests/unit/connector/test_opensearch_output.py
@@ -199,6 +199,20 @@ class TestOpenSearchOutput(BaseOutputTestCase):
         fake_bulk.assert_called()
 
     @mock.patch("logprep.connector.opensearch.output.opensearch.helpers.bulk")
+    def test__handle_bulk_index_error_calls_bulk_for_special_op_type(self, fake_bulk):
+        mock_bulk_index_error = mock.MagicMock()
+        mock_bulk_index_error.errors = [
+            {
+                "create": {
+                    "data": {"my": "document"},
+                    "error": {"type": "myerrortype", "reason": "myreason"},
+                }
+            }
+        ]
+        self.object._handle_bulk_index_error(mock_bulk_index_error)
+        fake_bulk.assert_called()
+
+    @mock.patch("logprep.connector.opensearch.output.opensearch.helpers.bulk")
     def test__handle_bulk_index_error_calls_bulk_with_error_documents(self, fake_bulk):
         mock_bulk_index_error = mock.MagicMock()
         mock_bulk_index_error.errors = [


### PR DESCRIPTION
this fixes a keyerror if the document has a special _op_type field, which we are using to write to data_streams.
the key for the error info will become `create` instead of `index` if you are using a field `"op_type": "create"` in your document