### PR TITLE
Fix typing in ip_informer processor

### DIFF
--- a/logprep/processor/ip_informer/processor.py
+++ b/logprep/processor/ip_informer/processor.py
@@ -20,7 +20,7 @@ Example
 from functools import partial
 import ipaddress
 from itertools import chain
-from typing import Iterable
+from typing import Dict, Iterable, List, Tuple
 from logprep.processor.base.exceptions import ProcessingWarning
 
 from logprep.processor.field_manager.processor import FieldManager
@@ -33,11 +33,11 @@ class IpInformer(FieldManager):
 
     __slots__ = ("_processing_warnings",)
 
-    _processing_warnings: list[tuple[str, Exception]]
+    _processing_warnings: List[Tuple[str, Exception]]
 
     rule_class = IpInformerRule
 
-    def _apply_rules(self, event: dict, rule: IpInformerRule) -> None:
+    def _apply_rules(self, event: Dict, rule: IpInformerRule) -> None:
         self._processing_warnings = []
         ip_address_list = self._get_flat_ip_address_list(event, rule)
         results = self._get_results(ip_address_list)
@@ -46,17 +46,17 @@ class IpInformer(FieldManager):
         for msg, error in self._processing_warnings:
             raise ProcessingWarning(msg) from error
 
-    def _get_results(self, ip_address_list: Iterable) -> dict:
+    def _get_results(self, ip_address_list: Iterable) -> Dict:
         results = [(ip, self._ip_properties(ip)) for ip in ip_address_list]
         return dict(filter(lambda x: bool(x[1]), results))
 
-    def _get_flat_ip_address_list(self, event: dict, rule: IpInformerRule) -> Iterable:
+    def _get_flat_ip_address_list(self, event: Dict, rule: IpInformerRule) -> Iterable:
         source_field_values = list(map(partial(get_dotted_field_value, event), rule.source_fields))
         list_elements = filter(lambda x: isinstance(x, list), source_field_values)
         str_elements = filter(lambda x: isinstance(x, str), source_field_values)
         return chain(*list_elements, str_elements)
 
-    def _ip_properties(self, ip_address: str) -> dict[str, any]:
+    def _ip_properties(self, ip_address: str) -> Dict[str, any]:
         try:
             ip_address = ipaddress.ip_address(ip_address)
         except ValueError as error:


### PR DESCRIPTION
When running the logprep auto tests, I get the following error:

```
File "logprep/processor/ip_informer/processor.py", line36, in IpInformer _processing_warnings: list[tuple[str, Exception]]
TypeError: 'type' object is not subscriptable
```

This PR fixes this error and allows the auto tests to run.