### PR TITLE
Add requester processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Add an `http input connector` that spawns a uvicorn server which parses requests content to events.
 * Provide the possibility to consume lists, rules and configuration from files and http endpoints
+* Add `requester` processor that enriches by macking http requests with field values
 * Add `calculator` processor to calculate with or without field values
 * Make output subfields of the `geoip_enricher` configurable by introducing the rule config
 `customize_target_subfields`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
 
 * Fix count of `number_of_processed_events` metric in `input` connector. Will now only count actual
 events.
-* provide the possibility to consume lists, rules and configuration from files and http endpoints
-* Add `requester` processor that enriches by making http requests with field values
 
 ## v4.0.0
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 * Fix count of `number_of_processed_events` metric in `input` connector. Will now only count actual
 events.
+* provide the possibility to consume lists, rules and configuration from files and http endpoints
+* Add `requester` processor that enriches by making http requests with field values
 
 ## v4.0.0
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * Add an `http input connector` that spawns a uvicorn server which parses requests content to events.
 * Provide the possibility to consume lists, rules and configuration from files and http endpoints
-* Add `requester` processor that enriches by macking http requests with field values
+* Add `requester` processor that enriches by making http requests with field values
 * Add `calculator` processor to calculate with or without field values
 * Make output subfields of the `geoip_enricher` configurable by introducing the rule config
 `customize_target_subfields`

--- a/doc/source/user_manual/configuration/processor.rst
+++ b/doc/source/user_manual/configuration/processor.rst
@@ -144,6 +144,13 @@ Processors
    :inherited-members:
    :noindex:
 
+.. automodule:: logprep.processor.requester.processor
+.. autoclass:: logprep.processor.requester.processor.Requester.Config
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :noindex:
+
 .. automodule:: logprep.processor.selective_extractor.processor
 .. autoclass:: logprep.processor.selective_extractor.processor.SelectiveExtractor.Config
    :members:

--- a/doc/source/user_manual/configuration/rules.rst
+++ b/doc/source/user_manual/configuration/rules.rst
@@ -133,6 +133,13 @@ Rules
    :inherited-members:
    :noindex:
 
+.. automodule:: logprep.processor.requester.rule
+.. autoclass:: logprep.processor.requester.rule.RequesterRule.Config
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :noindex:
+
 .. automodule:: logprep.processor.selective_extractor.rule
 .. autoclass:: logprep.processor.selective_extractor.rule.SelectiveExtractorRule.Config
    :members:

--- a/logprep/processor/calculator/processor.py
+++ b/logprep/processor/calculator/processor.py
@@ -27,8 +27,8 @@ from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.calculator.fourFn import BNF
 from logprep.processor.calculator.rule import CalculatorRule
+from logprep.util.helper import add_field_to, get_source_fields_dict
 from logprep.util.decorators import timeout
-from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
 class Calculator(Processor):
@@ -37,9 +37,7 @@ class Calculator(Processor):
     rule_class = CalculatorRule
 
     def _apply_rules(self, event, rule):
-        source_fields = rule.source_fields
-        source_field_values = map(partial(get_dotted_field_value, event), source_fields)
-        source_field_dict = dict(zip(source_fields, source_field_values))
+        source_field_dict = get_source_fields_dict(event, rule)
         self._check_for_missing_values(event, rule, source_field_dict)
         expression = self._template(rule.calc, source_field_dict)
         try:

--- a/logprep/processor/calculator/processor.py
+++ b/logprep/processor/calculator/processor.py
@@ -19,7 +19,7 @@ Example
 
 """
 import re
-from functools import cached_property, partial
+from functools import cached_property
 
 from pyparsing import ParseException
 

--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -92,7 +92,7 @@ from attrs import field, define, validators
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.validators import min_len_validator
 
-FIELD_PATTERN = r"\$\{([+&?]?[^\ ${]*)\}"
+FIELD_PATTERN = r"\$\{([+&?]?[^\ ${}]*)\}"
 
 
 class CalculatorRule(FieldManagerRule):

--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -89,10 +89,8 @@ from functools import partial
 
 from attrs import field, define, validators
 
-from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
 from logprep.util.validators import min_len_validator
-
-FIELD_PATTERN = r"\$\{([+&?]?[^\ ${}]*)\}"
 
 
 class CalculatorRule(FieldManagerRule):

--- a/logprep/processor/field_manager/rule.py
+++ b/logprep/processor/field_manager/rule.py
@@ -83,6 +83,7 @@ from functools import partial
 from attrs import define, field, validators
 from logprep.util.validators import min_len_validator
 from logprep.processor.base.rule import Rule
+from logprep.util.helper import get_dotted_field_value
 
 
 class FieldManagerRule(Rule):

--- a/logprep/processor/field_manager/rule.py
+++ b/logprep/processor/field_manager/rule.py
@@ -84,6 +84,8 @@ from attrs import define, field, validators
 from logprep.util.validators import min_len_validator
 from logprep.processor.base.rule import Rule
 
+FIELD_PATTERN = r"\$\{([+&?]?[^${}]*)\}"
+
 
 class FieldManagerRule(Rule):
     """Interface for a simple Rule with source_fields and target_field"""

--- a/logprep/processor/field_manager/rule.py
+++ b/logprep/processor/field_manager/rule.py
@@ -83,7 +83,6 @@ from functools import partial
 from attrs import define, field, validators
 from logprep.util.validators import min_len_validator
 from logprep.processor.base.rule import Rule
-from logprep.util.helper import get_dotted_field_value
 
 
 class FieldManagerRule(Rule):

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -22,5 +22,8 @@ class Requester(Processor):
     rule_class = RequesterRule
 
     def _apply_rules(self, event, rule):
-        response = requests.request(url=rule.url, method=rule.method, **rule.kwargs)
-        response.raise_for_status()
+        try:
+            response = requests.request(url=rule.url, method=rule.method, **rule.kwargs)
+            response.raise_for_status()
+        except requests.HTTPError as error:
+            self._handle_warning_error(event, rule, error)

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -1,6 +1,10 @@
 """
 Requester
-============
+=========
+
+A processor to invoke http requests. Could be usefull to enrich events from an external api or
+to trigger external systems by and with event field values.
+
 """
 from typing import List, Tuple, Any
 

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -2,7 +2,7 @@
 Requester
 =========
 
-A processor to invoke http requests. Could be usefull to enrich events from an external api or
+A processor to invoke http requests. Can be used to enrich events from an external api or
 to trigger external systems by and with event field values.
 
 Example

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -6,6 +6,7 @@ A processor to invoke http requests. Could be usefull to enrich events from an e
 to trigger external systems by and with event field values.
 
 """
+from functools import partial
 import re
 import requests
 from typing import List, Tuple, Any
