### PR TITLE
Geoip Enricher: Add config to customize target subfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 ### Features
 
 * Add an `http input connector` that spawns a uvicorn server which parses requests content to events.
-* provide the possibility to consume lists, rules and configuration from files and http endpoints
-* add `calculator` processor to calculate with or without field values
+* Provide the possibility to consume lists, rules and configuration from files and http endpoints
+* Add `calculator` processor to calculate with or without field values
+* Make output subfields of the `geoip_enricher` configurable by introducing the rule config
+`customize_target_subfields`
 
 ### Improvements
 
-* add support for python `3.10` and `3.11`
+* Add support for python `3.10` and `3.11`
 
 ## v4.0.0
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Building the documentation is done by executing the following command from withi
 the project root directory:
 
 ```
-tox -e py36-docs
+tox -e py39-docs
 ```
 
 A HTML documentation can be then found in `doc/_build/html/index.html`.

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -56,21 +56,23 @@ class GeoipEnricher(Processor):
             ip_addr = str(ip_address(ip_string))
             ip_data = self._city_db.city(ip_addr)
             geoip_data = GEOIP_DATA_STUBS.copy()
-            geoip_data.update({
-                "geometry.coordinates": [
-                    ip_data.location.longitude,
-                    ip_data.location.latitude,
-                ],
-                "properties.accuracy_radius": ip_data.location.accuracy_radius,
-                "properties.continent": ip_data.continent.name,
-                "properties.continent_code": ip_data.continent.code,
-                "properties.country": ip_data.country.name,
-                "properties.country_iso_code": ip_data.country.iso_code,
-                "properties.time_zone": ip_data.location.time_zone,
-                "properties.city": ip_data.city.name,
-                "properties.postal_code": ip_data.postal.code,
-                "properties.subdivision": ip_data.subdivisions.most_specific.name,
-            })
+            geoip_data.update(
+                {
+                    "geometry.coordinates": [
+                        ip_data.location.longitude,
+                        ip_data.location.latitude,
+                    ],
+                    "properties.accuracy_radius": ip_data.location.accuracy_radius,
+                    "properties.continent": ip_data.continent.name,
+                    "properties.continent_code": ip_data.continent.code,
+                    "properties.country": ip_data.country.name,
+                    "properties.country_iso_code": ip_data.country.iso_code,
+                    "properties.time_zone": ip_data.location.time_zone,
+                    "properties.city": ip_data.city.name,
+                    "properties.postal_code": ip_data.postal.code,
+                    "properties.subdivision": ip_data.subdivisions.most_specific.name,
+                }
+            )
             return geoip_data
         except (ValueError, AddressNotFoundError):
             return {}
@@ -87,8 +89,11 @@ class GeoipEnricher(Processor):
             if target_subfield in rule.customize_target_subfields:
                 full_output_field = rule.customize_target_subfields.get(target_subfield)
             adding_was_successful = add_field_to(
-                event, full_output_field, value, extends_lists=False,
-                overwrite_output_field=rule.overwrite_target
+                event=event,
+                output_field=full_output_field,
+                content=value,
+                extends_lists=False,
+                overwrite_output_field=rule.overwrite_target,
             )
             if not adding_was_successful:
                 raise DuplicationError(self.name, [full_output_field])

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -18,36 +18,16 @@ Example
 """
 from functools import cached_property
 from ipaddress import ip_address
-from typing import List
 
 from attr import define, field
 from geoip2 import database
 from geoip2.errors import AddressNotFoundError
 
 from logprep.abc import Processor
+from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.geoip_enricher.rule import GeoipEnricherRule
 from logprep.util.helper import add_field_to, get_dotted_field_value
 from logprep.util.validators import url_validator
-
-
-class GeoipEnricherError(BaseException):
-    """Base class for GeoipEnricher related exceptions."""
-
-    def __init__(self, name: str, message: str):
-        super().__init__(f"GeoipEnricher ({name}): {message}")
-
-
-class DuplicationError(GeoipEnricherError):
-    """Raise if field already exists."""
-
-    def __init__(self, name: str, skipped_fields: List[str]):
-        message = (
-            "The following fields already existed and "
-            "were not overwritten by the GeoipEnricher: "
-        )
-        message += " ".join(skipped_fields)
-
-        super().__init__(name, message)
 
 
 class GeoipEnricher(Processor):

--- a/logprep/processor/geoip_enricher/rule.py
+++ b/logprep/processor/geoip_enricher/rule.py
@@ -28,6 +28,21 @@ from attrs import define, field, validators
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.helper import add_and_overwrite, pop_dotted_field_value
 
+GEOIP_DATA_STUBS = {
+    "type": "Feature",
+    "geometry.type": "Point",
+    "geometry.coordinates": None,
+    "properties.accuracy_radius": None,
+    "properties.continent": None,
+    "properties.continent_code": None,
+    "properties.country": None,
+    "properties.country_iso_code": None,
+    "properties.time_zone": None,
+    "properties.city": None,
+    "properties.postal_code": None,
+    "properties.subdivision": None,
+}
+
 
 class GeoipEnricherRule(FieldManagerRule):
     """Check if documents match a filter."""
@@ -44,22 +59,7 @@ class GeoipEnricherRule(FieldManagerRule):
                 validators.deep_mapping(
                     key_validator=validators.and_(
                         validators.instance_of(str),
-                        validators.in_(
-                            [
-                                "type",
-                                "geometry.type",
-                                "geometry.coordinates",
-                                "properties.accuracy_radius",
-                                "properties.continent",
-                                "properties.continent_code",
-                                "properties.country",
-                                "properties.country_iso_code",
-                                "properties.time_zone",
-                                "properties.city",
-                                "properties.postal_code",
-                                "properties.subdivision",
-                            ]
-                        ),
+                        validators.in_(GEOIP_DATA_STUBS.keys()),
                     ),
                     value_validator=validators.instance_of(str),
                 ),
@@ -69,16 +69,17 @@ class GeoipEnricherRule(FieldManagerRule):
         """(Optional) Rewrites the default output subfield locations to custom output subfield
         locations. Must be in the form of key value mapping pairs
         (e.g. :code:`default_output: custom_output`). Following default outputs can be customized:
