### PR TITLE
Fix non-deterministic behavior

### DIFF
--- a/logprep/framework/rule_tree/rule_tree.py
+++ b/logprep/framework/rule_tree/rule_tree.py
@@ -2,7 +2,7 @@
 
 from json import load
 from logging import Logger
-from typing import List, Set
+from typing import List
 
 import numpy as np
 from attr import define, Factory
@@ -176,9 +176,7 @@ class RuleTree:
         """
         return self._rule_mapping[rule]
 
-    def get_matching_rules(
-        self, event: dict, current_node: Node = None, matches: Set[Rule] = None
-    ) -> Set[Rule]:
+    def get_matching_rules(self, event: dict) -> List[Rule]:
         """Get all rules in the tree that match given event.
 
         This function gets all rules that were added to the rule tree that match a given event.
@@ -194,30 +192,27 @@ class RuleTree:
         ----------
         event: dict
             Event dictionary that is used to check rules.
-        current_node: Node
-            Tree node that is currently investigated in recursive matching process.
-        matches: Set[Rule]
-            Set of matching rules that is extended in recursive matching process.
 
         Returns
         -------
-        matches: Set[Rule]
+        matches: List[Rule]
             Set of rules that match the given event.
-
         """
-        if not current_node:
-            current_node = self._root
-            matches = set()
+        matches = []
+        matching_rules = self._retrieve_matching_rules(event, self.root, matches)
+        matching_rules = list(dict.fromkeys(matching_rules))
+        return matching_rules
 
+    def _retrieve_matching_rules(
+        self, event: dict, current_node: Node = None, matches: List[Rule] = None
+    ) -> list:
+        """Recursively iterate through the rule tree to retrieve matching rules."""
         for child in current_node.children:
             if child.does_match(event):
                 current_node = child
-
-                for matching_rule in current_node.matching_rules:
-                    matches.add(matching_rule)
-
-                self.get_matching_rules(event, current_node, matches)
-
+                if current_node.matching_rules:
+                    matches += child.matching_rules
+                self._retrieve_matching_rules(event, current_node, matches)
         return matches
 
     def print(self, current_node: Node = None, depth: int = 1):

--- a/tests/unit/framework/rule_tree/test_rule_tree.py
+++ b/tests/unit/framework/rule_tree/test_rule_tree.py
@@ -161,7 +161,9 @@ class TestRuleTree:
             }
         )
         rule_tree.add_rule(rule2)
-        matchings_rules = rule_tree.get_matching_rules({"winlog": "123", "test": "Good", "foo": "bar"})
+        matchings_rules = rule_tree.get_matching_rules(
+            {"winlog": "123", "test": "Good", "foo": "bar"}
+        )
         assert matchings_rules == [rule, rule2]
 
     def test_match_rule_once_with_conjunction_like_sub_rule(self):
@@ -324,7 +326,10 @@ class TestRuleTree:
         )
         rule_tree.add_rule(rule)
 
-        assert rule_tree.get_matching_rules({"abc": "DEF", "foo": {"bar": {"test": "567"}}}) == [rule]
+        matching_rules = rule_tree.get_matching_rules(
+            {"abc": "DEF", "foo": {"bar": {"test": "567"}}}
+        )
+        assert matching_rules == [rule]
 
     def test_match_including_tags(self):
         tag_map = {"winlog": "WINDOWS"}

--- a/tests/unit/processor/selective_extractor/test_selective_extractor.py
+++ b/tests/unit/processor/selective_extractor/test_selective_extractor.py
@@ -94,7 +94,7 @@ class TestSelectiveExtractor(BaseProcessorTestCase):
         assert len(rule_trees) > 0
         for tree in rule_trees:
             matching_rules = tree.get_matching_rules({"message": "the message"})
-            assert isinstance(matching_rules, set)
+            assert isinstance(matching_rules, list)
             assert len(matching_rules) > 0
 
     def test_apply_rules_is_called(self):


### PR DESCRIPTION
The fix of the issue #166 and the corresponding pull request #168 introduced some non-deterministic behavior. Duplicate rules were filtered out by using a python `set` instead of a `list`, which in return resulted in the fact that the rules could be applied in different orders with each retrieval of matching rules. 

This pull requests uses a `list` again and removes duplicates manually by maintaining the original rule order. Also, to ensure this deterministic behavior in the future a new test was added. 