@@ -24,8 +25,11 @@ class Requester(Processor):
     rule_class = RequesterRule
 
     def _apply_rules(self, event, rule):
-        url = rule.url
-
+        source_fields = rule.source_fields
+        source_field_values = map(partial(get_dotted_field_value, event), source_fields)
+        source_field_dict = dict(zip(source_fields, source_field_values))
+        self._check_for_missing_values(event, rule, source_field_dict)
+        url = self._template(rule.url, source_field_dict)
         try:
             response = requests.request(url=url, method=rule.method, **rule.kwargs)
             response.raise_for_status()
@@ -39,3 +43,11 @@ class Requester(Processor):
             pattern = r"\$\{(" + rf"{key}" + r")\}"
             string = re.sub(pattern, str(value), string)
         return string
+
+    def _check_for_missing_values(self, event, rule, source_field_dict):
+        missing_fields = list(
+            dict(filter(lambda x: x[1] in [None, ""], source_field_dict.items())).keys()
+        )
+        if missing_fields:
+            error = BaseException(f"{self.name}: no value for fields: {missing_fields}")
+            self._handle_warning_error(event, rule, error)

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -5,6 +5,18 @@ Requester
 A processor to invoke http requests. Could be usefull to enrich events from an external api or
 to trigger external systems by and with event field values.
 
+Example
+^^^^^^^
+..  code-block:: yaml
+    :linenos:
+
+    - requestername:
+        type: requester
+        specific_rules:
+            - tests/testdata/rules/specific/
+        generic_rules:
+            - tests/testdata/rules/generic/
+
 """
 import json
 import re

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -5,6 +5,8 @@ Requester
 A processor to invoke http requests. Can be used to enrich events from an external api or
 to trigger external systems by and with event field values.
 
+For further information for the rule language see: :ref:`requester_rule`
+
 Example
 ^^^^^^^
 ..  code-block:: yaml

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -42,12 +42,12 @@ class Requester(Processor):
         source_field_dict = get_source_fields_dict(event, rule)
         self._check_for_missing_values(event, rule, source_field_dict)
         kwargs = self._template_kwargs(rule.kwargs, source_field_dict)
-        rsp = self._request(event, rule, kwargs)
-        self._handle_response(event, rule, rsp)
+        response = self._request(event, rule, kwargs)
+        self._handle_response(event, rule, response)
 
-    def _handle_response(self, event, rule, rsp):
+    def _handle_response(self, event, rule, response):
         if rule.target_field:
-            result = self._get_result(rsp)
+            result = self._get_result(response)
             successful = add_field_to(
                 event,
                 rule.target_field,
@@ -59,7 +59,7 @@ class Requester(Processor):
                 error = DuplicationError(self.name, [rule.target_field])
                 self._handle_warning_error(event, rule, error)
         if rule.target_field_mapping:
-            result = self._get_result(rsp)
+            result = self._get_result(response)
             for source_field, target_field in rule.target_field_mapping.items():
                 source_field_value = get_dotted_field_value(result, source_field)
                 successful = add_field_to(
@@ -75,20 +75,20 @@ class Requester(Processor):
 
     def _request(self, event, rule, kwargs):
         try:
-            rsp = requests.request(**kwargs)
-            rsp.raise_for_status()
+            response = requests.request(**kwargs)
+            response.raise_for_status()
         except requests.exceptions.HTTPError as error:
             self._handle_warning_error(event, rule, error)
         except requests.exceptions.ConnectTimeout as error:
             self._handle_warning_error(event, rule, error)
-        return rsp
+        return response
 
     @staticmethod
-    def _get_result(rsp):
+    def _get_result(response):
         try:
-            result = json.loads(rsp.content)
+            result = json.loads(response.content)
         except json.JSONDecodeError:
-            result = rsp.content.decode("utf-8")
+            result = response.content.decode("utf-8")
         return result
 
     def _template_kwargs(self, kwargs: dict, source: dict):

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -1,0 +1,19 @@
+"""
+Requester
+============
+"""
+from typing import List, Tuple, Any
+
+from logprep.abc import Processor
+from logprep.processor.base.exceptions import DuplicationError
+from logprep.processor.requester.rule import RequesterRule
+from logprep.util.helper import get_dotted_field_value, add_field_to, add_and_overwrite
+
+
+class Requester(Processor):
+    """A processor that copies, moves or merges source fields to one target field"""
+
+    rule_class = RequesterRule
+
+    def _apply_rules(self, event, rule):
+        pass

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -6,18 +6,15 @@ A processor to invoke http requests. Could be usefull to enrich events from an e
 to trigger external systems by and with event field values.
 
 """
-from copy import deepcopy
 from functools import partial
 import json
 import re
 import requests
-from typing import List, Tuple, Any
 
 from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.requester.rule import RequesterRule
 from logprep.util.helper import get_dotted_field_value, add_field_to, add_and_overwrite
-from logprep.processor.calculator.rule import FIELD_PATTERN
 
 
 class Requester(Processor):

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -6,6 +6,7 @@ A processor to invoke http requests. Could be usefull to enrich events from an e
 to trigger external systems by and with event field values.
 
 """
+import re
 import requests
 from typing import List, Tuple, Any
 
@@ -13,6 +14,7 @@ from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.requester.rule import RequesterRule
 from logprep.util.helper import get_dotted_field_value, add_field_to, add_and_overwrite
+from logprep.processor.calculator.rule import FIELD_PATTERN
 
 
 class Requester(Processor):
@@ -22,8 +24,18 @@ class Requester(Processor):
     rule_class = RequesterRule
 
     def _apply_rules(self, event, rule):
+        url = rule.url
+
         try:
-            response = requests.request(url=rule.url, method=rule.method, **rule.kwargs)
+            response = requests.request(url=url, method=rule.method, **rule.kwargs)
             response.raise_for_status()
         except requests.HTTPError as error:
             self._handle_warning_error(event, rule, error)
+
+    @staticmethod
+    def _template(string: str, source: dict) -> str:
+        for key, value in source.items():
+            key = key.replace(".", r"\.")
+            pattern = r"\$\{(" + rf"{key}" + r")\}"
+            string = re.sub(pattern, str(value), string)
+        return string

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -104,11 +104,3 @@ class Requester(Processor):
             pattern = r"\$\{(" + rf"{key}" + r")\}"
             string = re.sub(pattern, str(value), string)
         return string
-
-    def _check_for_missing_values(self, event, rule, source_field_dict):
-        missing_fields = list(
-            dict(filter(lambda x: x[1] in [None, ""], source_field_dict.items())).keys()
-        )
-        if missing_fields:
-            error = BaseException(f"{self.name}: no value for fields: {missing_fields}")
-            self._handle_warning_error(event, rule, error)

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -5,7 +5,7 @@ Requester
 A processor to invoke http requests. Can be used to enrich events from an external api or
 to trigger external systems by and with event field values.
 
-For further information for the rule language see: :ref:`requester_rule`
+For further information for the rule language see: :ref:`requester_rule`.
 
 Example
 ^^^^^^^

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -39,9 +39,9 @@ class Requester(Processor):
                     self._template(json.dumps(kwargs["json"]), source_field_dict)
                 )
         try:
-            response = requests.request(url=url, method=rule.method, **kwargs)
-            response.raise_for_status()
-        except requests.HTTPError as error:
+            rsp = requests.request(url=url, method=rule.method, **kwargs)
+            rsp.raise_for_status()
+        except requests.exceptions.HTTPError as error:
             self._handle_warning_error(event, rule, error)
 
     @staticmethod

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -16,7 +16,8 @@ from logprep.util.helper import get_dotted_field_value, add_field_to, add_and_ov
 
 
 class Requester(Processor):
-    """A processor that copies, moves or merges source fields to one target field"""
+    """A processor to invoke http requests with field data
+    and parses response data to field values"""
 
     rule_class = RequesterRule
 

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -6,15 +6,16 @@ A processor to invoke http requests. Could be usefull to enrich events from an e
 to trigger external systems by and with event field values.
 
 """