-        :code:`type`, :code:`geometry.type`, :code:`geometry.coordinates`,
-        :code:`properties.accuracy_radius`, :code:`properties.continent`,
-        :code:`properties.continent_code`, :code:`properties.country`,
-        :code:`properties.country_iso_code`, :code:`properties.time_zone`, :code:`properties.city`,
-        :code:`properties.postal_code`, :code:`properties.subdivision`. A concrete example would
-        look like:
+
+        .. datatemplate:import-module:: logprep.processor.geoip_enricher.rule
+
+            {% for item in data.GEOIP_DATA_STUBS.keys() %}
+                * :code:`{{ item }}`
+            {% endfor %}
+
+        A concrete example would look like this:
 
         ..  code-block:: yaml
             :linenos:
-            :caption: Geoip Enricher rule with customized target subfields
 
             filter: client.ip
             geoip:

--- a/logprep/processor/geoip_enricher/rule.py
+++ b/logprep/processor/geoip_enricher/rule.py
@@ -21,8 +21,9 @@ In the following example the IP in :code:`client.ip` will be enriched with geoip
 """
 
 import warnings
-from attrs import define, field, validators
 
+from attr import Factory
+from attrs import define, field, validators
 
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.helper import add_and_overwrite, pop_dotted_field_value
@@ -36,7 +37,62 @@ class GeoipEnricherRule(FieldManagerRule):
         """RuleConfig for GeoipEnricher"""
 
         target_field: str = field(validator=validators.instance_of(str), default="geoip")
-        """Field for the output information. Defaults to :code:`geoip`"""
+        """Field for the output information. Defaults to :code:`geoip`."""
+        customize_target_subfields: dict = field(
+            validator=[
+                validators.instance_of(dict),
+                validators.deep_mapping(
+                    key_validator=validators.and_(
+                        validators.min_len(4),
+                        validators.instance_of(str),
+                        validators.in_(
+                            [
+                                "type",
+                                "geometry.type",
+                                "geometry.coordinates",
+                                "properties.accuracy_radius",
+                                "properties.continent",
+                                "properties.continent_code",
+                                "properties.country",
+                                "properties.country_iso_code",
+                                "properties.time_zone",
+                                "properties.city",
+                                "properties.postal_code",
+                                "properties.subdivision",
+                            ]
+                        ),
+                    ),
+                    value_validator=validators.instance_of(str),
+                ),
+            ],
+            default=Factory(dict),
+        )
+        """(Optional) Rewrites the default output subfield locations to custom output subfield
+        locations. Must be in the form of key value mapping pairs
+        (e.g. :code:`default_output: custom_output`). Following default outputs can be customized:
+        :code:`type`, :code:`geometry.type`, :code:`geometry.coordinates`,
+        :code:`properties.accuracy_radius`, :code:`properties.continent`,
+        :code:`properties.continent_code`, :code:`properties.country`,
+        :code:`properties.country_iso_code`, :code:`properties.time_zone`, :code:`properties.city`,
+        :code:`properties.postal_code`, :code:`properties.subdivision`. A concrete example would
+        look like:
+
+        ..  code-block:: yaml
+            :linenos:
+            :caption: Geoip Enricher rule with customized target subfields
+
+            filter: client.ip
+            geoip:
+              source_fields: [client.ip]
+              customize_target_subfields:
+                geometry.type: client.geo.type
+                geometry.coordinates: client.geo.coordinates
+            description: '...'
+        """
+
+    @property
+    def customize_target_subfields(self) -> dict:  # pylint: disable=missing-function-docstring
+        return self._config.customize_target_subfields
 
     @classmethod
     def normalize_rule_dict(cls, rule: dict) -> None:

--- a/logprep/processor/geoip_enricher/rule.py
+++ b/logprep/processor/geoip_enricher/rule.py
@@ -43,7 +43,6 @@ class GeoipEnricherRule(FieldManagerRule):
                 validators.instance_of(dict),
                 validators.deep_mapping(
                     key_validator=validators.and_(
-                        validators.min_len(4),
                         validators.instance_of(str),
                         validators.in_(
                             [

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -129,7 +129,7 @@ class TestGeoipEnricher(BaseProcessorTestCase):
         with pytest.raises(
             DuplicationError,
             match=r"The following fields could not be written, because one or more subfields "
-                  r"existed and could not be extended: geoip.type",
+            r"existed and could not be extended: geoip.type",
         ):
             self.object.process(document)
 

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from geoip2.errors import AddressNotFoundError
 
-from logprep.processor.geoip_enricher.processor import DuplicationError
+from logprep.processor.base.exceptions import DuplicationError
 from tests.unit.processor.base import BaseProcessorTestCase
 
 
@@ -128,9 +128,8 @@ class TestGeoipEnricher(BaseProcessorTestCase):
 
         with pytest.raises(
             DuplicationError,
-            match=r"GeoipEnricher \(Test Instance Name\)\: The following fields "
-            r"already existed and were not overwritten by the GeoipEnricher\:"
-            r" geoip",
+            match=r"The following fields could not be written, because one or more subfields "
+                  r"existed and could not be extended: geoip.type",
         ):
             self.object.process(document)
 


### PR DESCRIPTION
Extends the `geoip_enricher` such that it's output subfields can be customized via a rule configuration. Furthermore, some refactorings were done.