### PR TITLE
fix output of warnings

### DIFF
--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -11,6 +11,7 @@ from logging import DEBUG, INFO, NOTSET, Handler, Logger
 from multiprocessing import Lock, Process, Value, current_process
 from time import time
 from typing import List, TYPE_CHECKING
+import warnings
 
 import attrs
 import numpy as np
@@ -212,7 +213,10 @@ class Pipeline:
 
     def run(self):
         """Start processing processors in the Pipeline."""
-        self._setup()
+        with self._lock:
+            with warnings.catch_warnings():
+                warnings.simplefilter("default")
+                self._setup()
         self._enable_iteration()
         try:
             if self._logger.isEnabledFor(DEBUG):  # pragma: no cover
@@ -444,7 +448,6 @@ class MultiprocessingPipeline(Process, Pipeline):
         self._continue_iterating = Value(c_bool)
         with self._continue_iterating.get_lock():
             self._continue_iterating.value = False
-
         Process.__init__(self)
 
     def run(self):

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -2,6 +2,7 @@
 """This module can be used to start the logprep."""
 # pylint: disable=logging-fstring-interpolation
 import inspect
+import logging
 import os
 import sys
 from argparse import ArgumentParser
@@ -21,6 +22,8 @@ from logprep.util.helper import print_fcolor
 from logprep.util.rule_dry_runner import DryRunner
 from logprep.util.schema_and_rule_checker import SchemaAndRuleChecker
 from logprep.util.time_measurement import TimeMeasurement
+
+logging.captureWarnings(True)
 
 DEFAULT_LOCATION_CONFIG = "/etc/logprep/pipeline.yml"
 getLogger("filelock").setLevel(ERROR)


### PR DESCRIPTION
This fixes the output of deprecation warnings in log. The change was needed, because the warnings module is not thread safe and so all warnings were suppressed.

Can be tested with run of the quickstart. You should see deprecation warnings:

```pwsh
PS> $env:PYTHONPATH="."; python3 -d logprep/run_logprep.py ./quickstart/exampledata/config/pipeline.yml
2022-11-15 05:23:42,236 Logprep INFO    : Log level set to 'INFO'
2022-11-15 05:23:42,281 Logprep INFO    : Metric tracking is disabled via config
2022-11-15 05:23:42,312 Logprep INFO    : Created new pipeline
2022-11-15 05:23:42,354 Logprep INFO    : Created new pipeline
2022-11-15 05:23:42,364 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/labeler/rule.py:63: DeprecationWarning: label is deprecated. Use labeler.label instead
  warnings.warn("label is deprecated. Use labeler.label instead", DeprecationWarning)

2022-11-15 05:23:42,371 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/dropper/rule.py:71: DeprecationWarning: drop is deprecated. Use dropper.drop instead
  warnings.warn("drop is deprecated. Use dropper.drop instead", DeprecationWarning)

2022-11-15 05:23:42,383 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/pseudonymizer/rule.py:76: DeprecationWarning: pseudonymize is deprecated. Use pseudonymizer.pseudonyms instead
  warnings.warn(

2022-11-15 05:23:42,409 Logprep INFO    : Startup complete
2022-11-15 05:23:42,420 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/labeler/rule.py:63: DeprecationWarning: label is deprecated. Use labeler.label instead
  warnings.warn("label is deprecated. Use labeler.label instead", DeprecationWarning)

2022-11-15 05:23:42,431 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/dropper/rule.py:71: DeprecationWarning: drop is deprecated. Use dropper.drop instead
  warnings.warn("drop is deprecated. Use dropper.drop instead", DeprecationWarning)

2022-11-15 05:23:42,439 py.warnings WARNING : /home/vagrant/external_work/Logprep/logprep/processor/pseudonymizer/rule.py:76: DeprecationWarning: pseudonymize is deprecated. Use pseudonymizer.pseudonyms instead
  warnings.warn(

^C2022-11-15 05:23:51,410 Logprep INFO    : Shutting down
2022-11-15 05:23:51,447 Logprep INFO    : Initiated shutdown
2022-11-15 05:23:51,536 Logprep INFO    : Shutdown complete
```