### PR TITLE
add option to submit a template through `list_search_base_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Improvements
 
 * Add support for python `3.10` and `3.11`
+* Add option to submit a template with `list_search_base_path` config parameter in `list_comparison` processor
 
 ### Bugfixes
 

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -46,9 +46,9 @@ class ListComparison(Processor):
         list_search_base_path: str = field(validator=validators.instance_of(str))
         """Relative list paths in rules will be relative to this path if this is set.
         This parameter is optional. For string format see :ref:`getters`.
-        You can pass a template with keys from environment,
-        like :code:`${<your environemnt variable>}`. The special key :code:`${LOGPREP_LIST}`
-        will be filled by this processor."""
+        You can also pass a template with keys from environment,
+        e.g.,  :code:`${<your environment variable>}`. The special key :code:`${LOGPREP_LIST}`
+        will be filled by this processor. """
 
     rule_class = ListComparisonRule
 

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -45,7 +45,10 @@ class ListComparison(Processor):
 
         list_search_base_path: str = field(validator=validators.instance_of(str))
         """Relative list paths in rules will be relative to this path if this is set.
-        This parameter is optional. For string format see :ref:`getters`."""
+        This parameter is optional. For string format see :ref:`getters`.
+        You can pass a template with keys from environment,
+        like :code:`${<your environemnt variable>}`. The special key :code:`${LOGPREP_LIST}`
+        will be filled by this processor."""
 
     rule_class = ListComparisonRule
 

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -63,7 +63,9 @@ class ListComparisonRule(FieldManagerRule):
         """List of files. For string format see :ref:`getters`."""
         list_search_base_path: str = field(validator=validators.instance_of(str), factory=str)
         """Base Path from where to find relative files from :code:`list_file_paths`.
-        For string format see :ref:`getters`. (Optional)"""
+        For string format see :ref:`getters`. You can pass a template with keys from environment,
+        like :code:`${<your environemnt variable>}`. The special key :code:`${LOGPREP_LIST}`
+        will be filled by this processor. (Optional)"""
 
     def __init__(self, filter_rule: FilterExpression, config: dict):
         super().__init__(filter_rule, config)

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -78,6 +78,15 @@ class ListComparisonRule(FieldManagerRule):
     def init_list_comparison(self, list_search_base_path: Optional[str] = None):
         """init method for list_comparision lists"""
         list_search_base_path = self._get_list_search_base_path(list_search_base_path)
+        if list_search_base_path.startswith("http"):
+            for list_path in self._config.list_file_paths:
+                os.environ.update({"LOGPREP_LIST": list_path})
+                content = GetterFactory.from_string(list_search_base_path).get()
+                os.environ.pop("LOGPREP_LIST")
+                compare_elements = content.splitlines()
+                file_elem_tuples = [elem for elem in compare_elements if not elem.startswith("#")]
+                self._compare_sets.update({list_path: set(file_elem_tuples)})
+            return
         absolute_list_paths = [
             list_path for list_path in self._config.list_file_paths if list_path.startswith("/")
         ]

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -63,9 +63,9 @@ class ListComparisonRule(FieldManagerRule):
         """List of files. For string format see :ref:`getters`."""
         list_search_base_path: str = field(validator=validators.instance_of(str), factory=str)
         """Base Path from where to find relative files from :code:`list_file_paths`.
-        For string format see :ref:`getters`. You can pass a template with keys from environment,
-        like :code:`${<your environemnt variable>}`. The special key :code:`${LOGPREP_LIST}`
-        will be filled by this processor. (Optional)"""
+        You can also pass a template with keys from environment,
+        e.g.,  :code:`${<your environment variable>}`. The special key :code:`${LOGPREP_LIST}`
+        will be filled by this processor. """
 
     def __init__(self, filter_rule: FilterExpression, config: dict):
         super().__init__(filter_rule, config)

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -209,14 +209,13 @@ class TestListComparison(BaseProcessorTestCase):
             ),
         )
         document = {"user": "Franz"}
-        expected = {"user_results": {"in_list": ["user_list.txt"]}}
+        expected = {"user": "Franz", "user_results": {"in_list": ["user_list.txt"]}}
         rule_dict = {
             "filter": "user",
             "list_comparison": {
                 "source_fields": ["user"],
-                "target_field": "user",
+                "target_field": "user_results",
                 "list_file_paths": ["user_list.txt"],
-                "overwrite_target": True,
             },
             "description": "",
         }


### PR DESCRIPTION
* adds the feature to list_comparison processor to submit a template like `"http://${LOGPREP_TEST_TARGET}/${LOGPREP_LIST_SEARCH_BASE_PATH}/${LOGPREP_LIST}?ref=bla"` in `list_search_base_path` config option