### PR TITLE
fix non-deterministic behavior and add test

### DIFF
--- a/logprep/processor/base/rule.py
+++ b/logprep/processor/base/rule.py
@@ -227,7 +227,7 @@ class Rule:
         return all([other.filter == self._filter, other._config == self._config])
 
     def __hash__(self) -> int:  # pylint: disable=function-redefined
-        return hash(repr(self))
+        return hash((repr(self), id(self)))
 
     def __repr__(self) -> str:
         if hasattr(self, "_config"):

--- a/logprep/processor/base/rule.py
+++ b/logprep/processor/base/rule.py
@@ -227,7 +227,7 @@ class Rule:
         return all([other.filter == self._filter, other._config == self._config])
 
     def __hash__(self) -> int:  # pylint: disable=function-redefined
-        return hash((repr(self), id(self)))
+        return id(self)
 
     def __repr__(self) -> str:
         if hasattr(self, "_config"):

--- a/logprep/processor/processor_strategy.py
+++ b/logprep/processor/processor_strategy.py
@@ -68,7 +68,7 @@ class SpecificGenericProcessStrategy(ProcessStrategy):
         processor_metrics: "Processor.ProcessorMetrics",
     ):
         applied_rules = set()
-        matching_rules = set(tree.get_matching_rules(event))
+        matching_rules = tree.get_matching_rules(event)
         while True:
             for rule in matching_rules:
                 begin = time()
@@ -78,6 +78,6 @@ class SpecificGenericProcessStrategy(ProcessStrategy):
                 rule.metrics.update_mean_processing_time(processing_time)
                 processor_metrics.update_mean_processing_time_per_event(processing_time)
                 applied_rules.add(rule)
-            matching_rules = set(tree.get_matching_rules(event))
-            if not matching_rules.difference(applied_rules):
+            matching_rules = tree.get_matching_rules(event)
+            if not set(matching_rules).difference(applied_rules):
                 break


### PR DESCRIPTION
The processor strategy applied rules in a random order due to using `set` at the wrong locations. This pull request moves the `set` operation to where it is really needed. 