### PR TITLE
refactor add_field_to

### DIFF
--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -73,7 +73,7 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
     """
 
     assert not (
-        extends_lists & overwrite_output_field
+        extends_lists and overwrite_output_field
     ), "An output field can't be overwritten and extended at the same time"
 
     output_field_path = [event, *output_field.split(".")]
@@ -90,14 +90,16 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
         return False
 
     target_field_value = target_field.get(target_key)
-    if extends_lists and isinstance(target_field_value, list):
+    if target_field_value is None:
+        target_field.update({target_key: content})
+        return True
+    if extends_lists:
+        if not isinstance(target_field_value, list):
+            return False
         if isinstance(content, list):
             target_field.update({target_key: [*target_field_value, *content]})
         else:
             target_field_value.append(content)
-        return True
-    if target_field_value is None:
-        target_field.update({target_key: content})
         return True
     return False
 

--- a/tests/unit/util/test_helper_add_field.py
+++ b/tests/unit/util/test_helper_add_field.py
@@ -20,7 +20,6 @@ class TestHelperAddField:
         expected_document = {"source": {"ip": "8.8.8.8"}, "sub": {"field": "content"}}
 
         add_was_successful = add_field_to(document, "sub.field", "content")
-
         assert add_was_successful, "Found duplicate even though there shouldn't be one"
         assert document == expected_document
 
@@ -146,3 +145,9 @@ class TestHelperAddField:
                 extends_lists=True,
                 overwrite_output_field=True,
             )
+
+    def test_returns_false_if_dotted_field_value_key_exists(self):
+        document = {"user": "Franz"}
+        content = ["user_list.txt"]
+        add_was_successful = add_field_to(document, "user.in_list", content)
+        assert not add_was_successful

--- a/tests/unit/util/test_helper_add_field.py
+++ b/tests/unit/util/test_helper_add_field.py
@@ -148,6 +148,23 @@ class TestHelperAddField:
 
     def test_returns_false_if_dotted_field_value_key_exists(self):
         document = {"user": "Franz"}
-        content = ["user_list.txt"]
+        content = ["user_inlist"]
         add_was_successful = add_field_to(document, "user.in_list", content)
         assert not add_was_successful
+
+    def test_add_list_with_nested_keys(self):
+        testdict = {
+            "key1": {"key2": {"key3": {"key4": {"key5": {"list": ["existing"], "key6": "value"}}}}}
+        }
+        expected = {
+            "key1": {
+                "key2": {
+                    "key3": {"key4": {"key5": {"list": ["existing", "content"], "key6": "value"}}}
+                }
+            }
+        }
+        add_was_successful = add_field_to(
+            testdict, "key1.key2.key3.key4.key5.list", ["content"], extends_lists=True
+        )
+        assert add_was_successful
+        assert testdict == expected


### PR DESCRIPTION
reimplement `add_field_to` with a slightly better performance but increased readability.

Testcode for performance measurement:

```python
from time import perf_counter

def original_add_field_to(event, output_field, content, extends_lists=False, overwrite_output_field=False):
    assert not (
        extends_lists & overwrite_output_field
    ), "An output field can't be overwritten and extended at the same time"

    conflicting_fields = []

    keys = output_field.split(".")
    for idx, key in enumerate(keys):
        if key not in event:
            if idx == len(keys) - 1:
                event[key] = content
                break
            event[key] = {}

        if isinstance(event[key], dict) and idx < len(keys) - 1:
            event = event[key]
        elif (
            isinstance(event[key], list)
            and extends_lists
            and idx == len(keys) - 1
            and not overwrite_output_field
        ):
            if isinstance(content, str):
                content = [content]
            event[key].extend(content)
        else:
            if not overwrite_output_field:
                conflicting_fields.append(keys[idx])
                break
            event[key] = content

    if conflicting_fields:
        return False
    return True

testdict = {"list": ["existing"], "key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    original_add_field_to(testdict, "key1.content", "my_content")
    original_add_field_to(testdict, "key1", "my_content")
    original_add_field_to(testdict, "key1", "my_content", overwrite_output_field=True)
    original_add_field_to(testdict, "list", "my_content", extends_lists=True)
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"list": ["existing"],"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    original_add_field_to(testdict, "key1.key2.key3.content", "my_content")
    original_add_field_to(testdict, "key1.key2.key3", "my_content")
    original_add_field_to(testdict, "key1.key2.key3", "my_content", overwrite_output_field=True)
    original_add_field_to(testdict, "key1.key2.list", "my_content", extends_lists=True)
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"list": ["existing"],"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    original_add_field_to(testdict, "key1.key2.key3.key4.key5.key6.content", "my_content")
    original_add_field_to(testdict, "key1.key2.key3.key4.key5.key6", "my_content")
    original_add_field_to(testdict, "key1.key2.key3.key4.key5.key6", "my_content", overwrite_output_field=True)
    original_add_field_to(testdict, "key1.key2.key3.key4.key5.list", "my_content", extends_lists=True)
print(perf_counter() - start)
```
results:

```
1.8568007459980436
3.1899936989939306
5.824654824013123
```

new implementation:

```python
from logprep.util.helper import add_field_to

testdict = {"list": ["existing"], "key1": {"key2": {"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    add_field_to(testdict, "key1.content", "my_content")
    add_field_to(testdict, "key1", "my_content")
    add_field_to(testdict, "key1", "my_content", overwrite_output_field=True)
    add_field_to(testdict, "list", "my_content", extends_lists=True)
    
print(perf_counter() - start)

testdict = {"key1": {"key2": {"list": ["existing"],"key3": {"key4": {"key5": {"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    add_field_to(testdict, "key1.key2.key3.content", "my_content")
    add_field_to(testdict, "key1.key2.key3", "my_content")
    add_field_to(testdict, "key1.key2.key3", "my_content", overwrite_output_field=True)
    add_field_to(testdict, "key1.key2.list", "my_content", extends_lists=True)
print(perf_counter() - start)

testdict = {"key1": {"key2": {"key3": {"key4": {"key5": {"list": ["existing"],"key6": "value"}}}}}}
start = perf_counter()
for _ in range(1_000_000):
    add_field_to(testdict, "key1.key2.key3.key4.key5.key6.content", "my_content")
    add_field_to(testdict, "key1.key2.key3.key4.key5.key6", "my_content")
    add_field_to(testdict, "key1.key2.key3.key4.key5.key6", "my_content", overwrite_output_field=True)
    add_field_to(testdict, "key1.key2.key3.key4.key5.list", "my_content", extends_lists=True)
print(perf_counter() - start)
```

results:

```
2.3162790409987792
3.6158120770123787
4.721510216011666
```




