### PR TITLE
dev-add-keychecker-processor

### DIFF
--- a/doc/source/user_manual/configuration/processor.rst
+++ b/doc/source/user_manual/configuration/processor.rst
@@ -128,3 +128,10 @@ Processors
    :undoc-members:
    :inherited-members:
    :noindex:
+
+.. automodule:: logprep.processor.key_checker.processor
+.. autoclass:: logprep.processor.key_checker.processor.KeyChecker.Config
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :noindex:

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -1704,9 +1704,9 @@ The example below deletes the log message if the message field equals "foo".
 
 Key Checker
 =======
-The :code:`Key Checker` checks if the Event has all fields definded in :code:`key_list`. In the example below
-the processor checks if the event has the key :code:`key1`. Because of this is not the case the processor 
-creates the new field :code:`missing_fields` and writes the missing key :code:`key1` in the field.
+The :code:`Key Checker` checks if the Event has all fields definded in :code:`key_list`. In the example below,
+the processor checks if the event has the key :code:`key1`. If this is not the case, the processor 
+creates the new field :code:`missing_fields` and appends the missing key :code:`key1` in the field.
 
 ..  code-block:: yaml
     :linenos:

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -1704,8 +1704,8 @@ The example below deletes the log message if the message field equals "foo".
 
 Key Checker
 =======
-The Key Checker checks if the Event has all fields definded in :code:`key_list`. In the example below
-the processor checks if the event has the key :code:`key1`. That is not the case so the processor 
+The :code:`Key Checker` checks if the Event has all fields definded in :code:`key_list`. In the example below
+the processor checks if the event has the key :code:`key1`. Because of this is not the case the processor 
 creates the new field :code:`missing_fields` and writes the missing key :code:`key1` in the field.
 
 ..  code-block:: yaml

--- a/doc/source/user_manual/rule_language.rst
+++ b/doc/source/user_manual/rule_language.rst
@@ -1702,3 +1702,32 @@ The example below deletes the log message if the message field equals "foo".
 
 .. automodule:: logprep.processor.dissector.rule
 
+Key Checker
+=======
+The Key Checker checks if the Event has all fields definded in :code:`key_list`. In the example below
+the processor checks if the event has the key :code:`key1`. That is not the case so the processor 
+creates the new field :code:`missing_fields` and writes the missing key :code:`key1` in the field.
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: *
+    key_checker:
+      key_list: [
+        'key1'
+      ]
+      output_field: 'missing_fields'
+    description: '...'
+    tests: 
+      raw:  
+            {
+              "testkey": "key1_value",
+              "_index": "value",
+            }
+      result: 
+            {
+              "testkey": "key1_value",
+              "_index": "value",
+              "missing_fields":"key1"
+            }

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -26,13 +26,13 @@ from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
 class KeyChecker(Processor):
-    """Checks if all keys of an given List are in the event"""
+    """Checks if all keys of a given List are in the event"""
 
     rule_class: Rule = KeyCheckerRule
 
     def _apply_rules(self, event, rule):
 
-        not_existing_fields = set([])
+        not_existing_fields = set()
 
         for dotted_field in rule.key_list:
             if not self._field_exists(event=event, dotted_field=dotted_field):

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -2,8 +2,8 @@
 KeyChecker
 ------------
 
-The `key_checker` processor checks for an event if all field-names in
-the given list are in the Event.
+The `key_checker` processor checks if all field names in a provided list are
+given in the processed event.
 
 Example
 ^^^^^^^

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -48,11 +48,11 @@ class KeyChecker(Processor):
                 not_existing_fields.append(dotted_field)
 
         if not_existing_fields:
-            error_field = get_dotted_field_value(event=event, dotted_field="error_field")
-            if error_field:
-                merged_lists = list(set(error_field).union(set(not_existing_fields)))
+            output_field = get_dotted_field_value(event=event, dotted_field="output_field")
+            if output_field:
+                merged_lists = list(set(output_field).union(set(not_existing_fields)))
                 merged_lists.sort()
-                add_field_to(event, rule.error_field, merged_lists)
+                add_field_to(event, rule.output_field, merged_lists)
             else:
                 not_existing_fields.sort()
-                add_field_to(event, rule.error_field, not_existing_fields)
+                add_field_to(event, rule.output_field, not_existing_fields)

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -13,27 +13,6 @@ from logprep.processor.key_checker.rule import KeyCheckerRule
 from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