-from functools import partial
 import json
 import re
+from functools import partial
+
 import requests
 
 from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.requester.rule import RequesterRule
-from logprep.util.helper import get_dotted_field_value, add_field_to, add_and_overwrite
+from logprep.util.helper import add_field_to, get_dotted_field_value
 
 TEMPLATE_KWARGS = ("url", "json", "data", "params")
 

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -8,14 +8,12 @@ to trigger external systems by and with event field values.
 """
 import json
 import re
-from functools import partial
-
 import requests
 
 from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.requester.rule import RequesterRule
-from logprep.util.helper import add_field_to, get_dotted_field_value
+from logprep.util.helper import add_field_to, get_dotted_field_value, get_source_fields_dict
 
 TEMPLATE_KWARGS = ("url", "json", "data", "params")
 
@@ -27,9 +25,7 @@ class Requester(Processor):
     rule_class = RequesterRule
 
     def _apply_rules(self, event, rule):
-        source_fields = rule.source_fields
-        source_field_values = map(partial(get_dotted_field_value, event), source_fields)
-        source_field_dict = dict(zip(source_fields, source_field_values))
+        source_field_dict = get_source_fields_dict(event, rule)
         self._check_for_missing_values(event, rule, source_field_dict)
         kwargs = self._template_kwargs(rule.kwargs, source_field_dict)
         rsp = self._request(event, rule, kwargs)

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -69,6 +69,8 @@ class Requester(Processor):
             rsp.raise_for_status()
         except requests.exceptions.HTTPError as error:
             self._handle_warning_error(event, rule, error)
+        except requests.exceptions.ConnectTimeout as error:
+            self._handle_warning_error(event, rule, error)
         return rsp
 
     @staticmethod

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -37,9 +37,9 @@ class Requester(Processor):
         except requests.exceptions.HTTPError as error:
             self._handle_warning_error(event, rule, error)
         if rule.target_field:
-            if rsp.headers.get("Content-Type") == "application/json":
-                result = rsp.json()
-            else:
+            try:
+                result = json.loads(rsp.content)
+            except json.JSONDecodeError:
                 result = rsp.content.decode("utf-8")
             successful = add_field_to(
                 event,

--- a/logprep/processor/requester/processor.py
+++ b/logprep/processor/requester/processor.py
@@ -6,6 +6,7 @@ A processor to invoke http requests. Could be usefull to enrich events from an e
 to trigger external systems by and with event field values.
 
 """
+import requests
 from typing import List, Tuple, Any
 
 from logprep.abc import Processor
@@ -20,4 +21,5 @@ class Requester(Processor):
     rule_class = RequesterRule
 
     def _apply_rules(self, event, rule):
