### PR TITLE
Fix reset of metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ under the subkey `preprocessing` of the `input` processor
 
 
 ### Bugfixes
+
+* Fix resetting of some metric, e.g. `number_of_matches`.
+
 ### Breaking
 
 ## v3.3.0

--- a/logprep/metrics/metric.py
+++ b/logprep/metrics/metric.py
@@ -63,6 +63,8 @@ class Metric:
         """Resets the statistics of self and children to 0"""
         for attribute in get_settable_metrics(self):
             attribute_value = self.__getattribute__(attribute)
+            if isinstance(attribute_value, Metric):
+                attribute_value = attribute_value.reset_statistics()
             if isinstance(attribute_value, list):
                 attribute_value = [child.reset_statistics() for child in attribute_value]
             if isinstance(attribute_value, int):

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -8,13 +8,10 @@ from argparse import ArgumentParser
 from logging import getLogger, Logger, DEBUG, ERROR
 from os.path import basename
 from pathlib import Path
-from typing import Optional
 
 from colorama import Fore
 
 from logprep._version import get_versions
-from logprep.metrics.metric import MetricTargets
-from logprep.metrics.metric_targets import get_metric_targets
 from logprep.processor.base.rule import Rule
 from logprep.runner import Runner
 from logprep.util.aggregating_logger import AggregatingLogger
@@ -82,11 +79,11 @@ def _parse_arguments():
     return arguments
 
 
-def _run_logprep(arguments, logger: Logger, status_logger: Optional[MetricTargets]):
+def _run_logprep(arguments, logger: Logger):
     runner = None
     try:
         runner = Runner.get_runner()
-        runner.set_logger(logger, status_logger)
+        runner.set_logger(logger)
         runner.load_configuration(arguments.config)
         if logger.isEnabledFor(DEBUG):  # pragma: no cover
             logger.debug("Configuration loaded")
@@ -156,10 +153,6 @@ def main():
         logger.exception(error)
         sys.exit(1)
 
-    metric_targets = None
-    if not args.disable_logging:
-        metric_targets = get_metric_targets(config, logger)
-
     measure_time_config = config.get("metrics", {}).get("measure_time", {})
     TimeMeasurement.TIME_MEASUREMENT_ENABLED = measure_time_config.get("enabled", False)
     TimeMeasurement.APPEND_TO_EVENT = measure_time_config.get("append_to_event", False)
@@ -195,7 +188,7 @@ def main():
     elif args.verify_config:
         print_fcolor(Fore.GREEN, "The verification of the configuration was successful")
     else:
-        _run_logprep(args, logger, metric_targets)
+        _run_logprep(args, logger)
 
 
 if __name__ == "__main__":

--- a/logprep/runner.py
+++ b/logprep/runner.py
@@ -8,7 +8,6 @@ from multiprocessing import Value, current_process
 from logprep.framework.pipeline_manager import PipelineManager
 from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.multiprocessing_log_handler import MultiprocessingLogHandler
-from logprep.metrics.metric import MetricTargets
 
 
 class RunnerError(BaseException):
@@ -104,16 +103,13 @@ class Runner:
         if not bypass_check_to_obtain_non_singleton_instance:
             raise UseGetRunnerToCreateRunnerSingleton
 
-    def set_logger(self, logger: Logger, status_logger: MetricTargets = None):
+    def set_logger(self, logger: Logger):
         """Setup logging for any "known" errors from any part of the software.
 
         Parameters
         ----------
         logger: Logger
             An instance of logging.Logger.
-        status_logger: List (optional)
-            List of status loggers. Rotating file logger and/or prometheus exporter for processor
-            status information.
 
         Raises
         ------
@@ -121,7 +117,6 @@ class Runner:
             If 'logger' is not an instance of Logger.
         MustNotSetLoggerTwiceError
             If 'self._logger' was already set.
-
         """
         if not isinstance(logger, Logger):
             raise NotALoggerError
@@ -129,7 +124,6 @@ class Runner:
             raise MustNotSetLoggerTwiceError
 
         self._logger = logger
-        self._metric_targets = status_logger
         self._log_handler = MultiprocessingLogHandler(logger.level)
 
     def load_configuration(self, yaml_file: str):

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -3,7 +3,7 @@
 # pylint: disable=missing-docstring
 import json
 from copy import deepcopy
-from logging import getLogger, DEBUG, basicConfig
+from logging import getLogger, basicConfig, DEBUG
 from os import path, makedirs
 
 from logprep.util.helper import recursive_compare


### PR DESCRIPTION
Attributes that were of type `Metric` weren't reset properly. This fixes it and revises the initialization of the metric targets (moved from `run_logprep.py` to `pipeline.py`).