### PR TITLE
Fix error with regex normalization

### DIFF
--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -296,13 +296,16 @@ class RegExFilterExpression(FilterExpression):
 
     @staticmethod
     def _normalize_regex(regex: str) -> str:
-        match = re.match(
-            r"^(?P<flag>\(\?\w\))?(?P<start>\^)?(?P<pattern>[^\$]*)(?P<end>\$)?", regex
-        )
-        flag, _, pattern, _ = match.groups()
+        match = re.match(r".*?(?P<escaping>\\*)\$$", regex)
+        if match and len(match.group("escaping")) % 2 == 0:
+            end_token = ""
+        else:
+            end_token = "$"
+        match = re.match(r"^(?P<flag>\(\?\w\))?(?P<start>\^)?(?P<pattern>.*)", regex)
+        flag, _, pattern = match.groups()
         flag = "" if flag is None else flag
         pattern = "" if pattern is None else pattern
-        return rf"{flag}^{pattern}$"
+        return rf"{flag}^{pattern}{end_token}"
 
     def does_match(self, document: dict) -> bool:
         value = self._get_value(self._key, document)

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=attribute-defined-outside-init
-# pylint: disable=no-self-use
 # pylint: disable=redefined-builtin
 # pylint: disable=protected-access
 from random import sample
@@ -316,7 +315,12 @@ class TestRegExFilterExpression(ValueBasedFilterExpressionTest):
                 r"(?i)^[\\s\\w\\W]*(bxor|join|char)[\\s\\w\\W]$",
             ),
             (r"start.*end", r"^start.*end$"),
+            (r"(^foo$)", r"^(^foo$)$"),
             (r"", r"^$"),
+            (r"\$", r"^\$$"),
+            (r"\\$", r"^\\$"),
+            (r"foo\$", r"^foo\$$"),
+            (r"foo\\$", r"^foo\\$"),
             (r"^start.*end$", r"^start.*end$"),
             (r"^start.*end", r"^start.*end$"),
             (r"start.*end$", r"^start.*end$"),


### PR DESCRIPTION
The problem was, that the normalization did cut of everything after "$". However, having multiple "$" is valid even if redundant. This is a problem if an expected closing parenthesis is located after a "$".
Additionally, escaped "$" are handled now.