-        pass
+        response = requests.request(url=rule.url, method=rule.method, **rule.kwargs)
+        response.raise_for_status()

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -19,6 +19,7 @@ REQUEST_CONFIG_KEYS = [
 
 URL_REGEX_PATTERN = r"(http|https):\/\/.+"
 
+HTTP_METHODS = 
 
 class RequesterRule(FieldManagerRule):
     """Interface for a simple Rule with source_fields and target_field"""
@@ -32,12 +33,14 @@ class RequesterRule(FieldManagerRule):
         method: str = field(
             validator=[
                 validators.instance_of(str),
-                validators.in_(["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]),
+                validators.in_(HTTP_METHODS),
             ]
         )
+        f"""the method for the request. must be one of {HTTP_METHODS}"""
         url: str = field(
             validator=[validators.instance_of(str), validators.matches_re(URL_REGEX_PATTERN)]
         )
+        """the url for the request. You can use dissect pattern language to add field values"""
         kwargs: dict = field(
             validator=[
                 validators.instance_of(dict),
@@ -48,3 +51,5 @@ class RequesterRule(FieldManagerRule):
             ],
             factory=dict,
         )
+        f"""keyword arguments for the request. You can use dissect pattern language to
+        fill with field values. Valid kwargs are: {REQUEST_CONFIG_KEYS}"""

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -70,8 +70,10 @@ class RequesterRule(FieldManagerRule):
             # pylint: disable=no-member,unsupported-membership-test
             if "json" in self.kwargs:
                 json_fields = re.findall(FIELD_PATTERN, json.dumps(self.kwargs.get("json")))
-            # pylint: enable=no-member,unsupported-membership-test
             self.source_fields = list({*url_fields, *json_fields})
+            if "auth" in self.kwargs:
+                self.kwargs.update({"auth": tuple(self.kwargs.get("auth"))})
+            # pylint: enable=no-member,unsupported-membership-test
 
     @property
     def url(self):

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -1,0 +1,21 @@
+"""
+Requester
+============
+
+"""
+from functools import partial
+from attrs import define, field, validators
+from logprep.util.validators import min_len_validator
+from logprep.processor.field_manager.rule import FieldManagerRule
+
+
+class RequesterRule(FieldManagerRule):
+    """Interface for a simple Rule with source_fields and target_field"""
+
+    @define(kw_only=True)
+    class Config(FieldManagerRule.Config):
+        """Config for RequesterRule"""
+
+        source_fields: list = field(factory=list)
+        target_field: str = field(factory=str)
+        kwargs: dict = field(validator=[validators.instance_of(dict)])

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -1,6 +1,7 @@
 """
 Requester
-============
+=========
+
 
 """
 import inspect

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -1,4 +1,6 @@
 """
+.. _requester_rule:
+
 Requester
 =========
 

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -45,7 +45,6 @@ class RequesterRule(FieldManagerRule):
         url: str = field(
             validator=[
                 validators.instance_of(str),
-                validators.matches_re(rf"({URL_REGEX_PATTERN})|({FIELD_PATTERN})"),
             ]
         )
         """the url for the request. You can use dissect pattern language to add field values"""

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -76,7 +76,7 @@ HTTP_METHODS = ["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 
 class RequesterRule(FieldManagerRule):
-    """Interface for a simple Rule with source_fields and target_field"""
+    """RequesterRule"""
 
     @define(kw_only=True)
     class Config(FieldManagerRule.Config):

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -19,7 +19,8 @@ REQUEST_CONFIG_KEYS = [
 
 URL_REGEX_PATTERN = r"(http|https):\/\/.+"
 
-HTTP_METHODS = 
+HTTP_METHODS = ["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
+
 
 class RequesterRule(FieldManagerRule):
     """Interface for a simple Rule with source_fields and target_field"""
@@ -53,3 +54,15 @@ class RequesterRule(FieldManagerRule):
         )
         f"""keyword arguments for the request. You can use dissect pattern language to
         fill with field values. Valid kwargs are: {REQUEST_CONFIG_KEYS}"""
+
+    @property
+    def url(self):
+        return self._config.url
+
+    @property
+    def method(self):
+        return self._config.method
+
+    @property
+    def kwargs(self):
+        return self._config.kwargs

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -65,8 +65,7 @@ import re
 import requests
 from attrs import define, field, validators
 
-from logprep.processor.calculator.rule import FIELD_PATTERN
-from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
 
 parameter_keys = inspect.signature(requests.Request).parameters.keys()
 REQUEST_CONFIG_KEYS = [

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -32,9 +32,9 @@ A speaking example for event enrichment via external api:
 
     {"message": {"hostname": "BB37293hhj"}}
 
-.. code-block:: json
-    :lineos:
-    :caption: raw response json data given from the api
+..  code-block:: json
+    :linenos:
+    :caption: Raw response json data given from the api
 
     {
         "city": "Montreal",
@@ -117,7 +117,7 @@ class RequesterRule(FieldManagerRule):
         """The url for the request. You can use dissect pattern language to add field values"""
         json: dict = field(validator=validators.instance_of(dict), factory=dict)
         """ (Optional) The json payload. Can be enriched with event data by using the pattern
-        :code:`${the.dotted.field}` to retrieve nested field values. 
+        :code:`${the.dotted.field}` to retrieve nested field values.
         """
         data: str = field(validator=validators.instance_of(str), default="")
         """ (Optional) The data payload. Can be templated by using the pattern

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -32,6 +32,17 @@ A speaking example for event enrichment via external api:
 
     {"message": {"hostname": "BB37293hhj"}}
 
+.. code-block:: json
+    :lineos:
+    :caption: raw response json data given from the api
+
+    {
+        "city": "Montreal",
+        "Building": "L76",
+        "Floor": 3,
+        "Room": 34
+    }
+
 ..  code-block:: json
     :linenos:
     :caption: Processed event

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -36,7 +36,7 @@ A speaking example for event enrichment via external api:
 
     {"message": {"hostname": "BB37293hhj"},
      "cmdb": {
-         "locaction": {
+         "location": {
              "city": "Montreal",
              "Building": "L76",
              "Floor": 3,
@@ -59,10 +59,7 @@ parameter_keys = inspect.signature(requests.Request).parameters.keys()
 REQUEST_CONFIG_KEYS = [
     parameter for parameter in parameter_keys if parameter not in ["hooks", "cookies", "files"]
 ] + ["timeout", "proxies", "verify", "cert"]
-
 URL_REGEX_PATTERN = r"(http|https):\/\/.+"
-
-
 HTTP_METHODS = ["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 
@@ -107,8 +104,8 @@ class RequesterRule(FieldManagerRule):
         )
         """The url for the request. You can use dissect pattern language to add field values"""
         json: dict = field(validator=validators.instance_of(dict), factory=dict)
-        """ (Optional) The json payload. Can be templated by using the pattern
-        :code:`${the.dotted.field}` somewhere in the key or value all elements.
+        """ (Optional) The json payload. Can be enriched with event data by using the pattern
+        :code:`${the.dotted.field}` to retrieve nested field values. 
         """
         data: str = field(validator=validators.instance_of(str), default="")
         """ (Optional) The data payload. Can be templated by using the pattern
@@ -145,7 +142,7 @@ class RequesterRule(FieldManagerRule):
         timeout: float = field(validator=validators.instance_of(float), converter=float, default=2)
         """ (Optional) The timeout in seconds as float for the request. Defaults to 2 seconds"""
         verify: bool = field(validator=validators.instance_of(bool), default=True)
-        """ (Optional) Wether or not verify the ssl context. Defaults to :code:`True`"""
+        """ (Optional) Whether or not verify the ssl context. Defaults to :code:`True`."""
         proxies: dict = field(
             validator=[
                 validators.instance_of(dict),

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -8,11 +8,16 @@ import inspect
 import requests
 from attrs import define, field, validators
 from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.util.validators import url_validator
 
 parameter_keys = inspect.signature(requests.Request).parameters.keys()
 REQUEST_CONFIG_KEYS = [
-    parameter for parameter in parameter_keys if parameter not in ["hooks", "cookies"]
+    parameter
+    for parameter in parameter_keys
+    if parameter not in ["hooks", "cookies", "method", "url"]
 ]
+
+URL_REGEX_PATTERN = r"(http|https):\/\/.+"
 
 
 class RequesterRule(FieldManagerRule):
@@ -24,6 +29,15 @@ class RequesterRule(FieldManagerRule):
 
         source_fields: list = field(factory=list)
         target_field: str = field(factory=str)
+        method: str = field(
+            validator=[
+                validators.instance_of(str),
+                validators.in_(["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]),
+            ]
+        )
+        url: str = field(
+            validator=[validators.instance_of(str), validators.matches_re(URL_REGEX_PATTERN)]
+        )
         kwargs: dict = field(
             validator=[
                 validators.instance_of(dict),
@@ -31,5 +45,6 @@ class RequesterRule(FieldManagerRule):
                     key_validator=validators.in_(REQUEST_CONFIG_KEYS),
                     value_validator=validators.instance_of(object),
                 ),
-            ]
+            ],
+            factory=dict,
         )

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -75,6 +75,7 @@ class RequesterRule(FieldManagerRule):
                 self.kwargs.update({"auth": tuple(self.kwargs.get("auth"))})
             # pylint: enable=no-member,unsupported-membership-test
 
+    # pylint: disable=missing-docstring
     @property
     def url(self):
         return self._config.url
@@ -86,3 +87,5 @@ class RequesterRule(FieldManagerRule):
     @property
     def kwargs(self):
         return self._config.kwargs
+
+    # pylint: enable=missing-docstring

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -120,8 +120,8 @@ class RequesterRule(FieldManagerRule):
         :code:`${the.dotted.field}` to retrieve nested field values.
         """
         data: str = field(validator=validators.instance_of(str), default="")
-        """ (Optional) The data payload. Can be templated by using the pattern
-        :code:`${the.dotted.field}` somewhere in value"""
+        """ (Optional) The data payload. Can be enriched with event data by using the pattern
+        :code:`${the.dotted.field}` to retrieve nested field values."""
         params: dict = field(
             validator=[
                 validators.instance_of(dict),
@@ -132,8 +132,8 @@ class RequesterRule(FieldManagerRule):
             ],
             factory=dict,
         )
-        """ (Optional) The query parameters as dictionary. Can be templated by using the pattern
-        :code:`${the.dotted.field}` somewhere in the key or value all elements."""
+        """ (Optional) The query parameters as dictionary. Can be enriched with event data by
+        using the pattern :code:`${the.dotted.field}` to retrieve nested field values."""
         headers: dict = field(
             validator=[
                 validators.instance_of(dict),

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -32,8 +32,11 @@ class RequesterRule(FieldManagerRule):
     class Config(FieldManagerRule.Config):
         """Config for RequesterRule"""
 
-        source_fields: list = field(factory=list, converter=sorted)
-        target_field: str = field(factory=str)
+        source_fields: list = field(
+            factory=list, converter=sorted, validator=validators.instance_of(list)
+        )
+        target_field: str = field(factory=str, validator=validators.instance_of(str))
+        """(Optional) The target field to write the complete response json or body to"""
         target_field_mapping: dict = field(
             validator=[
                 validators.instance_of(dict),
@@ -45,7 +48,7 @@ class RequesterRule(FieldManagerRule):
             factory=dict,
         )
         """(Optional) A mapping from dotted_fields to dotted_fields to extract data from response
-        json to target fields"""
+        json to target fields. If target_field is given too, this is made additionally"""
         method: str = field(
             validator=[
                 validators.instance_of(str),

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -39,7 +39,9 @@ class RequesterRule(FieldManagerRule):
                 validators.in_(HTTP_METHODS),
             ]
         )
-        f"""the method for the request. must be one of {HTTP_METHODS}"""
+        """the method for the request. must be one of
+        :code:`GET`, :code:`OPTIONS`, :code:`HEAD`,
+        :code:`POST`, :code:`PUT`, :code:`PATCH`, :code:`DELETE`"""
         url: str = field(
             validator=[
                 validators.instance_of(str),
@@ -57,8 +59,9 @@ class RequesterRule(FieldManagerRule):
             ],
             factory=dict,
         )
-        f"""keyword arguments for the request. You can use dissect pattern language to
-        fill with field values. Valid kwargs are: {REQUEST_CONFIG_KEYS}"""
+        """keyword arguments for the request. You can use dissect pattern language to
+        fill with field values. Valid kwargs are:
+        :code:`headers`, :code:`files`, :code:`data`, :code:`params`, :code:`auth`, :code:`json`"""
 
         def __attrs_post_init__(self):
             url_fields = re.findall(FIELD_PATTERN, self.url)

--- a/logprep/processor/timestamp_differ/rule.py
+++ b/logprep/processor/timestamp_differ/rule.py
@@ -45,9 +45,8 @@ import re
 from attr import field
 from attrs import define, validators
 
-from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
 
-FIELD_PATTERN = r"\$\{([+&?]?[^${]*)\}"
 DEFAULT_TIMESTAMP_PATTERN = "YYYY-MM-DDTHH:mm:ssZZ"
 
 

--- a/logprep/registry.py
+++ b/logprep/registry.py
@@ -34,6 +34,7 @@ from logprep.processor.list_comparison.processor import ListComparison
 from logprep.processor.normalizer.processor import Normalizer
 from logprep.processor.pre_detector.processor import PreDetector
 from logprep.processor.pseudonymizer.processor import Pseudonymizer
+from logprep.processor.requester.processor import Requester
 from logprep.processor.selective_extractor.processor import SelectiveExtractor
 from logprep.processor.template_replacer.processor import TemplateReplacer
 from logprep.processor.timestamp_differ.processor import TimestampDiffer
@@ -64,6 +65,7 @@ class Registry:
         "normalizer": Normalizer,
         "pre_detector": PreDetector,
         "pseudonymizer": Pseudonymizer,
+        "requester": Requester,
         "selective_extractor": SelectiveExtractor,
         "template_replacer": TemplateReplacer,
         "timestamp_differ": TimestampDiffer,

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -254,3 +254,11 @@ def append(event, target_field, content, separator):
         add_and_overwrite(event, target_field, target_value)
     else:
         append_as_list(event, target_field, content)
+
+
+def get_source_fields_dict(event, rule):
+    """returns a dict with dotted fields as keys and target values as values"""
+    source_fields = rule.source_fields
+    source_field_values = map(partial(get_dotted_field_value, event), source_fields)
+    source_field_dict = dict(zip(source_fields, source_field_values))
+    return source_field_dict

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ pyparsing
 python-dateutil
 pytz
 pyyaml
+requests
 ruamel.yaml
 tldextract
 urlextract

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,6 +105,7 @@ regex==2022.10.31
     # via pygrok
 requests==2.28.1
     # via
+    #   -r ./requirements.in
     #   geoip2
     #   opensearch-py
     #   requests-file

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -6,3 +6,4 @@ pylint
 pytest
 pytest-cov
 semgrep
+responses

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -5,5 +5,5 @@ isort
 pylint
 pytest
 pytest-cov
-semgrep
 responses
+semgrep

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -185,7 +185,7 @@ pydantic==1.10.2
     #   fastapi
 pygrok==1.0.0
     # via -r ./requirements.txt
-pylint==2.15.8
+pylint==2.15.7
     # via -r ./requirements_dev.in
 pyparsing==3.0.9
     # via
@@ -219,12 +219,15 @@ requests==2.28.1
     #   geoip2
     #   opensearch-py
     #   requests-file
+    #   responses
     #   semgrep
     #   tldextract
 requests-file==1.5.1
     # via
     #   -r ./requirements.txt
     #   tldextract
+responses==0.22.0
+    # via -r ./requirements_dev.in
 rfc3986[idna2008]==1.5.0
     # via httpx
 ruamel-yaml==0.17.21
@@ -235,7 +238,7 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r ./requirements.txt
     #   ruamel-yaml
-semgrep==1.1.0
+semgrep==1.0.0
     # via -r ./requirements_dev.in
 six==1.16.0
     # via
@@ -254,6 +257,8 @@ starlette==0.22.0
     #   fastapi
 tldextract==3.4.0
     # via -r ./requirements.txt
+toml==0.10.2
+    # via responses
 tomli==2.0.1
     # via
     #   black
@@ -265,6 +270,8 @@ tomlkit==0.11.6
     # via pylint
 tqdm==4.64.1
     # via semgrep
+types-toml==0.10.8.1
+    # via responses
 typing-extensions==4.4.0
     # via
     #   -r ./requirements.txt
@@ -289,6 +296,7 @@ urllib3==1.26.13
     #   geoip2
     #   opensearch-py
     #   requests
+    #   responses
     #   semgrep
 uvicorn==0.20.0
     # via -r ./requirements.txt

--- a/tests/testdata/unit/requester/generic_rules/requester.json
+++ b/tests/testdata/unit/requester/generic_rules/requester.json
@@ -1,0 +1,8 @@
+[
+    {
+        "filter": "message1",
+        "requester": {
+            "kwargs": {}
+        }
+    }
+]

--- a/tests/testdata/unit/requester/generic_rules/requester.json
+++ b/tests/testdata/unit/requester/generic_rules/requester.json
@@ -2,7 +2,8 @@
     {
         "filter": "message1",
         "requester": {
-            "kwargs": {}
+            "url": "http://the-url",
+            "method": "GET"
         }
     }
 ]

--- a/tests/testdata/unit/requester/specific_rules/requester.json
+++ b/tests/testdata/unit/requester/specific_rules/requester.json
@@ -2,7 +2,8 @@
     {
         "filter": "message",
         "requester": {
-            "kwargs": {}
+            "url": "http://the-url",
+            "method": "GET"
         }
     }
 ]

--- a/tests/testdata/unit/requester/specific_rules/requester.json
+++ b/tests/testdata/unit/requester/specific_rules/requester.json
@@ -1,0 +1,8 @@
+[
+    {
+        "filter": "message",
+        "requester": {
+            "kwargs": {}
+        }
+    }
+]

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -120,6 +120,38 @@ test_cases = [
             "status": 200,
         },
     ),
+    (
+        "parses json result to target field",
+        {
+            "filter": "message",
+            "requester": {"url": "http://mock-mock/", "method": "GET", "target_field": "result"},
+        },
+        {"message": "the message"},
+        {"message": "the message", "result": {"testkey": "testresult"}},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "json": {"testkey": "testresult"},
+            "content_type": "application/json",
+            "status": 200,
+        },
+    ),
+    (
+        "parses text result to target field",
+        {
+            "filter": "message",
+            "requester": {"url": "http://mock-mock/", "method": "GET", "target_field": "result"},
+        },
+        {"message": "the message"},
+        {"message": "the message", "result": "the body"},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "body": "the body",
+            "content_type": "text/plain",
+            "status": 200,
+        },
+    ),
 ]  # testcase, rule, event, expected, response
 
 failure_test_cases = [

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -14,11 +14,18 @@ test_cases = [
         {"method": "GET", "url": "http://mock-mock", "status": 200},
     ),
     (
-        "simple request with url from field",
+        "request with url from field",
         {"filter": "message", "requester": {"url": "${url}", "method": "GET"}},
         {"message": "the message", "url": "http://mock-mock"},
         {"message": "the message", "url": "http://mock-mock"},
         {"method": "GET", "url": "http://mock-mock", "status": 200},
+    ),
+    (
+        "request with url from different fields",
+        {"filter": "message", "requester": {"url": "${url}/${file}", "method": "GET"}},
+        {"message": "the message", "url": "http://mock-mock", "file": "file.yml"},
+        {"message": "the message", "url": "http://mock-mock", "file": "file.yml"},
+        {"method": "GET", "url": "http://mock-mock/file.yml", "status": 200},
     ),
 ]  # testcase, rule, event, expected, response
 

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -152,6 +152,26 @@ test_cases = [
             "status": 200,
         },
     ),
+    (
+        "parses json result with simple target field mapping",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://mock-mock/",
+                "method": "GET",
+                "target_field_mapping": {"key1.key2.key3": "result.custom"},
+            },
+        },
+        {"message": "the message"},
+        {"message": "the message", "result": {"custom": "value"}},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "json": {"key1": {"key2": {"key3": "value"}}},
+            "content_type": "text/plain",
+            "status": 200,
+        },
+    ),
 ]  # testcase, rule, event, expected, response
 
 failure_test_cases = [

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -1,12 +1,11 @@
 # pylint: disable=missing-docstring
-from unittest import mock
 
 import pytest
 import responses
-from requests import HTTPError
-from responses import matchers, Response
+from requests import ConnectTimeout, HTTPError
+from responses import matchers
 
-from logprep.processor.base.exceptions import DuplicationError, ProcessingWarning
+from logprep.processor.base.exceptions import ProcessingWarning
 from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [
@@ -186,6 +185,22 @@ failure_test_cases = [
             "body": HTTPError("404"),
             "content_type": "text/plain",
             "status": 404,
+        },
+    ),
+    (
+        "timout error",
+        {
+            "filter": "message",
+            "requester": {"url": "http://failure_mock", "method": "GET", "timeout": 0.2},
+        },
+        {"message": "the message"},
+        {"message": "the message", "tags": ["_requester_failure"]},
+        {
+            "method": "GET",
+            "url": "http://failure_mock",
+            "body": ConnectTimeout(),
+            "content_type": "text/plain",
+            "status": 200,
         },
     ),
     (

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -38,7 +38,7 @@ test_cases = [
             "requester": {
                 "url": "http://mock-mock",
                 "method": "POST",
-                "kwargs": {"json": {"the": "json value"}},
+                "json": {"the": "json value"},
             },
         },
         {"message": "the message", "url": "http://mock-mock"},
@@ -52,7 +52,7 @@ test_cases = [
             "requester": {
                 "url": "http://mock-mock",
                 "method": "POST",
-                "kwargs": {"json": {"the": "${message}"}},
+                "json": {"the": "${message}"},
             },
         },
         {"message": "the message", "url": "http://mock-mock"},
@@ -71,7 +71,7 @@ test_cases = [
             "requester": {
                 "url": "http://${message.url}",
                 "method": "POST",
-                "kwargs": {"json": {"${message.key}": "${message.value}"}},
+                "json": {"${message.key}": "${message.value}"},
             },
         },
         {"message": {"url": "mock-mock", "key": "keyvalue", "value": "valuevalue"}},
@@ -80,6 +80,7 @@ test_cases = [
             "method": "POST",
             "url": "http://mock-mock/",
             "match": [matchers.json_params_matcher({"keyvalue": "valuevalue"})],
+            "content_type": "application/json",
             "status": 200,
         },
     ),
@@ -90,7 +91,25 @@ test_cases = [
             "requester": {
                 "url": "http://mock-mock/",
                 "method": "GET",
-                "kwargs": {"auth": ["username", "password"]},
+                "auth": ["username", "password"],
+            },
+        },
+        {"message": "the message"},
+        {"message": "the message"},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "status": 200,
+        },
+    ),
+    (
+        "post request with templated data",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://mock-mock/",
+                "method": "GET",
+                "data": "fielddata ${message}",
             },
         },
         {"message": "the message"},

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -12,7 +12,14 @@ test_cases = [
         {"message": "the message"},
         {"message": "the message"},
         {"method": "GET", "url": "http://mock-mock", "status": 200},
-    )
+    ),
+    (
+        "simple request with url from field",
+        {"filter": "message", "requester": {"url": "${url}", "method": "GET"}},
+        {"message": "the message", "url": "http://mock-mock"},
+        {"message": "the message", "url": "http://mock-mock"},
+        {"method": "GET", "url": "http://mock-mock", "status": 200},
+    ),
 ]  # testcase, rule, event, expected, response
 
 failure_test_cases = [

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -80,6 +80,24 @@ test_cases = [
             "status": 200,
         },
     ),
