### PR TITLE
reimplement get_dotted_field_value

### DIFF
--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,6 +1,6 @@
 """This module contains helper functions that are shared by different modules."""
 import re
-from functools import partial
+from functools import partial, reduce
 from os import remove
 from typing import Optional, Union
 
@@ -109,10 +109,13 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         The value of the requested dotted field.
     """
 
-    fields = dotted_field.split(".")
-    return _retrieve_field_value_and_delete_field_if_configured(
-        event, fields, delete_source_field=False
-    )
+    fields = [event, *dotted_field.split(".")]
+    try:
+        return reduce(dict.__getitem__, fields)
+    except KeyError:
+        return None
+    except TypeError:
+        return None
 
 
 def pop_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dict, list, str]]:


### PR DESCRIPTION
This is a reimplementation of the `get_dotted_field_value` based on python builtin `functools.reduce` function.
It is much faster and I guess  it scales in O(n) if the depth increases.
The original time complexity was O(n*n).

This was my testcode for performance measurement:

```python
from logprep.util.helper import get_dotted_field_value, _retrieve_field_value_and_delete_field_if_configured
from time import perf_counter

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    get_dotted_field_value(testdict, "key1.key2.key3")
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    get_dotted_field_value(testdict, "key1.key2.key3.key4.key5")
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    get_dotted_field_value(testdict, "key1.key2.key3.key4.key5.key6")
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    fields = "key1.key2.key3".split(".")
    _retrieve_field_value_and_delete_field_if_configured(testdict, fields)
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    fields = "key1.key2.key3.key4".split(".")
    _retrieve_field_value_and_delete_field_if_configured(testdict, fields)
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    fields = "key1.key2.key3.key4.key5".split(".")
    _retrieve_field_value_and_delete_field_if_configured(testdict, fields)
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    fields = "key1.key2.key3.key4.key5.key6".split(".")
    _retrieve_field_value_and_delete_field_if_configured(testdict, fields)
    
print(perf_counter() - start)
```

My results for the reimplementation were:

```
0.41639920699526556
0.4441328860120848
0.48215398599859327
```

and for the old implementation:

```
0.6929165629844647
0.8572491399827413
1.0821901469898876
1.3071544179983903
```
