### PR TITLE
Fix auto rule tester to call all processor setup methods

### DIFF
--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -54,9 +54,9 @@ class ListComparison(Processor):
 
     def __init__(self, name: str, configuration: "Processor.Config", logger: Logger):
         super().__init__(name, configuration, logger)
-        self._init_rules_list_comparison()
+        self.setup()
 
-    def _init_rules_list_comparison(self):
+    def setup(self):
         for rule in [*self._specific_rules, *self._generic_rules]:
             rule.init_list_comparison(self._config.list_search_base_path)
 

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -140,7 +140,6 @@ class Pseudonymizer(Processor):
         self.pseudonyms = []
         self.pseudonymized_fields = set()
         self.setup()
-        self._replace_regex_keywords_by_regex_expression()
 
     @cached_property
     def _url_extractor(self):
@@ -165,6 +164,7 @@ class Pseudonymizer(Processor):
         )
         self._init_tld_extractor()
         self._load_regex_mapping(self._config.regex_mapping)
+        self._replace_regex_keywords_by_regex_expression()
 
     def _init_tld_extractor(self):
         if self._config.tld_lists is not None:
@@ -346,10 +346,12 @@ class Pseudonymizer(Processor):
     def _replace_regex_keywords_by_regex_expression(self):
         for rule in self._specific_rules:
             for dotted_field, regex_keyword in rule.pseudonyms.items():
-                rule.pseudonyms[dotted_field] = self._regex_mapping[regex_keyword]
+                if regex_keyword in self._regex_mapping:
+                    rule.pseudonyms[dotted_field] = self._regex_mapping[regex_keyword]
         for rule in self._generic_rules:
             for dotted_field, regex_keyword in rule.pseudonyms.items():
-                rule.pseudonyms[dotted_field] = self._regex_mapping[regex_keyword]
+                if regex_keyword in self._regex_mapping:
+                    rule.pseudonyms[dotted_field] = self._regex_mapping[regex_keyword]
 
     def _wrap_hash(self, hash_string: str) -> str:
         return self.HASH_PREFIX + hash_string + self.HASH_SUFFIX

--- a/logprep/util/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester.py
@@ -14,17 +14,15 @@ from logging import getLogger
 from os import walk, path
 from pprint import pprint
 from typing import Tuple, TYPE_CHECKING
-from logprep.framework.rule_tree.rule_tree import RuleTree
 
-from typing.io import TextIO
 import regex as re
 from colorama import Fore
 from ruamel.yaml import YAML, YAMLError
+from typing.io import TextIO
 
-from logprep.processor.pre_detector.processor import PreDetector
-from logprep.processor.pseudonymizer.processor import Pseudonymizer
-from logprep.processor.list_comparison.processor import ListComparison
 from logprep.factory import Factory
+from logprep.framework.rule_tree.rule_tree import RuleTree
+from logprep.processor.pre_detector.processor import PreDetector
 from logprep.util.grok_pattern_loader import GrokPatternLoader as gpl
 from logprep.util.helper import print_fcolor, remove_file_if_exists, get_dotted_field_value
 
@@ -355,14 +353,8 @@ class AutoRuleTester:
             processor.load_rules(self._empty_rules_dirs, [])
         elif rule_type == "generic_rules":
             processor.load_rules([], self._empty_rules_dirs)
-        self._do_processor_specific_setup(processor)
+        processor.setup()
 
-    @staticmethod
-    def _do_processor_specific_setup(processor: "Processor"):
-        if isinstance(processor, Pseudonymizer):
-            processor._replace_regex_keywords_by_regex_expression()
-        if isinstance(processor, ListComparison):
-            processor._init_rules_list_comparison()
 
     def _prepare_test_eval(
         self, processor: "Processor", rule_dict: dict, rule_type: str, temp_rule_path: str

--- a/logprep/util/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester.py
@@ -355,7 +355,6 @@ class AutoRuleTester:
             processor.load_rules([], self._empty_rules_dirs)
         processor.setup()
 
-
     def _prepare_test_eval(
         self, processor: "Processor", rule_dict: dict, rule_type: str, temp_rule_path: str
     ):

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -191,7 +191,7 @@ class TestListComparison(BaseProcessorTestCase):
         }
         expected = {"user_results": {"in_list": ["user_list.txt"]}}
         self._load_specific_rule(rule_dict)
-        self.object._init_rules_list_comparison()
+        self.object.setup()
         self.object.process(document)
         assert document == expected
 
@@ -209,7 +209,7 @@ class TestListComparison(BaseProcessorTestCase):
             "description": "",
         }
         self._load_specific_rule(rule_dict)
