### PR TITLE
fix artifacts load during process time

### DIFF
--- a/logprep/processor/domain_label_extractor/processor.py
+++ b/logprep/processor/domain_label_extractor/processor.py
@@ -77,12 +77,14 @@ class DomainLabelExtractor(Processor):
     def setup(self):
         super().setup()
         downloaded_tld_lists_paths = []
+        self._logger.debug("start tldlists download...")
         for index, tld_list in enumerate(self._config.tld_lists):
             list_path = Path(f"{current_process().name}-{self.name}-tldlist-{index}.dat")
             list_path.touch()
             list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
             downloaded_tld_lists_paths.append(f"file://{str(list_path.absolute())}")
         self._config.tld_lists = downloaded_tld_lists_paths
+        self._logger.debug("finished tldlists download...")
 
     def _apply_rules(self, event, rule: DomainLabelExtractorRule):
         """

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -143,12 +143,14 @@ class DomainResolver(Processor):
     def setup(self):
         super().setup()
         downloaded_tld_lists_paths = []
+        self._logger.debug("start tldlists download...")
         for index, tld_list in enumerate(self._config.tld_lists):
             list_path = Path(f"{current_process().name}-{self.name}-tldlist-{index}.dat")
             list_path.touch()
             list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
             downloaded_tld_lists_paths.append(f"file://{str(list_path.absolute())}")
         self._config.tld_lists = downloaded_tld_lists_paths
+        self._logger.debug("finished tldlists download...")
 
     def _apply_rules(self, event, rule):
         source_field = rule.source_fields[0]

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -26,10 +26,11 @@ Example
         debug_cache: false
 """
 import datetime
+from pathlib import Path
 import socket
 from functools import cached_property
 from logging import Logger
-from multiprocessing import context
+from multiprocessing import context, current_process
 from multiprocessing.pool import ThreadPool
 from typing import Optional
 
@@ -40,6 +41,7 @@ from logprep.abc import Processor
 from logprep.processor.base.exceptions import DuplicationError
 from logprep.processor.domain_resolver.rule import DomainResolverRule
 from logprep.util.cache import Cache
+from logprep.util.getter import GetterFactory
 from logprep.util.hasher import SHA256Hasher
 from logprep.util.helper import add_field_to, get_dotted_field_value
 from logprep.util.validators import list_of_urls_validator
@@ -137,6 +139,16 @@ class DomainResolver(Processor):
         if self._config.tld_lists is not None:
             return TLDExtract(suffix_list_urls=self._config.tld_lists)
         return TLDExtract()
+
+    def setup(self):
+        super().setup()
+        downloaded_tld_lists_paths = []
+        for index, tld_list in enumerate(self._config.tld_lists):
+            list_path = Path(f"{current_process().name}-{self.name}-tldlist-{index}.dat")
+            list_path.touch()
+            list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
+            downloaded_tld_lists_paths.append(f"file://{str(list_path.absolute())}")
+        self._config.tld_lists = downloaded_tld_lists_paths
 
     def _apply_rules(self, event, rule):
         source_field = rule.source_fields[0]

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -19,6 +19,7 @@ Example
 from functools import cached_property
 from ipaddress import ip_address
 from pathlib import Path
+from multiprocessing import current_process
 
 from attr import define, field, validators
 from geoip2 import database
@@ -59,7 +60,7 @@ class GeoipEnricher(Processor):
         db_path = Path(self._config.db_path)
         if not db_path.exists():
             self._logger.debug("start geoip database download...")
-            db_path_file = Path(db_path.name)
+            db_path_file = Path(f"{current_process().name}-{self.name}.mmdb")
             db_path_file.touch()
             db_path_file.write_bytes(GetterFactory.from_string(str(self._config.db_path)).get_raw())
             self._logger.debug("finished geoip database download.")

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
@@ -350,7 +350,7 @@ class TestDomainLabelExtractor(BaseProcessorTestCase):
         assert document == expected
 
     @responses.activate