+    (
+        "get request with auth from kwargs",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://mock-mock/",
+                "method": "GET",
+                "kwargs": {"auth": ["username", "password"]},
+            },
+        },
+        {"message": "the message"},
+        {"message": "the message"},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "status": 200,
+        },
+    ),
 ]  # testcase, rule, event, expected, response
 
 failure_test_cases = [

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -184,6 +184,16 @@ failure_test_cases = [
             "status": 200,
         },
     ),
+    (
+        "errors on missing fields",
+        {
+            "filter": "message",
+            "requester": {"url": "http://${missingfield}", "method": "GET"},
+        },
+        {"message": "the message"},
+        {"message": "the message", "tags": ["_requester_failure"]},
+        {},
+    ),
 ]  # testcase, rule, event, expected, mock
 
 
@@ -210,7 +220,8 @@ class TestRequester(BaseProcessorTestCase):
     def test_requester_testcases_failure_handling(
         self, testcase, rule, event, expected, response_kwargs
     ):
-        responses.add(responses.Response(**response_kwargs))
+        if response_kwargs:
+            responses.add(responses.Response(**response_kwargs))
         self._load_specific_rule(rule)
         with pytest.raises(ProcessingWarning):
             self.object.process(event)

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -1,12 +1,13 @@
 # pylint: disable=missing-docstring
