### PR TITLE
reimplement dropper

### DIFF
--- a/logprep/processor/dropper/processor.py
+++ b/logprep/processor/dropper/processor.py
@@ -33,11 +33,9 @@ class Dropper(Processor):
 
     def _apply_rules(self, event: dict, rule: DropperRule):
         """Drops fields from event Logs."""
-        self._logger.debug(f"{self.describe()} processing matching event")
-        drop_full = rule.drop_full
-        if drop_full:
+        if rule.drop_full:
             drop_function = partial(pop_dotted_field_value, event)
-        if not drop_full:
+        else:
             drop_function = partial(self._drop, event)
         list(map(drop_function, rule.fields_to_drop))
 

--- a/logprep/processor/dropper/processor.py
+++ b/logprep/processor/dropper/processor.py
@@ -35,12 +35,11 @@ class Dropper(Processor):
     def _apply_rules(self, event: dict, rule: DropperRule):
         """Drops fields from event Logs."""
 
-        if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
-            self._logger.debug(f"{self.describe()} processing matching event")
-
-        if rule.drop_full:
+        self._logger.debug(f"{self.describe()} processing matching event")
+        drop_full = rule.drop_full
+        if drop_full:
             reduce(self._drop_full, [event, *rule.fields_to_drop])
-        else:
+        if not drop_full:
             reduce(self._drop, [event, *rule.fields_to_drop])
 
     @staticmethod

