### PR TITLE
Fix add version info preprocessor and revice tests

### DIFF
--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -172,8 +172,10 @@ class Pipeline:
         input_connector_config = self._logprep_config.get("input")
         connector_name = list(input_connector_config.keys())[0]
         input_connector_config[connector_name]["metric_labels"] = self._metric_labels
+        input_connector_config[connector_name].update(
+            {"version_information": self._event_version_information}
+        )
         self._input = Factory.create(input_connector_config, self._logger)
-        input_connector_config.update({"version_information": self._event_version_information})
         output_connector_config = self._logprep_config.get("output")
         connector_name = list(output_connector_config.keys())[0]
         output_connector_config[connector_name]["metric_labels"] = self._metric_labels

--- a/tests/acceptance/test_preprocessing.py
+++ b/tests/acceptance/test_preprocessing.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-docstring
+# pylint: disable=no-self-use
+from logging import getLogger, DEBUG, basicConfig
+
+import pytest
+
+from logprep.util.json_handling import dump_config_as_file
+from tests.acceptance.util import (
+    get_default_logprep_config,
+    get_test_output,
+)
+
+basicConfig(level=DEBUG, format="%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s")
+logger = getLogger("Logprep-Test")
+
+
+@pytest.fixture(name="config")
+def get_config():
+    pipeline = [
+        {
+            "normalizername": {
+                "type": "normalizer",
+                "specific_rules": ["tests/testdata/acceptance/normalizer/rules_static/specific"],
+                "generic_rules": ["tests/testdata/acceptance/normalizer/rules_static/generic"],
+                "regex_mapping": "tests/testdata/acceptance/normalizer/rules_static/regex_mapping.yml",
+            }
+        }
+    ]
+    return get_default_logprep_config(pipeline, with_hmac=False)
+
+
+class TestVersionInfoTargetField:
+
+    def test_preprocessor_adds_version_information(self, tmp_path, config):
+        config["input"]["jsonl"].update({
+            "documents_path": "tests/testdata/input_logdata/selective_extractor_events.jsonl",
+            "preprocessing": {"version_info_target_field": "version_info"}
+        })
+
+        config_path = str(tmp_path / "generated_config.yml")
+        dump_config_as_file(config_path, config)
+        test_output, _, __ = get_test_output(config_path)
+        assert test_output, "should not be empty"
+        processed_event = test_output[0]
+        assert processed_event.get("version_info", {}).get("logprep"), "no logprep version info found"
+        assert processed_event.get("version_info", {}).get("configuration"), "no config version info found"

--- a/tests/acceptance/test_preprocessing.py
+++ b/tests/acceptance/test_preprocessing.py
@@ -30,17 +30,22 @@ def get_config():
 
 
 class TestVersionInfoTargetField:
-
     def test_preprocessor_adds_version_information(self, tmp_path, config):
-        config["input"]["jsonl"].update({
-            "documents_path": "tests/testdata/input_logdata/selective_extractor_events.jsonl",
-            "preprocessing": {"version_info_target_field": "version_info"}
-        })
+        config["input"]["jsonl"].update(
+            {
+                "documents_path": "tests/testdata/input_logdata/selective_extractor_events.jsonl",
+                "preprocessing": {"version_info_target_field": "version_info"},
+            }
+        )
 
         config_path = str(tmp_path / "generated_config.yml")
         dump_config_as_file(config_path, config)
         test_output, _, __ = get_test_output(config_path)
         assert test_output, "should not be empty"
         processed_event = test_output[0]
-        assert processed_event.get("version_info", {}).get("logprep"), "no logprep version info found"
-        assert processed_event.get("version_info", {}).get("configuration"), "no config version info found"
+        assert processed_event.get("version_info", {}).get(
+            "logprep"
+        ), "no logprep version info found"
+        assert processed_event.get("version_info", {}).get(
+            "configuration"
+        ), "no config version info found"

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -96,6 +96,7 @@ class TmpFileProducerMock:
 
 def get_default_logprep_config(pipeline_config, with_hmac=True):
     config_yml = {
+        "version": "1",
         "process_count": 1,
         "timeout": 0.1,
         "profile_pipelines": False,

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -272,7 +272,8 @@ class BaseInputTestCase(BaseConnectorTestCase):
             "preprocessing": {
                 "version_info_target_field": "version_info",
                 "hmac": {"target": "", "key": "", "output_field": ""},
-            }
+            },
+            "version_information": {"logprep": "3.3.0", "configuration": "unset"},
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
@@ -280,7 +281,8 @@ class BaseInputTestCase(BaseConnectorTestCase):
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
-        assert result.get("version_info")
+        assert result.get("version_info", {}).get("logprep") == "3.3.0"
+        assert result.get("version_info", {}).get("configuration") == "unset"
 
     def test_pipeline_preprocessing_does_not_add_versions_if_target_field_exists_already(self):
         preprocessing_config = {

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -510,7 +510,7 @@ class TestPipeline(ConfigurationForTests):
     ):
         self.pipeline._create_logger()
         self.pipeline._create_connectors()
-        called_input_config = mock_create.call_args_list[0][0][0]
+        called_input_config = mock_create.call_args_list[0][0][0]["dummy"]
         assert "version_information" in called_input_config, "ensure version_information is added"
         assert "logprep" in called_input_config.get("version_information"), "ensure logprep key"
         assert "configuration" in called_input_config.get("version_information"), "ensure config"


### PR DESCRIPTION
The preprocessor that adds the version information didn't really add the corresponding information. It only added always emtpy strings. This pull request fixes this and revises the tests.