### PR TITLE
fix opensearch-output-connector-raises-to-late-if-unauthenticated 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -188,7 +186,7 @@ jobs:
         with:
           push: true # Will only build if this is not here
           build-args: |
-            LOGPREP_VERSION=latest
+            LOGPREP_VERSION=dev
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### Bugfix
 
-* fixes a bug that breaks templating config and rule files with environment variables if one or more
-variables are not set in environment
+* fixes a bug that breaks templating config and rule files with environment variables if one or more variables are not set in environment
+* fixes a bug for `opensearch_output` and `elasticsearch_output` not handling authentication issues
 
 ## v5.0.1
 

--- a/doc/source/user_manual/configuration/configurationdata.rst
+++ b/doc/source/user_manual/configuration/configurationdata.rst
@@ -22,7 +22,8 @@ Details for configuring connectors are described in :ref:`output` and :ref:`inpu
 General information about the configuration of the pipeline can be found in :ref:`pipeline_config` .
 
 It is possible to use environment variables in all configuration and rules files in all places.
-Environment variables have to be set in uppercase. Lowercase variables are ignored.
+Environment variables have to be set in uppercase. Lowercase variables are ignored. Forbidden
+variable names are: :code:`["LOGPREP_LIST"]`
 
 The following config file will be valid by setting the given environment variables:
 

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -60,7 +60,7 @@ class Getter(ABC):
             var
             for var in {*used_env_vars, *used_braced_env_vars}
             if var not in BLOCKLIST_VARIABLE_NAMES
-        ]  # deduplicate and clean blacklisted values
+        ]  # deduplicate and clean blocklisted values
 
     def get_yaml(self) -> Union[Dict, List]:
         """gets and parses the raw content to yaml"""

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -10,6 +10,12 @@ from attrs import define, field, validators
 
 yaml = YAML(typ="safe", pure=True)
 
+BLACKLIST_VARIABLE_NAMES = [
+    "",
+    " ",
+    "LOGPREP_LIST",  # used by list_comparison processor
+]
+
 
 @define(kw_only=True)
 class Getter(ABC):
@@ -51,8 +57,10 @@ class Getter(ABC):
         used_env_vars = map(lambda x: x[1], found_variables)
         used_braced_env_vars = map(lambda x: x[2], found_variables)
         return [
-            var for var in {*used_env_vars, *used_braced_env_vars} if var
-        ]  # deduplicate and clean out whitespace
+            var
+            for var in {*used_env_vars, *used_braced_env_vars}
+            if var not in BLACKLIST_VARIABLE_NAMES
+        ]  # deduplicate and clean blacklisted values
 
     def get_yaml(self) -> Union[Dict, List]:
         """gets and parses the raw content to yaml"""

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -10,7 +10,7 @@ from attrs import define, field, validators
 
 yaml = YAML(typ="safe", pure=True)
 
-BLACKLIST_VARIABLE_NAMES = [
+BLOCKLIST_VARIABLE_NAMES = [
     "",
     " ",
     "LOGPREP_LIST",  # used by list_comparison processor
@@ -59,7 +59,7 @@ class Getter(ABC):
         return [
             var
             for var in {*used_env_vars, *used_braced_env_vars}
-            if var not in BLACKLIST_VARIABLE_NAMES
+            if var not in BLOCKLIST_VARIABLE_NAMES
         ]  # deduplicate and clean blacklisted values
 
     def get_yaml(self) -> Union[Dict, List]:

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -1,5 +1,6 @@
 """Module for getter interface"""
 from abc import ABC, abstractmethod
+from copy import deepcopy
 import os
 import re
 from string import Template
@@ -47,20 +48,28 @@ class Getter(ABC):
         """
         content = self.get_raw().decode("utf8")
         template = self.EnvTemplate(content)
+        kwargs = self._get_kwargs(template, content)
+        return template.safe_substitute(**kwargs)
+
+    def _get_kwargs(self, template, content):
         used_env_vars = self._get_used_env_vars(content, template)
         self.missing_env_vars = [env_var for env_var in used_env_vars if env_var not in os.environ]
         defaults_for_missing = {missing_key: "" for missing_key in self.missing_env_vars}
-        return template.safe_substitute({**os.environ, **defaults_for_missing})
+        kwargs = deepcopy(os.environ)
+        kwargs |= defaults_for_missing
+        return dict(filter(lambda item: self._not_in_blocklist(item[0]), kwargs.items()))
 
     def _get_used_env_vars(self, content, template):
-        found_variables = template.pattern.findall(content)
-        used_env_vars = map(lambda x: x[1], found_variables)
+        found_variables = template.pattern.findall(
+            content
+        )  # returns a list of tuples in form (escaped, named, braced, invalid)
+        used_named_env_vars = map(lambda x: x[1], found_variables)
         used_braced_env_vars = map(lambda x: x[2], found_variables)
-        return [
-            var
-            for var in {*used_env_vars, *used_braced_env_vars}
-            if var not in BLOCKLIST_VARIABLE_NAMES
-        ]  # deduplicate and clean blocklisted values
+        return filter(self._not_in_blocklist, {*used_named_env_vars, *used_braced_env_vars})
+
+    @staticmethod
+    def _not_in_blocklist(var):
+        return var not in BLOCKLIST_VARIABLE_NAMES
 
     def get_yaml(self) -> Union[Dict, List]:
         """gets and parses the raw content to yaml"""

--- a/logprep/connector/elasticsearch/output.py
+++ b/logprep/connector/elasticsearch/output.py
@@ -41,7 +41,7 @@ import arrow
 import elasticsearch
 from attr import define, field
 from attrs import validators
-from elasticsearch import helpers
+from elasticsearch import helpers, AuthenticationException
 
 from logprep.abc.output import FatalOutputError, Output
 
@@ -363,5 +363,7 @@ class ElasticsearchOutput(Output):
 
     def setup(self):
         super().setup()
-        info = self._search_context.info()
-        assert info
+        try:
+            self._search_context.info()
+        except AuthenticationException as error:
+            raise FatalOutputError(error) from error

--- a/logprep/connector/elasticsearch/output.py
+++ b/logprep/connector/elasticsearch/output.py
@@ -360,3 +360,8 @@ class ElasticsearchOutput(Output):
             for date_format_match in date_format_matches:
                 formatted_date = now.format(date_format_match[2:-1])
                 document["_index"] = re.sub(date_format_match, formatted_date, document["_index"])
+
+    def setup(self):
+        super().setup()
+        info = self._search_context.info()
+        assert info

--- a/logprep/connector/opensearch/output.py
+++ b/logprep/connector/opensearch/output.py
@@ -34,6 +34,7 @@ import logging
 from functools import cached_property
 
 import opensearchpy as opensearch
+from opensearchpy import AuthenticationException
 
 from logprep.abc.output import FatalOutputError, Output
 from logprep.connector.elasticsearch.output import ElasticsearchOutput
@@ -147,3 +148,9 @@ class OpensearchOutput(ElasticsearchOutput):
 
         """
         raise FatalOutputError(f"{error.args[1]} in document {error.args[0]}")
+
+    def setup(self):
+        try:
+            super().setup()
+        except AuthenticationException as error:
+            raise FatalOutputError(error) from error

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -294,7 +294,12 @@ class Pipeline:
         )
         self._input.pipeline_index = self.pipeline_index
         self._input.setup()
-        self._output.setup()
+        try:
+            self._output.setup()
+        except FatalOutputError as error:
+            self._logger.error(f"Output {self._output.describe()} failed: {error}")
+            self._output.metrics.number_of_errors += 1
+            self.stop()
         if hasattr(self._input, "server"):
             while self._input.server.config.port in self._used_server_ports:
                 self._input.server.config.port += 1

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -299,7 +299,7 @@ class Pipeline:
         except FatalOutputError as error:
             self._logger.error(f"Output {self._output.describe()} failed: {error}")
             self._output.metrics.number_of_errors += 1
-            raise error
+            self.stop()
         if hasattr(self._input, "server"):
             while self._input.server.config.port in self._used_server_ports:
                 self._input.server.config.port += 1
@@ -318,13 +318,13 @@ class Pipeline:
 
     def run(self) -> None:
         """Start processing processors in the Pipeline."""
+        self._enable_iteration()
         assert self._input, "Pipeline should not be run without input connector"
         assert self._output, "Pipeline should not be run without output connector"
         with self._lock:
             with warnings.catch_warnings():
                 warnings.simplefilter("default")
                 self._setup()
-        self._enable_iteration()
         self._logger.debug(f"Start iterating ({self._process_name})")
         if hasattr(self._input, "server"):
             with self._input.server.run_in_thread():

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -299,7 +299,7 @@ class Pipeline:
         except FatalOutputError as error:
             self._logger.error(f"Output {self._output.describe()} failed: {error}")
             self._output.metrics.number_of_errors += 1
-            self.stop()
+            raise error
         if hasattr(self._input, "server"):
             while self._input.server.config.port in self._used_server_ports:
                 self._input.server.config.port += 1

--- a/tests/unit/connector/test_elasticsearch_output.py
+++ b/tests/unit/connector/test_elasticsearch_output.py
@@ -225,3 +225,9 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     def test_handle_serialization_error_raises_fatal_output_error(self):
         with pytest.raises(FatalOutputError):
             self.object._handle_serialization_error(mock.MagicMock())
+
+    def test_setup_raises_fatal_output_error_if_unauthenticated(self):
+        self.object._search_context.info = mock.MagicMock()
+        self.object._search_context.info.side_effect = elasticsearch.AuthenticationException
+        with pytest.raises(FatalOutputError):
+            self.object.setup()

--- a/tests/unit/connector/test_opensearch_output.py
+++ b/tests/unit/connector/test_opensearch_output.py
@@ -248,3 +248,9 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     def test_handle_serialization_error_raises_fatal_output_error(self):
         with pytest.raises(FatalOutputError):
             self.object._handle_serialization_error(mock.MagicMock())
+
+    def test_setup_raises_fatal_output_error_if_unauthenticated(self):
+        self.object._search_context.info = mock.MagicMock()
+        self.object._search_context.info.side_effect = opensearchpy.AuthenticationException
+        with pytest.raises(FatalOutputError):
+            self.object.setup()

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -414,6 +414,16 @@ class TestPipeline(ConfigurationForTests):
         assert re.search("Output .* failed:", mock_error.call_args[0][0]), "error message is logged"
         mock_shut_down.assert_called()
 
+    @mock.patch("logging.Logger.error")
+    def test_processor_fatal_output_error_in_setup_is_logged_pipeline_is_rebuilt(
+        self, mock_error, _
+    ):
+        self.pipeline._output = mock.MagicMock()
+        self.pipeline._output.setup.side_effect = FatalOutputError
+        self.pipeline.run()
+        mock_error.assert_called()
+        assert re.search("Output .* failed:", mock_error.call_args[0][0]), "error message is logged"
+
     def test_extra_data_tuple_is_passed_to_store_custom(self, _):
         self.pipeline._setup()
         self.pipeline._input.get_next.return_value = ({"some": "event"}, None)

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -108,6 +108,14 @@ class TestGetterFactory:
         my_getter = GetterFactory.from_string(str(testfile))
         assert my_getter.get() == "this is my mytoken, and this is my ${not_a_token}"
 
+    def test_getter_ignores_list_comparison_logprep_list_variable(self, tmp_path):
+        os.environ.update({"PYTEST_TEST_TOKEN": "mytoken"})
+        testfile = tmp_path / "test_getter.json"
+        testfile.write_text("this is my ${PYTEST_TEST_TOKEN}, and this is my ${LOGPREP_LIST}")
+        my_getter = GetterFactory.from_string(str(testfile))
+        assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
+        assert len(my_getter.missing_env_vars) == 0
+
     def test_getter_expands_environment_variables_in_yaml_content(self, tmp_path):
         os.environ.update({"PYTEST_TEST_TOKEN": "mytoken"})
         testfile = tmp_path / "test_getter.json"

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -116,7 +116,7 @@ class TestGetterFactory:
         assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
         assert len(my_getter.missing_env_vars) == 0
 
-    def test_getter_ignores_list_comparison_logprep_list_variable_if_setted(self, tmp_path):
+    def test_getter_ignores_list_comparison_logprep_list_variable_if_set(self, tmp_path):
         os.environ.update({"PYTEST_TEST_TOKEN": "mytoken"})
         os.environ.update({"LOGPREP_LIST": "foo"})
         testfile = tmp_path / "test_getter.json"

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -116,6 +116,15 @@ class TestGetterFactory:
         assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
         assert len(my_getter.missing_env_vars) == 0
 
+    def test_getter_ignores_list_comparison_logprep_list_variable_if_setted(self, tmp_path):
+        os.environ.update({"PYTEST_TEST_TOKEN": "mytoken"})
+        os.environ.update({"LOGPREP_LIST": "foo"})
+        testfile = tmp_path / "test_getter.json"
+        testfile.write_text("this is my ${PYTEST_TEST_TOKEN}, and this is my ${LOGPREP_LIST}")
+        my_getter = GetterFactory.from_string(str(testfile))
+        assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
+        assert len(my_getter.missing_env_vars) == 0
+
     def test_getter_expands_environment_variables_in_yaml_content(self, tmp_path):
         os.environ.update({"PYTEST_TEST_TOKEN": "mytoken"})
         testfile = tmp_path / "test_getter.json"


### PR DESCRIPTION
* adds blacklist variable names to enrichment from environment, because we use a special variable LOGPREP_LIST in list_comparison
* fixes docker build for branch and not for main for PRs
* adds connection check for opensearch and elasticsearch output connectors