-class KeyCheckerError(BaseException):
-    """Base class for KeyChecker related exceptions."""
-
-    def __init__(self, name: str, message: str):
-        super().__init__(f"KeyChecker ({name}): {message}")
-
-
-class FieldNotExistingError(KeyCheckerError):
-    """Raise if Key in List isnt in Event."""
-
-    def __init__(self, name: str, not_existing_fields: list):
-        message = "The following fields arent in the Event Log: "
-        for fields in not_existing_fields:
-            if fields == not_existing_fields[-1]:
-                message += fields
-            else:
-                message += fields + ", "
-
-        super().__init__(name, message)
-
-
 class KeyChecker(Processor):
     """Checks if all keys of an given List are in the event"""
 

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -1,11 +1,58 @@
-import imp
+"""
+KeyChecker
+------------
+
+The `key_checker` processor checks for an event if all field-names in
+the given list are in the Event. If thats not the case it......
+
+"""
+
 from logprep.abc import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.key_checker.rule import KeyCheckerRule
+from logprep.util.helper import add_field_to, get_dotted_field_value
+
+
+class KeyCheckerError(BaseException):
+    """Base class for KeyChecker related exceptions."""
+
+    def __init__(self, name: str, message: str):
+        super().__init__(f"KeyChecker ({name}): {message}")
+
+
+class FieldNotExistingError(KeyCheckerError):
+    """Raise if Key in List isnt in Event."""
+
+    def __init__(self, name: str, not_existing_fields: list):
+        message = "The following fields arent in the Event Log: "
+        for fields in not_existing_fields:
+            if fields == not_existing_fields[-1]:
+                message += fields
+            else:
+                message += fields + ", "
+
+        super().__init__(name, message)
 
 
 class KeyChecker(Processor):
+    """Checks if all keys of an given List are in the event"""
+
     rule_class: Rule = KeyCheckerRule
 
     def _apply_rules(self, event, rule):
-        return super()._apply_rules(event, rule)
+
+        not_existing_fields = []
+
+        for dotted_field in rule.key_list:
+            if not self._field_exists(event=event, dotted_field=dotted_field):
+                not_existing_fields.append(dotted_field)
+
+        if not_existing_fields:
+            error_field = get_dotted_field_value(event=event, dotted_field="error_field")
+            if error_field:
+                merged_lists = list(set(error_field).union(set(not_existing_fields)))
+                merged_lists.sort()
+                add_field_to(event, rule.error_field, merged_lists)
+            else:
+                not_existing_fields.sort()
+                add_field_to(event, rule.error_field, not_existing_fields)

--- a/logprep/processor/key_checker/processor.py
+++ b/logprep/processor/key_checker/processor.py
@@ -1,0 +1,11 @@
+import imp
+from logprep.abc import Processor
+from logprep.processor.base.rule import Rule
+from logprep.processor.key_checker.rule import KeyCheckerRule
+
+
+class KeyChecker(Processor):
+    rule_class: Rule = KeyCheckerRule
+
+    def _apply_rules(self, event, rule):
+        return super()._apply_rules(event, rule)

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -59,14 +59,15 @@ class KeyCheckerRule(Rule):
     class Config:
         """key_checker rule config"""
 
-        key_list: list = field(
+        key_list: set = field(
             validator=[
                 validators.deep_iterable(
                     member_validator=validators.instance_of(str),
-                    iterable_validator=validators.instance_of(list),
+                    iterable_validator=validators.instance_of(set),
                 ),
                 partial(min_len_validator, min_length=1),
-            ]
+            ],
+            converter=set,
         )
 
         output_field: str = field(validator=validators.instance_of(str))

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -34,7 +34,7 @@ class KeyCheckerRule(Rule):
             ]
         )
 
-        error_field: str = field(validator=validators.instance_of(str))
+        output_field: str = field(validator=validators.instance_of(str))
 
     def __eq__(self, other: "KeyCheckerRule") -> bool:
         return all([other.filter == self._filter, other._config == self._config])
@@ -48,8 +48,8 @@ class KeyCheckerRule(Rule):
         return self._config.key_list
 
     @property
-    def error_field(self) -> str:  # pylint: disable=missing-docstring
-        return self._config.error_field
+    def output_field(self) -> str:  # pylint: disable=missing-docstring
+        return self._config.output_field
 
     @staticmethod
     def _create_from_dict(rule: dict) -> "KeyCheckerRule":

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -1,25 +1,55 @@
+"""
+KeyCheckerRule
+------------
+
+The `key_checker` processor needs a list with atleast one element in it.
+
+"""
+from functools import partial
+
+from attrs import define, field, validators
+
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.base.rule import Rule
 
 
+from logprep.util.validators import min_len_validator
+
+
 class KeyCheckerRule(Rule):