-    def test_setup_downloads_tld_lists_to_seperate_process_file(self):
+    def test_setup_downloads_tld_lists_to_separate_process_file(self):
         tld_list = "http://db-path-target/list.dat"
         tld_list_content = Path("/usr/bin/ls").read_bytes()
         expected_checksum = hashlib.md5(tld_list_content).hexdigest()  # nosemgrep

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
@@ -1,7 +1,11 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
 
+import hashlib
+from multiprocessing import current_process
+from pathlib import Path
 import pytest
+import responses
 
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.domain_label_extractor.processor import DuplicationError
@@ -344,3 +348,18 @@ class TestDomainLabelExtractor(BaseProcessorTestCase):
         with pytest.raises(DuplicationError):
             self.object.process(document)
         assert document == expected
+
+    @responses.activate
+    def test_setup_downloads_tld_lists_to_seperate_process_file(self):
+        tld_list = "http://db-path-target/list.dat"
+        tld_list_content = Path("/usr/bin/ls").read_bytes()
+        expected_checksum = hashlib.md5(tld_list_content).hexdigest()  # nosemgrep
+        responses.add(responses.GET, tld_list, tld_list_content)
+        self.object._config.tld_lists = [tld_list]
+        self.object.setup()
+        downloaded_file = Path(f"{current_process().name}-{self.object.name}-tldlist-0.dat")
+        assert downloaded_file.exists()
+        downloaded_checksum = hashlib.md5(downloaded_file.read_bytes()).hexdigest()  # nosemgrep
+        assert expected_checksum == downloaded_checksum
+        # delete testfile
+        downloaded_file.unlink()

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 from copy import deepcopy
+import hashlib
+from multiprocessing import current_process
 from os.path import exists
 from pathlib import Path
 from unittest import mock
@@ -273,3 +275,18 @@ sth.ac.at
         self._load_specific_rule(rule_dict)
         self.object.process(document)
         assert document == expected
+
+    @responses.activate
+    def test_setup_downloads_tld_lists_to_seperate_process_file(self):
+        tld_list = "http://db-path-target/list.dat"
+        tld_list_content = Path("/usr/bin/ls").read_bytes()
+        expected_checksum = hashlib.md5(tld_list_content).hexdigest()  # nosemgrep
+        responses.add(responses.GET, tld_list, tld_list_content)
+        self.object._config.tld_lists = [tld_list]
+        self.object.setup()
+        downloaded_file = Path(f"{current_process().name}-{self.object.name}-tldlist-0.dat")
+        assert downloaded_file.exists()
+        downloaded_checksum = hashlib.md5(downloaded_file.read_bytes()).hexdigest()  # nosemgrep
+        assert expected_checksum == downloaded_checksum
+        # delete testfile
+        downloaded_file.unlink()

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -277,7 +277,7 @@ sth.ac.at
         assert document == expected
 
     @responses.activate
-    def test_setup_downloads_tld_lists_to_seperate_process_file(self):
+    def test_setup_downloads_tld_lists_to_separate_process_file(self):
         tld_list = "http://db-path-target/list.dat"
         tld_list_content = Path("/usr/bin/ls").read_bytes()
         expected_checksum = hashlib.md5(tld_list_content).hexdigest()  # nosemgrep

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=no-member
 import hashlib
+from multiprocessing import current_process
 from pathlib import Path
 from unittest import mock
 
@@ -312,7 +313,7 @@ class TestGeoipEnricher(BaseProcessorTestCase):
         responses.add(responses.GET, geoip_database_path, db_path_content)
         self.object._config.db_path = geoip_database_path
         self.object.setup()
-        downloaded_file = Path("db_file.mmdb")
+        downloaded_file = Path(f"{current_process().name}-{self.object.name}.mmdb")
         assert downloaded_file.exists()
         downloaded_checksum = hashlib.md5(downloaded_file.read_bytes()).hexdigest()  # nosemgrep
         assert expected_checksum == downloaded_checksum


### PR DESCRIPTION
This PR fixes a bug, that the domain_label_extractor and domain_resolver download the tldlists during processing time. 
With this fix the tld lists were downloaded during setup time.
Additionally the lists were saved per process and per processor instance to avoid problems with getting a file lock on the downloaded artifacts. 