### PR TITLE
remove verification of configuration in pipeline manager and run_logprep

### DIFF
--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -38,8 +38,7 @@ class PipelineManager:
         self._used_server_ports = None
 
     def set_configuration(self, configuration: Configuration):
-        """Verify the configuration and set it in the pipeline manager."""
-        configuration.verify(self._logger)
+        """set the verified config"""
         self._configuration = configuration
 
         manager = Manager()

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -219,6 +219,11 @@ def main():
         )
         dry_runner.run()
     elif args.verify_config:
+        try:
+            config.verify(logger)
+        except InvalidConfigurationError as error:
+            logger.critical(error)
+            sys.exit(1)
         print_fcolor(Fore.GREEN, "The verification of the configuration was successful")
     elif args.auto_corpus_test:
         if args.corpus_testdata is None:

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -104,6 +104,7 @@ def _run_logprep(arguments, logger: Logger):
         logger.critical(f"A critical error occurred: {error}")
         if runner:
             runner.stop()
+        sys.exit(1)
     # pylint: enable=broad-except
 
 
@@ -164,20 +165,6 @@ def _load_configuration(args):
     return config
 
 
-def _verify_configuration(args, config, logger):
-    try:
-        if args.validate_rules or args.auto_test:
-            config.verify_pipeline_only(logger)
-        else:
-            config.verify(logger)
-    except InvalidConfigurationError as error:
-        logger.critical(error)
-        sys.exit(1)
-    except BaseException as error:  # pylint: disable=broad-except
-        logger.exception(error)
-        sys.exit(1)
-
-
 def _setup_metrics_and_time_measurement(args, config, logger):
     measure_time_config = config.get("metrics", {}).get("measure_time", {})
     TimeMeasurement.TIME_MEASUREMENT_ENABLED = measure_time_config.get("enabled", False)
@@ -212,7 +199,6 @@ def main():
     config = _load_configuration(args)
     logger = _setup_logger(args, config)
 
-    _verify_configuration(args, config, logger)
     if args.validate_rules or args.auto_test:
         _validate_rules(args, logger)
     _setup_metrics_and_time_measurement(args, config, logger)

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -175,7 +175,12 @@ def _setup_metrics_and_time_measurement(args, config, logger):
     logger.debug(f"Config path: {args.config}")
 
 
-def _validate_rules(args, logger):
+def _validate_rules(args, config: Configuration, logger: Logger):
+    try:
+        config.verify_pipeline_only(logger)
+    except InvalidConfigurationError as error:
+        logger.critical(error)
+        sys.exit(1)
     type_rule_map = get_processor_type_and_rule_class()
     rules_valid = []
     for processor_type, rule_class in type_rule_map.items():
@@ -200,7 +205,7 @@ def main():
     logger = _setup_logger(args, config)
 
     if args.validate_rules or args.auto_test:
-        _validate_rules(args, logger)
+        _validate_rules(args, config, logger)
     _setup_metrics_and_time_measurement(args, config, logger)
 
     if args.auto_test:

--- a/tests/unit/test_run_logprep.py
+++ b/tests/unit/test_run_logprep.py
@@ -227,8 +227,9 @@ class TestRunLogprep:
     def test_main_calls_runner_stop_on_any_exception(self, mock_stop, mock_start):
         mock_start.side_effect = Exception
         config_path = "quickstart/exampledata/config/pipeline.yml"
-        with mock.patch("sys.argv", ["logprep", config_path]):
-            run_logprep.main()
+        with pytest.raises(SystemExit):
+            with mock.patch("sys.argv", ["logprep", config_path]):
+                run_logprep.main()
         mock_stop.assert_called()
 
     def test_logprep_exits_if_logger_can_not_be_created(self):

--- a/tests/unit/test_run_logprep.py
+++ b/tests/unit/test_run_logprep.py
@@ -262,3 +262,23 @@ class TestRunLogprep:
             with mock.patch("sys.argv", ["logprep", "http://localhost/does-not-exists"]):
                 with pytest.raises(SystemExit):
                     run_logprep.main()
+
+    @mock.patch("logprep.util.configuration.Configuration.verify")
+    def test_logprep_verifies_config(self, mock_verify):
+        with mock.patch(
+            "sys.argv",
+            ["logprep", "quickstart/exampledata/config/pipeline.yml", "--verify-config"],
+        ):
+            run_logprep.main()
+        mock_verify.assert_called()
+
+    @mock.patch("logprep.util.configuration.Configuration.verify")
+    def test_logprep_exits_on_verify_config_with_invalid_config(self, mock_verify):
+        mock_verify.side_effect = InvalidConfigurationError
+        with mock.patch(
+            "sys.argv",
+            ["logprep", "quickstart/exampledata/config/pipeline.yml", "--verify-config"],
+        ):
+            with pytest.raises(SystemExit):
+                run_logprep.main()
+        mock_verify.assert_called()


### PR DESCRIPTION
the configuration is verified already here:

https://github.com/fkie-cad/Logprep/blob/49303b87ee622502f90a9a220f0d3f52653317ac/logprep/runner.py#L133-L157

on reload the configuration is verified again here to prevent faulty config from loading:

https://github.com/fkie-cad/Logprep/blob/49303b87ee622502f90a9a220f0d3f52653317ac/logprep/runner.py#L236-L256

I think there is no need for this configuration verification in the pipeline manager. this will improve logprep start times

additionally the config was checked on logprep start in `run_logprep` so the config was checked 3 times for one start and in every verification the whole pipeline was instantiated and all rules were loaded.