+    """key_checker rule"""
+
+    @define(kw_only=True)
     class Config:
-        pass
+        """key_checker rule config"""
+
+        key_list: list = field(
+            validator=[
+                validators.deep_iterable(
+                    member_validator=validators.instance_of(str),
+                    iterable_validator=validators.instance_of(list),
+                ),
+                partial(min_len_validator, min_length=1),
+            ]
+        )
+
+        error_field: str = field(validator=validators.instance_of(str))
+
+    def __eq__(self, other: "KeyCheckerRule") -> bool:
+        return all([other.filter == self._filter, other._config == self._config])
 
     def __init__(self, filter_rule: FilterExpression, config: "KeyCheckerRule.Config"):
-        """
-        Instantiate ConcatenatorRule based on a given filter and processor configuration.
-
-        Parameters
-        ----------
-        filter_rule : FilterExpression
-            Given lucene filter expression as a representation of the rule's logic.
-        config : "ConcatenatorRule.Config"
-            Configuration fields from a given pipeline that refer to the processor instance.
-        """
         super().__init__(filter_rule)
         self._config = config
+
+    @property
+    def key_list(self) -> list:  # pylint: disable=missing-docstring
+        return self._config.key_list
+
+    @property
+    def error_field(self) -> str:  # pylint: disable=missing-docstring
+        return self._config.error_field
 
     @staticmethod
     def _create_from_dict(rule: dict) -> "KeyCheckerRule":

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -3,8 +3,43 @@ KeyCheckerRule
 ------------
 
 The `key_checker` processor needs a list with atleast one element in it.
+The Rule contains this list and it also contains a missing field where the processor
+can store all missing keys.
 
