### PR TITLE
Adapt rule configuration validation

### DIFF
--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -1,3 +1,4 @@
+# pylint: disable=anomalous-backslash-in-string
 """
 Generic Adder
 =============
@@ -84,6 +85,7 @@ It is also possible to use a table from a MySQL database to add fields to an eve
         destination_field_prefix: nested.dict
     description: '...'
 """
+# pylint: enable=anomalous-backslash-in-string
 
 import re
 from os.path import isfile
@@ -122,7 +124,7 @@ class GenericAdderRule(Rule):
         add: dict = field(
             validator=validators.deep_mapping(
                 key_validator=validators.instance_of(str),
-                value_validator=validators.instance_of(str),
+                value_validator=validators.instance_of((str, bool)),
             ),
             default={},
         )
@@ -160,6 +162,7 @@ class GenericAdderRule(Rule):
             ],
             factory=dict,
         )
+        # pylint: disable=anomalous-backslash-in-string
         """ sql config for generic adder (Optional)
         If a specified field in the table matches a condition, the remaining fields,
         except for the ID field, will be added to the event.
@@ -185,6 +188,8 @@ class GenericAdderRule(Rule):
         Since :code:`destination_field_prefix: nested.dict` is set,
         a newly added field :code:`FOO_NEW` would be placed under :code:`nested.dict.FOO_NEW`.
         """
+
+        # pylint: enable=anomalous-backslash-in-string
 
         def __attrs_post_init__(self):
             if self.add_from_file:

--- a/logprep/processor/pre_detector/rule.py
+++ b/logprep/processor/pre_detector/rule.py
@@ -49,7 +49,7 @@ the IPs from the list is also available in the specified fields.
     - some_ip_field
 """
 
-from typing import Union
+from typing import Union, Optional
 from attrs import define, field, validators, asdict
 
 from logprep.processor.base.rule import Rule
@@ -81,6 +81,10 @@ class PreDetectorRule(Rule):
             validator=validators.instance_of((list, bool)), factory=list
         )
         """tbd"""
+        link: Optional[str] = field(
+            validator=validators.optional(validators.instance_of(str)), default=None
+        )
+        """A link to the rule if applicable."""
 
     def __eq__(self, other: "PreDetectorRule") -> bool:
         return all(
@@ -94,6 +98,8 @@ class PreDetectorRule(Rule):
     @property
     def detection_data(self) -> dict:
         detection_data = asdict(self._config)
+        if self._config.link is None:
+            del detection_data["link"]
         for special_field in Rule.special_field_types:
             detection_data.pop(special_field)
         return detection_data

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -87,3 +87,11 @@ class TestGenericAdderRule:
         rule1 = GenericAdderRule._create_from_dict(specific_rule_definition)
         rule2 = GenericAdderRule._create_from_dict(other_rule_definition)
         assert (rule1 == rule2) == is_equal, testcase
+
+    def test_rule_accepts_bool_type(self):
+        rule_definition = {
+            "filter": "add_generic_test",
+            "generic_adder": {"add": {"added_bool_field": True}},
+        }
+        rule = GenericAdderRule._create_from_dict(rule_definition)
+        assert isinstance(rule.add.get("added_bool_field"), bool)

--- a/tests/unit/processor/pre_detector/test_pre_detector_rule.py
+++ b/tests/unit/processor/pre_detector/test_pre_detector_rule.py
@@ -6,8 +6,8 @@ import pytest
 from logprep.processor.pre_detector.rule import PreDetectorRule
 
 
-@pytest.fixture()
-def specific_rule_definition():
+@pytest.fixture(name="specific_rule_definition")
+def fixture_specific_rule_definition():
     return {
         "filter": "message",
         "pre_detector": {
@@ -169,3 +169,20 @@ class TestPreDetectorRule:
         rule1 = PreDetectorRule._create_from_dict(specific_rule_definition)
         rule2 = PreDetectorRule._create_from_dict(other_rule_definition)
         assert (rule1 == rule2) == is_equal, testcase
+
+        specific_rule_definition["pre_detector"]["link"] = "some_link"
+        other_rule_definition["pre_detector"]["link"] = "some_link"
+        rule1 = PreDetectorRule._create_from_dict(specific_rule_definition)
+        rule2 = PreDetectorRule._create_from_dict(other_rule_definition)
+        assert (rule1 == rule2) == is_equal, f"{testcase} (with link)"
+
+    def test_detection_data_link_is_not_none_does_exists(self, specific_rule_definition):
+        specific_rule_definition["pre_detector"]["link"] = "some_link"
+        rule = PreDetectorRule._create_from_dict(specific_rule_definition)
+        assert "link" in rule.detection_data
+        assert rule.detection_data["link"] == "some_link"
+
+    def test_detection_data_link_is_none_does_not_exist(self, specific_rule_definition):
+        specific_rule_definition["pre_detector"]["link"] = None
+        rule = PreDetectorRule._create_from_dict(specific_rule_definition)
+        assert "link" not in rule.detection_data


### PR DESCRIPTION
The rule configuration validation has become to strict for some cases.
This pull requests aims to restore functionality in the generic adder and the pre detector that was lost due to this.

- In the pre detector an optional field `link` will be validated and and only added if it is not `None`.
- in the generic adder, added fields can have the type bool.