-from requests import HTTPError
 from unittest import mock
+
 import pytest
 import responses
+from requests import HTTPError
 from responses import matchers
+
 from logprep.processor.base.exceptions import DuplicationError, ProcessingWarning
 from tests.unit.processor.base import BaseProcessorTestCase
-
 
 test_cases = [
     (
@@ -147,5 +148,5 @@ class TestRequester(BaseProcessorTestCase):
             "event_id": "1234",
             "message": "user root logged in",
         }
-        count = self.object.metrics.number_of_processed_events
+        _ = self.object.metrics.number_of_processed_events
         self.object.process(document)

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -1,0 +1,31 @@
+# pylint: disable=missing-docstring
+import pytest
+from logprep.processor.base.exceptions import DuplicationError, ProcessingWarning
+from tests.unit.processor.base import BaseProcessorTestCase
+
+
+test_cases = []  # testcase, rule, event, expected
+
+failure_test_cases = []  # testcase, rule, event, expected
+
+
+class TestRequester(BaseProcessorTestCase):
+
+    CONFIG: dict = {
+        "type": "requester",
+        "specific_rules": ["tests/testdata/unit/requester/specific_rules"],
+        "generic_rules": ["tests/testdata/unit/requester/generic_rules"],
+    }
+
+    @pytest.mark.parametrize("testcase, rule, event, expected", test_cases)
+    def test_testcases(self, testcase, rule, event, expected):  # pylint: disable=unused-argument
+        self._load_specific_rule(rule)
+        self.object.process(event)
+        assert event == expected
+
+    @pytest.mark.parametrize("testcase, rule, event, expected", failure_test_cases)
+    def test_testcases_failure_handling(self, testcase, rule, event, expected):
+        self._load_specific_rule(rule)
+        with pytest.raises(ProcessingWarning):
+            self.object.process(event)
+        assert event == expected, testcase

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -171,6 +171,70 @@ test_cases = [
             "status": 200,
         },
     ),