+..  code-block:: yaml
+    :linenos:
+    :caption: Given key_checker rule
+
+    filter: *
+    key_checker: {
+            key_list: [
+                "key1",
+                "key2",
+            ],
+            output_field: "missing_fields"
+        },
+    description: '...'
+
+..  code-block:: json
+    :linenos:
+    :caption: Incoming event
+
+    {
+        testkey: "key1_value",
+        _index: "value",
+    }
+
+..  code-block:: json
+    :linenos:
+    :caption: Processed event
+
+    {
+        testkey: "key1_value",
+        _index: "value",
+        missing_fields: "key1","key2"
+    }
 """
+
 from functools import partial
 
 from attrs import define, field, validators

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -1,0 +1,31 @@
+from logprep.filter.expression.filter_expression import FilterExpression
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.base.rule import Rule
+
+
+class KeyCheckerRule(Rule):
+    class Config:
+        pass
+
+    def __init__(self, filter_rule: FilterExpression, config: "KeyCheckerRule.Config"):
+        """
+        Instantiate ConcatenatorRule based on a given filter and processor configuration.
+
+        Parameters
+        ----------
+        filter_rule : FilterExpression
+            Given lucene filter expression as a representation of the rule's logic.
+        config : "ConcatenatorRule.Config"
+            Configuration fields from a given pipeline that refer to the processor instance.
+        """
+        super().__init__(filter_rule)
+        self._config = config
+
+    @staticmethod
+    def _create_from_dict(rule: dict) -> "KeyCheckerRule":
+        filter_expression = Rule._create_filter_expression(rule)
+        config = rule.get("key_checker")
+        if not isinstance(config, dict):
+            raise InvalidRuleDefinitionError("config is not a dict")
+        config = KeyCheckerRule.Config(**config)
+        return KeyCheckerRule(filter_expression, config)

--- a/logprep/processor/key_checker/rule.py
+++ b/logprep/processor/key_checker/rule.py
@@ -2,8 +2,8 @@
 KeyCheckerRule
 ------------
 
-The `key_checker` processor needs a list with atleast one element in it.
-The Rule contains this list and it also contains a missing field where the processor
+The `key_checker` processor needs a list with at least one element in it.
+The Rule contains this list and it also contains a custom field where the processor
 can store all missing keys.
 
 ..  code-block:: yaml

--- a/logprep/registry.py
+++ b/logprep/registry.py
@@ -25,6 +25,7 @@ from logprep.processor.generic_adder.processor import GenericAdder
 from logprep.processor.generic_resolver.processor import GenericResolver
 from logprep.processor.geoip_enricher.processor import GeoipEnricher
 from logprep.processor.hyperscan_resolver.processor import HyperscanResolver
+from logprep.processor.key_checker.processor import KeyChecker
 from logprep.processor.labeler.processor import Labeler
 from logprep.processor.list_comparison.processor import ListComparison
 from logprep.processor.normalizer.processor import Normalizer
@@ -51,6 +52,7 @@ class Registry:
         "generic_resolver": GenericResolver,
         "geoip_enricher": GeoipEnricher,
         "hyperscan_resolver": HyperscanResolver,
+        "key_checker": KeyChecker,
         "labeler": Labeler,
         "list_comparison": ListComparison,
         "normalizer": Normalizer,

--- a/tests/testdata/unit/key_checker/key_checker_rule.json
+++ b/tests/testdata/unit/key_checker/key_checker_rule.json
@@ -1,0 +1,7 @@
+[
+    {
+        "filter": "message",
+        "key_checker": {},
+        "description": "do nothing rule for dissector"
+    }
+]

--- a/tests/testdata/unit/key_checker/key_checker_rule.json
+++ b/tests/testdata/unit/key_checker/key_checker_rule.json
@@ -1,7 +1,14 @@
 [
     {
-        "filter": "message",
-        "key_checker": {},
-        "description": "do nothing rule for dissector"
+        "filter": "*",
+        "key_checker": {
+            "key_list": [
+                "key1",
+                "key2",
+                "key1.key2"
+            ],
+            "error_field": "error_field"
+        },
+        "description": "rule for key_checker"
     }
 ]

--- a/tests/testdata/unit/key_checker/key_checker_rule.json
+++ b/tests/testdata/unit/key_checker/key_checker_rule.json
@@ -7,7 +7,7 @@
                 "key2",
                 "key1.key2"
             ],
-            "error_field": "error_field"
+            "output_field": "missing_fields"
         },
         "description": "rule for key_checker"
     }

--- a/tests/unit/processor/key_checker/test_key_checker.py
+++ b/tests/unit/processor/key_checker/test_key_checker.py
@@ -1,4 +1,30 @@
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+# pylint: disable=import-error
+import pytest
+
 from tests.unit.processor.base import BaseProcessorTestCase
+
+test_cases = [  # testcase, rule, event, expected
+    (
+        "writes new fields with same separator",
+        {
+            "filter": "*",
+            "key_checker": {
+                "key_list": ["key2"],
+                "error_field": "missing_fields",
+            },
+        },
+        {"bla": {"key1": "key1_value", "_index": "value"}},
+        {
+            "bla": {
+                "key1": "key1_value",
+                "_index": "value",
+            },
+            "missing_fields": ["key2"],
+        },
+    ),
+]
 
 
 class TestKeyChecker(BaseProcessorTestCase):
@@ -9,3 +35,17 @@ class TestKeyChecker(BaseProcessorTestCase):
         "specific_rules": ["tests/testdata/unit/key_checker/"],
         "generic_rules": ["tests/testdata/unit/key_checker/"],
     }
+
+    @property
+    def generic_rules_dirs(self):
+        return self.CONFIG["generic_rules"]
+
+    @property
+    def specific_rules_dirs(self):
+        return self.CONFIG["specific_rules"]
+
+    @pytest.mark.parametrize("testcase, rule, event, expected", test_cases)
+    def test_testcases(self, testcase, rule, event, expected):  # pylint: disable=unused-argument
+        self._load_specific_rule(rule)
+        self.object.process(event)
+        assert event == expected

--- a/tests/unit/processor/key_checker/test_key_checker.py
+++ b/tests/unit/processor/key_checker/test_key_checker.py
@@ -132,6 +132,55 @@ test_cases = [  # testcase, rule, event, expected
             }
         },
     ),
+    (
+        "Detect key duplication",
+        {
+            "filter": "*",
+            "key_checker": {
+                "key_list": ["key1", "key1"],
+                "output_field": "missing_fields",
+            },
+        },
+        {
+            "randomkey": {
+                "key2": {"key3": {"key3": "key3_value"}, "random_key": "random_key_value"},
+                "_index": "value",
+            },
+            "randomkey2": "randomvalue2",
+        },
+        {
+            "randomkey": {
+                "key2": {"key3": {"key3": "key3_value"}, "random_key": "random_key_value"},
+                "_index": "value",
+            },
+            "randomkey2": "randomvalue2",
+            "missing_fields": ["key1"],
+        },
+    ),
+    (
+        "Detect key duplication2",
+        {
+            "filter": "*",
+            "key_checker": {
+                "key_list": ["key1", "key1"],
+                "output_field": "missing_fields",
+            },
+        },
+        {
+            "key1": {
+                "key2": {"key3": {"key3": "key3_value"}, "random_key": "random_key_value"},
+                "_index": "value",
+            },
+            "randomkey2": "randomvalue2",
+        },
+        {
+            "key1": {
+                "key2": {"key3": {"key3": "key3_value"}, "random_key": "random_key_value"},
+                "_index": "value",
+            },
+            "randomkey2": "randomvalue2",
+        },
+    ),
 ]
 
 

--- a/tests/unit/processor/key_checker/test_key_checker.py
+++ b/tests/unit/processor/key_checker/test_key_checker.py
@@ -1,0 +1,11 @@
+from tests.unit.processor.base import BaseProcessorTestCase
+
+
+class TestKeyChecker(BaseProcessorTestCase):
+    timeout = 0.01
+
+    CONFIG = {
+        "type": "key_checker",
+        "specific_rules": ["tests/testdata/unit/key_checker/"],
+        "generic_rules": ["tests/testdata/unit/key_checker/"],
+    }

--- a/tests/unit/processor/key_checker/test_key_checker_rule.py
+++ b/tests/unit/processor/key_checker/test_key_checker_rule.py
@@ -1,2 +1,95 @@
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+# pylint: disable=import-error
+
+import pytest
+from logprep.processor.key_checker.rule import KeyCheckerRule
+
+
 class TestKeyCheckerRule:
-    pass
+    @pytest.mark.parametrize(
+        ["rule", "error", "message"],
+        [
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": ["key1", "key2", "key1.key2"],
+                        "error_field": "",
+                    },
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": ["key1"],
+                        "error_field": "",
+                    },
+                },
+                None,
+                None,
+            ),
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": ["key1.key2"],
+                        "error_field": "",
+                    },
+                },
+                None,
+                None,
+            ),
+            (
+                {"filter": "message", "key_checker": {}},
+                TypeError,
+                "missing 2 required keyword-only arguments: 'key_list' and 'error_field'",
+            ),
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": [],
+                        "error_field": "",
+                    },
+                },
+                ValueError,
+                "Length of 'key_list' must be => 1: 0",
+            ),
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": "not a list",
+                        "error_field": "",
+                    },
+                },
+                TypeError,
+                "'key_list' must be <class 'list'",
+            ),
+            (
+                {
+                    "filter": "message",
+                    "key_checker": {
+                        "key_list": [1, 2, 3],
+                        "error_field": False,
+                    },
+                },
+                TypeError,
+                "'key_list' must be <class 'str'",
+            ),
+        ],
+    )
+    def test_create_from_dict_validates_config(self, rule, error, message):
+        if error:
+            with pytest.raises(error, match=message):
+                KeyCheckerRule._create_from_dict(rule)
+        else:
+            keychecker_rule = KeyCheckerRule._create_from_dict(rule)
+            assert hasattr(keychecker_rule, "_config")
+            for key, value in rule.get("key_checker").items():
+                assert hasattr(keychecker_rule._config, key)
+                assert value == getattr(keychecker_rule._config, key)

--- a/tests/unit/processor/key_checker/test_key_checker_rule.py
+++ b/tests/unit/processor/key_checker/test_key_checker_rule.py
@@ -15,7 +15,7 @@ class TestKeyCheckerRule:
                     "filter": "message",
                     "key_checker": {
                         "key_list": ["key1", "key2", "key1.key2"],
-                        "error_field": "",
+                        "output_field": "",
                     },
                 },
                 None,
@@ -26,7 +26,7 @@ class TestKeyCheckerRule:
                     "filter": "message",
                     "key_checker": {
                         "key_list": ["key1"],
-                        "error_field": "",
+                        "output_field": "",
                     },
                 },
                 None,
@@ -37,7 +37,7 @@ class TestKeyCheckerRule:
                     "filter": "message",
                     "key_checker": {
                         "key_list": ["key1.key2"],
-                        "error_field": "",
+                        "output_field": "",
                     },
                 },
                 None,
@@ -46,14 +46,14 @@ class TestKeyCheckerRule:
             (
                 {"filter": "message", "key_checker": {}},
                 TypeError,
-                "missing 2 required keyword-only arguments: 'key_list' and 'error_field'",
+                "missing 2 required keyword-only arguments: 'key_list' and 'output_field'",
             ),
             (
                 {
                     "filter": "message",
                     "key_checker": {
                         "key_list": [],
-                        "error_field": "",
+                        "output_field": "",
                     },
                 },
                 ValueError,
@@ -64,7 +64,7 @@ class TestKeyCheckerRule:
                     "filter": "message",
                     "key_checker": {
                         "key_list": "not a list",
-                        "error_field": "",
+                        "output_field": "",
                     },
                 },
                 TypeError,
@@ -75,7 +75,7 @@ class TestKeyCheckerRule:
                     "filter": "message",
                     "key_checker": {
                         "key_list": [1, 2, 3],
-                        "error_field": False,
+                        "output_field": "",
                     },
                 },
                 TypeError,

--- a/tests/unit/processor/key_checker/test_key_checker_rule.py
+++ b/tests/unit/processor/key_checker/test_key_checker_rule.py
@@ -1,0 +1,2 @@
+class TestKeyCheckerRule:
+    pass

--- a/tests/unit/processor/key_checker/test_key_checker_rule.py
+++ b/tests/unit/processor/key_checker/test_key_checker_rule.py
@@ -63,17 +63,6 @@ class TestKeyCheckerRule:
                 {
                     "filter": "message",
                     "key_checker": {
-                        "key_list": "not a list",
-                        "output_field": "missing_fields",
-                    },
-                },
-                TypeError,
-                "'key_list' must be <class 'list'",
-            ),
-            (
-                {
-                    "filter": "message",
-                    "key_checker": {
                         "key_list": [1, 2, 3],
                         "output_field": "missing_fields",
                     },
@@ -102,18 +91,27 @@ class TestKeyCheckerRule:
             assert hasattr(keychecker_rule, "_config")
             for key, value in rule.get("key_checker").items():
                 assert hasattr(keychecker_rule._config, key)
-                assert value == getattr(keychecker_rule._config, key)
+                sad = type(value)
+                temp_list = list(getattr(keychecker_rule._config, key))
+                temp_list.sort()
+                if isinstance(value, list):
+                    temp_list = list(getattr(keychecker_rule._config, key))
+                    temp_list.sort()
+                    value.sort()
+                    assert value == temp_list
+                else:
+                    assert value == getattr(keychecker_rule._config, key)
 
     @pytest.mark.parametrize(
         ["testcase", "rule1", "rule2", "equality"],
         [
             (
-                "should be equal, because only the name has changed",
+                "should not be equal, because the name is different",
                 {
                     "filter": "*",
                     "key_checker": {
                         "key_list": ["key1"],
-                        "output_field": "",
+                        "output_field": "missing_fields",
                     },
                 },
                 {
@@ -123,7 +121,7 @@ class TestKeyCheckerRule:
                         "output_field": "missing_fields",
                     },
                 },
-                True,
+                False,
             ),
             (
                 "should be equal, because only the order has changed",
@@ -131,7 +129,7 @@ class TestKeyCheckerRule:
                     "filter": "*",
                     "key_checker": {
                         "key_list": ["key1", "key2"],
-                        "output_field": "",
+                        "output_field": "missing_fields",
                     },
                 },
                 {

--- a/tests/unit/processor/key_checker/test_key_checker_rule.py
+++ b/tests/unit/processor/key_checker/test_key_checker_rule.py
@@ -91,7 +91,6 @@ class TestKeyCheckerRule:
             assert hasattr(keychecker_rule, "_config")
             for key, value in rule.get("key_checker").items():
                 assert hasattr(keychecker_rule._config, key)
-                sad = type(value)
                 temp_list = list(getattr(keychecker_rule._config, key))
                 temp_list.sort()
                 if isinstance(value, list):
@@ -158,6 +157,24 @@ class TestKeyCheckerRule:
                     },
                 },
                 False,
+            ),
+            (
+                "should be equal, because unique keys are the same",
+                {
+                    "filter": "*",
+                    "key_checker": {
+                        "key_list": ["key1", "key2", "key2"],
+                        "output_field": "missing_fields",
+                    },
+                },
+                {
+                    "filter": "*",
+                    "key_checker": {
+                        "key_list": ["key1", "key1", "key2"],
+                        "output_field": "missing_fields",
+                    },
+                },
+                True,
             ),
         ],
     )


### PR DESCRIPTION
The processor gets a list of event fields and compares these fields with the fields of a given event. If fields from the List are missing in the event, the processor creates a "missing_fields" field in the Event and writes all missing fields in this new field.