### PR TITLE
Fix typo in elasticsearch output connector

### DIFF
--- a/logprep/registry.py
+++ b/logprep/registry.py
@@ -70,7 +70,7 @@ class Registry:
         "confluentkafka_input": ConfluentKafkaInput,
         "confluentkafka_output": ConfluentKafkaOutput,
         "console_output": ConsoleOutput,
-        "eleasticsearch_output": ElasticsearchOutput,
+        "elasticsearch_output": ElasticsearchOutput,
         "jsonl_output": JsonlOutput,
         "opensearch_output": OpensearchOutput,
     }

--- a/tests/unit/connector/test_elasticsearch_output.py
+++ b/tests/unit/connector/test_elasticsearch_output.py
@@ -44,7 +44,7 @@ elasticsearch.helpers.bulk = mock_bulk
 class TestElasticsearchOutput(BaseOutputTestCase):
 
     CONFIG = {
-        "type": "eleasticsearch_output",
+        "type": "elasticsearch_output",
         "hosts": ["host:123"],
         "default_index": "default_index",
         "error_index": "error_index",


### PR DESCRIPTION
Typo: "elasticsearch" was "eleasticsearch"