+    (
+        "parses json result with simple target field mapping and overwrite target",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://mock-mock/",
+                "method": "GET",
+                "target_field_mapping": {"key1.key2.key3": "result.custom"},
+                "overwrite_target": True,
+            },
+        },
+        {"message": "the message", "result": {"custom", "preexisting"}},
+        {"message": "the message", "result": {"custom": "value"}},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "json": {"key1": {"key2": {"key3": "value"}}},
+            "content_type": "text/plain",
+            "status": 200,
+        },
+    ),
+    (
+        "parses text result to preexisting target field",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://mock-mock/",
+                "method": "GET",
+                "target_field": "result",
+                "overwrite_target": True,
+            },
+        },
+        {"message": "the message", "result": "preexisting"},
+        {"message": "the message", "result": "the body"},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "body": "the body",
+            "content_type": "text/plain",
+            "status": 200,
+        },
+    ),
+    (
+        "deletes source fields",
+        {
+            "filter": "message",
+            "requester": {
+                "url": "http://${domain}/",
+                "method": "GET",
+                "json": {"${field1}": "the other ${field2}"},
+                "target_field": "result",
+                "delete_source_fields": True,
+            },
+        },
+        {"message": "the message", "domain": "mock-mock", "field1": "key", "field2": "value"},
+        {"message": "the message", "result": "the body"},
+        {
+            "method": "GET",
+            "url": "http://mock-mock/",
+            "body": "the body",
+            "content_type": "text/plain",
+            "status": 200,
+        },
+    ),
 ]  # testcase, rule, event, expected, response
 
 failure_test_cases = [
@@ -207,7 +271,11 @@ failure_test_cases = [
         "does not overwrite if not permitted",
         {
             "filter": "message",
-            "requester": {"url": "http://failure_mock", "method": "GET", "target_field": "result"},
+            "requester": {
+                "url": "http://failure_mock",
+                "method": "GET",
+                "target_field": "result",
+            },
         },
         {"message": "the message", "result": "preexisting"},
         {"message": "the message", "result": "preexisting", "tags": ["_requester_failure"]},

--- a/tests/unit/processor/requester/test_requester.py
+++ b/tests/unit/processor/requester/test_requester.py
@@ -310,13 +310,11 @@ class TestRequester(BaseProcessorTestCase):
 
     @responses.activate
     @pytest.mark.parametrize("testcase, rule, event, expected, response_kwargs", test_cases)
-    def test_testcases(
-        self, testcase, rule, event, expected, response_kwargs
-    ):  # pylint: disable=unused-argument
+    def test_testcases(self, testcase, rule, event, expected, response_kwargs):
         responses.add(responses.Response(**response_kwargs))
         self._load_specific_rule(rule)
         self.object.process(event)
-        assert event == expected
+        assert event == expected, testcase
 
     @responses.activate
     @pytest.mark.parametrize("testcase, rule, event, expected, response_kwargs", failure_test_cases)

--- a/tests/unit/processor/requester/test_requester_rule.py
+++ b/tests/unit/processor/requester/test_requester_rule.py
@@ -1,0 +1,39 @@
+# pylint: disable=protected-access
+# pylint: disable=missing-docstring
+import pytest
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.requester.rule import RequesterRule
+
+
+class TestFieldManagerRule:
+    def test_create_from_dict_returns_requester_rule(self):
+        rule = {
+            "filter": "message",
+            "requester": {"kwargs": {"method": "GET", "url": "http://fancyapi"}},
+        }
+        rule_dict = RequesterRule._create_from_dict(rule)
+        assert isinstance(rule_dict, RequesterRule)
+
+    @pytest.mark.parametrize(
+        ["rule", "error", "message"],
+        [],
+    )
+    def test_create_from_dict_validates_config(self, rule, error, message):
+        if error:
+            with pytest.raises(error, match=message):
+                RequesterRule._create_from_dict(rule)
+        else:
+            rule_instance = RequesterRule._create_from_dict(rule)
+            assert hasattr(rule_instance, "_config")
+            for key, value in rule.get("requester").items():
+                assert hasattr(rule_instance._config, key)
+                assert value == getattr(rule_instance._config, key)
+
+    @pytest.mark.parametrize(
+        ["testcase", "rule1", "rule2", "equality"],
+        [],
+    )
+    def test_equality(self, testcase, rule1, rule2, equality):
+        rule1 = RequesterRule._create_from_dict(rule1)
+        rule2 = RequesterRule._create_from_dict(rule2)
+        assert (rule1 == rule2) == equality, testcase

--- a/tests/unit/processor/requester/test_requester_rule.py
+++ b/tests/unit/processor/requester/test_requester_rule.py
@@ -238,7 +238,7 @@ class TestRequesterRule:
                         "data": "the data from field ${datafield.bla}",
                     },
                 },