--- a/logprep/processor/dropper/processor.py
+++ b/logprep/processor/dropper/processor.py
@@ -19,17 +19,12 @@ Example
             - tests/testdata/rules/generic/
 """
 
+from functools import reduce
 from logging import DEBUG
 from logprep.abc.processor import Processor
 
 from logprep.processor.dropper.rule import DropperRule
-
-
-class DropperError(BaseException):
-    """Base class for Dropper related exceptions."""
-
-    def __init__(self, name, message):
-        super().__init__(f"Dropper ({name}): {message}")
+from logprep.util.helper import pop_dotted_field_value, get_dotted_field_value
 
 
 class Dropper(Processor):
@@ -37,33 +32,25 @@ class Dropper(Processor):
 
     rule_class = DropperRule
 
-    def _traverse_dict_and_delete(self, dict_: dict, sub_fields, drop_full: bool):
-        sub_field = sub_fields[0] if sub_fields else None
-        remaining_sub_fields = sub_fields[1:]
-
-        if not remaining_sub_fields and sub_field in dict_.keys():
-            del dict_[sub_field]
-        if (
-            isinstance(dict_, dict)
-            and sub_field in dict_
-            and (isinstance(dict_[sub_field], dict) and dict_[sub_field])
-        ):
-            self._traverse_dict_and_delete(dict_[sub_field], remaining_sub_fields, drop_full)
-            if dict_[sub_field] == {} and drop_full:
-                del dict_[sub_field]
-
-    def _drop_field(self, event: dict, dotted_field: str, drop_full: bool):
-        sub_fields = dotted_field.split(".")
-        self._traverse_dict_and_delete(event, sub_fields, drop_full)
-
     def _apply_rules(self, event: dict, rule: DropperRule):
         """Drops fields from event Logs."""
 
         if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
             self._logger.debug(f"{self.describe()} processing matching event")
-        for drop_field in rule.fields_to_drop:
-            self._try_dropping_field(event, drop_field, rule.drop_full)
 
-    def _try_dropping_field(self, event: dict, dotted_field: str, drop_full: bool):
-        if self._field_exists(event, dotted_field):
-            self._drop_field(event, dotted_field, drop_full)
+        if rule.drop_full:
+            reduce(self._drop_full, [event, *rule.fields_to_drop])
+        else:
+            reduce(self._drop, [event, *rule.fields_to_drop])
+
+    @staticmethod
+    def _drop(event, dotted_field):
+        parent_field, _, key = dotted_field.rpartition(".")
+        parent_field_value = get_dotted_field_value(event, parent_field)
+        parent_field_value.pop(key)
+        return event
+
+    @staticmethod
+    def _drop_full(event, dotted_field):
+        pop_dotted_field_value(event, dotted_field)
+        return event

--- a/logprep/processor/dropper/processor.py
+++ b/logprep/processor/dropper/processor.py
@@ -28,7 +28,7 @@ from logprep.util.helper import pop_dotted_field_value, get_dotted_field_value
 
 
 class Dropper(Processor):
-    """Normalize log events by copying specific values to standardized fields."""
+    """Drop log events."""
 
     rule_class = DropperRule
 

--- a/tests/unit/processor/dropper/test_dropper.py
+++ b/tests/unit/processor/dropper/test_dropper.py
@@ -134,3 +134,34 @@ class TestDropper(BaseProcessorTestCase):
         ) as mock_apply_rules:
             self.object.process(document)
             mock_apply_rules.assert_called()
+
+    def test_subkey_not_in_event(self):
+        document = {
+            "list": ["existing"],
+            "key1": {
+                "a": {"b": "value"},
+            },
+        }
+        rule = {
+            "filter": "key1",
+            "dropper": {
+                "drop": ["key1.a", "key1.b", "key1.key2.a", "key1.key2.key3.b"],
+                "drop_full": False,
+            },
+        }
+        self._load_specific_rule(rule)
+        self.object.process(document)
+
+    def test_key_not_in_event(self):
+        document = {
+            "list": ["existing"],
+        }
+        rule = {
+            "filter": "list",
+            "dropper": {
+                "drop": ["key1.a"],
+                "drop_full": False,
+            },
+        }
+        self._load_specific_rule(rule)
+        self.object.process(document)


### PR DESCRIPTION
this reimplements the dropper with helper methods.
performance wise it has a slightly better performance on my machine.

performance testing code:

```python
from logging import DEBUG
from logprep.factory import Factory
from logprep.registry import Registry
from logprep.abc import Processor
from logprep.processor.dropper.rule import DropperRule
from time import perf_counter
from logging import getLogger

class OldDropper(Processor):
    """Normalize log events by copying specific values to standardized fields."""

    rule_class = DropperRule

    def _traverse_dict_and_delete(self, dict_: dict, sub_fields, drop_full: bool):
        sub_field = sub_fields[0] if sub_fields else None
        remaining_sub_fields = sub_fields[1:]

        if not remaining_sub_fields and sub_field in dict_.keys():
            del dict_[sub_field]
        if (
            isinstance(dict_, dict)
            and sub_field in dict_
            and (isinstance(dict_[sub_field], dict) and dict_[sub_field])
        ):
            self._traverse_dict_and_delete(dict_[sub_field], remaining_sub_fields, drop_full)
            if dict_[sub_field] == {} and drop_full:
                del dict_[sub_field]

    def _drop_field(self, event: dict, dotted_field: str, drop_full: bool):
        sub_fields = dotted_field.split(".")
        self._traverse_dict_and_delete(event, sub_fields, drop_full)

    def _apply_rules(self, event: dict, rule: DropperRule):
        """Drops fields from event Logs."""

        if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
            self._logger.debug(f"{self.describe()} processing matching event")
        for drop_field in rule.fields_to_drop:
            self._try_dropping_field(event, drop_field, rule.drop_full)

    def _try_dropping_field(self, event: dict, dotted_field: str, drop_full: bool):
        if self._field_exists(event, dotted_field):
            self._drop_field(event, dotted_field, drop_full)

dropper_config = {
    "dropper": {
        "type": "dropper",
        "specific_rules": ["/dev"],
        "generic_rules": ["/dev"]  
    }
}

logger = getLogger(__name__)

dropper = Factory.create(dropper_config, logger)

Registry.mapping.update({"old_dropper": OldDropper})

old_dropper_config = {
    "dropper": {
        "type": "old_dropper",
        "specific_rules": ["/dev"],
        "generic_rules": ["/dev"]  
    }
}

old_dropper = Factory.create(old_dropper_config, logger)

dropper
old_dropper

rules = [
{
    "filter": "key1",
    "dropper": {
        "drop": ["key1"],
        
    },
},
{
    "filter": "key1",
    "dropper": {
        "drop": ["key1.a", "key1.b", "key1.key2.a", "key1.key2.key3.b"],
        
    }
},
{
    "filter": "key1",
    "dropper": {
        "drop": ["key1.key2.a", "key1.key2.key3.key4.key5.a", "key1.key2.ke3.b", "key1.key2.ke3.a"],
    }
}

]

rules = [DropperRule._create_from_dict(rule) for rule in rules]
[dropper._specific_tree.add_rule(rule) for rule in rules]
[old_dropper._specific_tree.add_rule(rule) for rule in rules]

document = {
    "list": ["existing"],
    "key1": {
        "a": {"b": "value"},
        "key2": {
            "a": {"b": "value"},
            "key3": {
                "a": {"b": "value"},
                "key4": {
                    "a": {"b": "value"},
                    "key5": {
                        "a": {"b": "value"},
                        "key6": "value"}
                    
}}}}}


documents = [document for _ in range(1_000_000)]
start = perf_counter()
for event in documents:
    dropper.process(event)
print(perf_counter() - start)

documents1 = [document for _ in range(1_000_000)]
start = perf_counter()
for event in documents1:
    old_dropper.process(event)
print(perf_counter() - start)
```

results for old implementation:

```
9.373076757008675
```

results for new implementation:

```
8.650774190959055
```