-        self.object._init_rules_list_comparison()
+        self.object.setup()
         match = (
             r"ProcessingWarning: \(Test Instance Name - The following fields could not be written, "
             r"because one or more subfields existed and could not be extended: user\.in_list\)"
@@ -247,7 +247,7 @@ Hans
         processor = Factory.create({"custom_lister": config}, self.logger)
         rule = processor.rule_class._create_from_dict(rule_dict)
         processor._specific_tree.add_rule(rule)
-        processor._init_rules_list_comparison()
+        processor.setup()
         assert processor._specific_rules[0].compare_sets == {
             "bad_users.list": {"Franz", "Heinz", "Hans"}
         }

--- a/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
+++ b/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
@@ -6,8 +6,9 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+
 from logprep.factory import Factory
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.pseudonymizer.rule import PseudonymizerRule
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -102,8 +103,7 @@ class TestPseudonymizer(BaseProcessorTestCase):
         )
 
     def test_recently_stored_pseudonyms_are_not_stored_again(self):
-        self.object._cache_max_timedelta = CACHE_MAX_TIMEDELTA
-        self.object.setup()
+        self.object._cache._max_timedelta = CACHE_MAX_TIMEDELTA
         event = {"event_id": 1234, "something": "something"}
 
         rule_dict = {
@@ -312,7 +312,6 @@ class TestPseudonymizer(BaseProcessorTestCase):
             }
         }
 
-        self.object.setup()
         self.object.process(event)
 
         assert (

--- a/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
+++ b/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
@@ -652,3 +652,14 @@ class TestPseudonymizer(BaseProcessorTestCase):
         self._load_specific_rule(rule)
         self.object.process(event)
         return event
+
+    def test_replace_regex_keywords_by_regex_expression_can_be_called_multiple_times(self):
+        rule_dict = {
+            "filter": "event_id: 1234",
+            "pseudonymizer": {"pseudonyms": {"something": "RE_WHOLE_FIELD"}},
+            "description": "description content irrelevant for these tests",
+        }
+        self._load_specific_rule(rule_dict)  # First call
+        assert self.object._specific_tree.rules[0].pseudonyms == {"something": "(.*)"}
+        self.object._replace_regex_keywords_by_regex_expression()  # Second Call
+        assert self.object._specific_tree.rules[0].pseudonyms == {"something": "(.*)"}

--- a/tests/unit/util/test_auto_rule_tester.py
+++ b/tests/unit/util/test_auto_rule_tester.py
@@ -166,10 +166,10 @@ class TestAutoRuleTester:
         assert mock_replace_regex_keywords_by_regex_expression.call_count == 2
 
     @mock.patch(
-        "logprep.processor.list_comparison.processor.ListComparison._init_rules_list_comparison"
+        "logprep.processor.list_comparison.processor.ListComparison.setup"
     )
     def test_list_comparison_specific_setup_called_on_load_rules(
-        self, mock_init_rules_list_comparison, auto_rule_tester
+        self, mock_setup, auto_rule_tester
     ):
         list_comparison_cfg = {
             "type": "list_comparison",
@@ -178,16 +178,16 @@ class TestAutoRuleTester:
             "tree_config": "tests/testdata/unit/shared_data/tree_config.json",
             "list_search_base_path": "tests/testdata/unit/list_comparison/rules",
         }
-        mock_init_rules_list_comparison.assert_not_called()
+        mock_setup.assert_not_called()
         processor = auto_rule_tester._get_processor_instance(
             "list_comparison", list_comparison_cfg, LOGGER
         )
         auto_rule_tester._reset_trees(
             processor
         )  # Called every time by auto tester before adding rules instead
-        mock_init_rules_list_comparison.assert_called_once()
+        mock_setup.assert_called_once()
         auto_rule_tester._load_rules(processor, "specific_rules")
-        assert mock_init_rules_list_comparison.call_count == 2
+        assert mock_setup.call_count == 2
 
     def test_full_auto_rule_test_run(self, auto_rule_tester, capsys):
         with pytest.raises(SystemExit):

--- a/tests/unit/util/test_auto_rule_tester.py
+++ b/tests/unit/util/test_auto_rule_tester.py
@@ -165,9 +165,7 @@ class TestAutoRuleTester:
         auto_rule_tester._load_rules(processor, "specific_rules")
         assert mock_replace_regex_keywords_by_regex_expression.call_count == 2
 
-    @mock.patch(
-        "logprep.processor.list_comparison.processor.ListComparison.setup"
-    )
+    @mock.patch("logprep.processor.list_comparison.processor.ListComparison.setup")
     def test_list_comparison_specific_setup_called_on_load_rules(
         self, mock_setup, auto_rule_tester
     ):


### PR DESCRIPTION
The auto-rule-tester didn't load the tldextract lists properly because the processor setup method wasn't called in the auto-rule-tester. This pull requests fixes it by calling all setup methods and adjusting the list_comparision processor as well as the pseudonymizer to make proper use of the setup method. 