-                ["url", "json", "params", "data", "method"],
+                ["url", "json", "params", "data", "method", "timeout", "verify"],
             ),
             (
                 {
@@ -248,7 +248,7 @@ class TestRequesterRule:
                         "url": "http://${field1}/${field2}",
                     },
                 },
-                ["url", "method"],
+                ["url", "method", "timeout", "verify"],
             ),
         ],
     )

--- a/tests/unit/processor/requester/test_requester_rule.py
+++ b/tests/unit/processor/requester/test_requester_rule.py
@@ -66,7 +66,7 @@ class TestRequesterRule:
                     },
                 },
                 ValueError,
-                r"'kwargs' must be in \['headers', 'files', 'data', 'params', 'auth', 'json'\]",
+                r"'kwargs' must be in \['headers', 'data', 'params', 'auth', 'json'\]",
             ),
             (
                 {
@@ -104,6 +104,38 @@ class TestRequesterRule:
                     },
                 },
                 ["field1"],
+            ),
+            (
+                {
+                    "filter": "message",
+                    "requester": {
+                        "method": "GET",
+                        "url": "http://${field1}/${field2}",
+                    },
+                },
+                ["field1", "field2"],
+            ),
+            (
+                {
+                    "filter": "message",
+                    "requester": {
+                        "method": "GET",
+                        "url": "http://${field1}/${field2}",
+                        "kwargs": {"json": {"${jsonkey}": "the ${jsonvalue} bla"}},
+                    },
+                },
+                ["field1", "field2", "jsonkey", "jsonvalue"],
+            ),
+            (
+                {
+                    "filter": "message",
+                    "requester": {
+                        "method": "GET",
+                        "url": "http://${field1}/${field2}",
+                        "kwargs": {"json": {"${jsonkey}": "the ${jsonvalue}"}},
+                    },
+                },
+                ["field1", "field2", "jsonkey", "jsonvalue"],
             ),
         ],
     )

--- a/tests/unit/processor/requester/test_requester_rule.py
+++ b/tests/unit/processor/requester/test_requester_rule.py
@@ -68,6 +68,17 @@ class TestRequesterRule:
                 ValueError,
                 r"'kwargs' must be in \['headers', 'files', 'data', 'params', 'auth', 'json'\]",
             ),
+            (
+                {
+                    "filter": "message",
+                    "requester": {
+                        "method": "GET",
+                        "url": "${field}",
+                    },
+                },
+                None,
+                None,
+            ),
         ],
     )
     def test_create_from_dict_validates_config(self, rule, error, message):
@@ -80,3 +91,22 @@ class TestRequesterRule:
             for key, value in rule.get("requester").items():
                 assert hasattr(rule_instance._config, key)
                 assert value == getattr(rule_instance._config, key)
+
+    @pytest.mark.parametrize(
+        "rule, expected_source_fields",
+        [
+            (
+                {
+                    "filter": "message",
+                    "requester": {
+                        "method": "GET",
+                        "url": "${field1}",
+                    },
+                },
+                ["field1"],
+            ),
+        ],
+    )
+    def test_sets_source_fields(self, rule, expected_source_fields):
+        rule_instance = RequesterRule._create_from_dict(rule)
+        assert expected_source_fields == rule_instance.source_fields

--- a/tests/unit/processor/requester/test_requester_rule.py
+++ b/tests/unit/processor/requester/test_requester_rule.py
@@ -121,18 +121,6 @@ class TestRequesterRule:
                     "requester": {
                         "method": "GET",
                         "url": "http://the-api/endpoint",
-                        "params": '{"key": "value"}',
-                    },
-                },
-                TypeError,
-                r"must be <class \\\'dict\\\'>",
-            ),
-            (
-                {
-                    "filter": "message",
-                    "requester": {
-                        "method": "GET",
-                        "url": "http://the-api/endpoint",
                         "params": {"key": {}},
                     },
                 },


### PR DESCRIPTION
A processor to invoke http requests. Could be usefull to enrich events from an external api or
to trigger external systems by and with event field values.
Parses the response to enrich event data.