### PR TITLE
Fix dry_runner to deal with multiple outputs

### DIFF
--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -436,9 +436,10 @@ class Pipeline:
                     self._handle_processing_warning(processor, warning)
             except BaseException as error:  # pylint: disable=broad-except
                 msg = self._handle_fatal_processing_error(processor, error)
-                for _, output in self._output.items():
-                    if output.default:
-                        output.store_failed(msg, json.loads(event_received), event)
+                if self._output:
+                    for _, output in self._output.items():
+                        if output.default:
+                            output.store_failed(msg, json.loads(event_received), event)
                 processor.metrics.number_of_errors += 1
                 event.clear()  # 'delete' the event, i.e. no regular output
             if not event:

--- a/logprep/util/aggregating_logger.py
+++ b/logprep/util/aggregating_logger.py
@@ -49,10 +49,11 @@ class AggregatingLogger:
 
         """
         cls.logger_disabled = logger_disabled
-        cls.logger_config = config.get("logger", dict())
+        cls.logger_config = config.get("logger", {})
 
         cls.level_str = cls.logger_config.get("level", "INFO")
-
+        if cls.level_str is None:
+            cls.level_str = "INFO"
         cls.log_level = name_to_level.get(cls.level_str.upper(), INFO)
         basicConfig(
             level=cls.log_level, format="%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s"
@@ -84,7 +85,7 @@ class AggregatingLogger:
             logger.handlers = []
             logger.addHandler(SysLogHandler(address="/dev/log"))
 
-        if cls.level_str.upper() not in name_to_level.keys():
+        if cls.level_str.upper() not in name_to_level:
             logger.info(f"Invalid log level '{cls.level_str.upper()}', defaulting to 'INFO'")
         else:
             logger.setLevel(cls.log_level)

--- a/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
@@ -88,6 +88,7 @@ import sys
 import tempfile
 from functools import cached_property
 from json import JSONDecodeError
+from logging import getLogger
 from pathlib import Path
 from pprint import pprint
 from typing import List
@@ -159,6 +160,7 @@ class RuleCorpusTester:
             self._original_config_path, self._tmp_dir, str(merged_input_file_path)
         )
         config = Configuration.create_from_yaml(path_to_patched_config)
+        config.verify(getLogger("logprep"), ignore_processor_outputs=True)
         del config["output"]
         pipeline = Pipeline(config=config)
         return pipeline

--- a/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
@@ -160,7 +160,7 @@ class RuleCorpusTester:
             self._original_config_path, self._tmp_dir, str(merged_input_file_path)
         )
         config = Configuration.create_from_yaml(path_to_patched_config)
-        config.verify(getLogger("logprep"), ignore_processor_outputs=True)
+        config.verify_pipeline_without_processor_outputs(getLogger("logprep"))
         del config["output"]
         pipeline = Pipeline(config=config)
         return pipeline

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -76,7 +76,7 @@ class DryRunner:
             input_file_path=self._input_file_path,
         )
         config = Configuration.create_from_yaml(patched_config_path)
-        config.verify(self._logger, ignore_processor_outputs=True)
+        config.verify_pipeline_without_processor_outputs(self._logger)
         del config["output"]
         return Pipeline(config=config)
 

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -44,146 +44,86 @@ import shutil
 import tempfile
 from copy import deepcopy
 from difflib import ndiff
+from functools import cached_property
 
 from colorama import Fore, Back
 from ruamel.yaml import YAML
 
-from logprep.runner import Runner
+from logprep.framework.pipeline import Pipeline
 from logprep.util.configuration import Configuration
-from logprep.util.getter import GetterFactory
 from logprep.util.helper import (
     color_print_line,
     recursive_compare,
-    remove_file_if_exists,
     color_print_title,
 )
-from logprep.util.json_handling import parse_jsonl, parse_json
+from logprep.util.json_handling import parse_json, parse_jsonl
 
 yaml = YAML(typ="safe", pure=True)
-
-
-def get_runner_outputs(patched_runner) -> list:
-    # pylint: disable=protected-access
-    """
-    Extracts the outputs of a patched logprep runner.
-
-    Parameters
-    ----------
-    patched_runner : Runner
-        The patched logprep runner
-
-    Returns
-    -------
-    parsed_outputs : list
-        A list of logprep outputs containing events, extra outputs like pre-detections or pseudonyms
-        and errors
-    """
-    parsed_outputs = [None, None, None]
-    output_config = list(patched_runner._configuration.get("output").values())[0]
-    output_paths = [
-        output_path for key, output_path in output_config.items() if "output_file" in key
-    ]
-
-    for output_path in output_paths:
-        remove_file_if_exists(output_path)
-
-    patched_runner.start()
-
-    for index, output_path in enumerate(output_paths):
-        parsed_outputs[index] = parse_jsonl(output_path)
-        remove_file_if_exists(output_path)
-
-    return parsed_outputs
-
-
-def get_patched_runner(config_path, logger):
-    """
-    Creates a patched runner that bypasses check to obtain non singleton instance and the runner
-    won't continue iterating on an empty pipeline.
-
-    Parameters
-    ----------
-    config_path : str
-        The logprep configuration that should be used for the patched runner
-    logger : Logger
-        The application logger the runner should use
-
-    Returns
-    -------
-    runner : Runner
-        The patched logprep runner
-    """
-    runner = Runner(bypass_check_to_obtain_non_singleton_instance=True)
-    runner.set_logger(logger)
-    runner.load_configuration(config_path)
-
-    # patch runner to stop on empty pipeline
-    def keep_iterating():
-        """generator that stops on first iteration"""
-        return  # nosemgrep
-        yield
-
-    runner._keep_iterating = keep_iterating  # pylint: disable=protected-access
-
-    return runner
 
 
 class DryRunner:
     """Used to run pipeline with given events and show changes made by processing."""
 
-    def __init__(self, dry_run: str, config_path: str, full_output: bool, use_json: bool, logger):
-        self._tmp_path = tempfile.mkdtemp()
-        self.patched_config_path = Configuration.patch_yaml_with_json_connectors(
-            original_config_path=config_path, output_dir=self._tmp_path, input_file_path=dry_run
+    @cached_property
+    def _tmp_path(self):
+        return tempfile.mkdtemp()
+
+    @cached_property
+    def _pipeline(self):
+        patched_config_path = Configuration.patch_yaml_with_json_connectors(
+            original_config_path=self._config_path,
+            output_dir=self._tmp_path,
+            input_file_path=self._input_file_path,
         )
+        config = Configuration.create_from_yaml(patched_config_path)
+        config.verify(self._logger, ignore_processor_outputs=True)
+        del config["output"]
+        return Pipeline(config=config)
+
+    @cached_property
+    def _input_documents(self):
+        return (
+            parse_json(self._input_file_path)
+            if self._use_json
+            else parse_jsonl(self._input_file_path)
+        )
+
+    def __init__(
+        self, input_file_path: str, config_path: str, full_output: bool, use_json: bool, logger
+    ):
+        self._input_file_path = input_file_path
+        self._config_path = config_path
         self._full_output = full_output
         self._use_json = use_json
         self._logger = logger
 
     def run(self):
         """Run the dry runner."""
-        patched_runner = get_patched_runner(self.patched_config_path, self._logger)
-        test_output, test_output_custom, test_output_error = get_runner_outputs(patched_runner)
-        config_yaml = GetterFactory.from_string(self.patched_config_path).get_yaml()
-        input_path = config_yaml.get("input", {}).get("patched_input", {}).get("documents_path")
-        input_data = parse_json(input_path) if self._use_json else parse_jsonl(input_path)
-        self._print_output_results(input_data, test_output, test_output_custom, test_output_error)
+        transformed_cnt = 0
+        output_count = 0
+        for input_document in self._input_documents:
+            test_output, test_output_custom = self._pipeline.process_pipeline()
+            if test_output:
+                output_count += 1
+            diff = self._print_output_results(input_document, test_output, test_output_custom)
+            if diff:
+                transformed_cnt += 1
+        color_print_title(Back.WHITE, f"TRANSFORMED EVENTS: {transformed_cnt}/{output_count}")
         shutil.rmtree(self._tmp_path)
 
-    def _print_output_results(self, input_data, test_output, test_output_custom, test_output_error):
-        """Call the print methods that correspond to the output type"""
-        if not test_output_error:
-            self._print_transformed_events(input_data, test_output, test_output_custom)
-        if self._full_output and test_output_custom and not test_output_error:
-            self._print_pseudonyms(test_output_custom)
-            self._print_predetections(test_output_custom)
-        if test_output_error:
-            self._print_errors(test_output_error)
-
-    def _print_transformed_events(self, input_data, test_output, test_output_custom):
-        """
-        Print the differences between input and output event as well as corresponding pre-detections
-        """
-        transformed_cnt = 0
-        for idx, test_item in enumerate(test_output):
-            test_copy = deepcopy(test_item)
-            input_copy = deepcopy(input_data[idx])
-            difference = recursive_compare(test_copy, input_copy)
-            if difference:
-                test_json = json.dumps(test_item, sort_keys=True, indent=4)
-                input_path_json = json.dumps(input_data[idx], sort_keys=True, indent=4)
-                diff = ndiff(input_path_json.splitlines(), test_json.splitlines())
-                color_print_title(Back.CYAN, "PROCESSED EVENT")
-                self._print_ndiff_items(diff)
-                transformed_cnt += 1
-
-            for test_item_custom in test_output_custom:
-                detector_id = test_item_custom.get("pre_detection_id")
-                if detector_id and detector_id == test_item.get("pre_detection_id"):
-                    color_print_title(Back.YELLOW, "PRE-DETECTION FOR PRECEDING EVENT")
-                    test_json_custom = json.dumps(test_item_custom, sort_keys=True, indent=4)
-                    color_print_line(Back.BLACK, Fore.YELLOW, test_json_custom)
-        color_print_title(Back.WHITE, f"TRANSFORMED EVENTS: {transformed_cnt}/{len(test_output)}")
+    def _print_output_results(self, input_document, test_output, test_output_custom):
+        test_copy = deepcopy(test_output)
+        input_copy = deepcopy(input_document)
+        difference = recursive_compare(test_copy, input_copy)
+        if difference:
+            test_json = json.dumps(test_output, sort_keys=True, indent=4)
+            input_path_json = json.dumps(input_document, sort_keys=True, indent=4)
+            diff = ndiff(input_path_json.splitlines(), test_json.splitlines())
+            color_print_title(Back.CYAN, "PROCESSED EVENT")
+            self._print_ndiff_items(diff)
+        if self._full_output and test_output_custom:
+            self._print_custom_outputs(test_output_custom)
+        return difference
 
     def _print_ndiff_items(self, diff):
         """
@@ -199,35 +139,10 @@ class DryRunner:
             else:
                 color_print_line(Back.BLACK, Fore.CYAN, item)
 
-    def _print_pseudonyms(self, test_output_custom):
-        """Print only the pseudonyms from all custom outputs"""
-        color_print_title(Back.MAGENTA, "ALL PSEUDONYMS")
-        for test_item in test_output_custom:
-            if "pseudonym" in test_item.keys() and "origin" in test_item.keys():
-                test_json = json.dumps(test_item, sort_keys=True, indent=4)
-                color_print_line(Back.BLACK, Fore.MAGENTA, test_json)
-
-    def _print_predetections(self, test_output_custom):
-        """Print only the pre-detections from all custom outputs"""
-        color_print_title(Back.YELLOW, "ALL PRE-DETECTIONS")
-        for test_item in test_output_custom:
-            if "pre_detection_id" in test_item.keys():
-                test_json = json.dumps(test_item, sort_keys=True, indent=4)
+    def _print_custom_outputs(self, test_output_custom):
+        color_print_title(Back.MAGENTA, "CUSTOM OUTPUTS")
+        for output, output_target in test_output_custom:
+            color_print_title(Back.YELLOW, f"Output Target: {str(output_target[0])}")
+            for out in output:
+                test_json = json.dumps(out, sort_keys=True, indent=4)
                 color_print_line(Back.BLACK, Fore.YELLOW, test_json)
-
-    def _print_errors(self, test_output_error):
-        """Print all errors"""
-        for test_items in test_output_error:
-            color_print_title(Back.RED, "ERROR")
-
-            json_message = test_items.get("error_message")
-            color_print_line(Back.BLACK, Fore.RED, json_message)
-
-            json_original = test_items.get("document_received")
-            json_processed = test_items.get("document_processed")
-
-            diff = ndiff(str(json_original), str(json_processed))
-            color_print_title(Back.YELLOW, "PARTIALLY PROCESSED EVENT")
-            self._print_ndiff_items(diff)
-        log_message = "^^^ RESULTS CAN NOT BE SHOWN UNTIL ALL ERRORS HAVE BEEN FIXED ^^^"
-        color_print_line(Back.RED, Fore.WHITE, log_message)

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -51,12 +51,12 @@ from ruamel.yaml import YAML
 
 from logprep.framework.pipeline import Pipeline
 from logprep.util.configuration import Configuration
+from logprep.util.getter import GetterFactory
 from logprep.util.helper import (
     color_print_line,
     recursive_compare,
     color_print_title,
 )
-from logprep.util.json_handling import parse_json, parse_jsonl
 
 yaml = YAML(typ="safe", pure=True)
 
@@ -82,11 +82,7 @@ class DryRunner:
 
     @cached_property
     def _input_documents(self):
-        return (
-            parse_json(self._input_file_path)
-            if self._use_json
-            else parse_jsonl(self._input_file_path)
-        )
+        return GetterFactory.from_string(self._input_file_path).get_yaml()
 
     def __init__(
         self, input_file_path: str, config_path: str, full_output: bool, use_json: bool, logger

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -21,9 +21,10 @@ from os import makedirs, path
 
 from logprep.abc.processor import Processor
 from logprep.registry import Registry
+from logprep.runner import Runner
 from logprep.util.decorators import timeout
-from logprep.util.helper import recursive_compare
-from logprep.util.rule_dry_runner import get_patched_runner, get_runner_outputs
+from logprep.util.helper import recursive_compare, remove_file_if_exists
+from logprep.util.json_handling import parse_jsonl
 from tests.unit.processor.base import BaseProcessorTestCase
 
 basicConfig(level=DEBUG, format="%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s")
@@ -110,6 +111,72 @@ def store_latest_test_output(target_output_identifier, output_of_test):
     with open(latest_output_path, "w", encoding="utf-8") as latest_output:
         for test_output_line in output_of_test:
             latest_output.write(json.dumps(test_output_line) + "\n")
+
+
+def get_runner_outputs(patched_runner) -> list:
+    # pylint: disable=protected-access
+    """
+    Extracts the outputs of a patched logprep runner.
+
+    Parameters
+    ----------
+    patched_runner : Runner
+        The patched logprep runner
+
+    Returns
+    -------
+    parsed_outputs : list
+        A list of logprep outputs containing events, extra outputs like pre-detections or pseudonyms
+        and errors
+    """
+    parsed_outputs = [None, None, None]
+    output_config = list(patched_runner._configuration.get("output").values())[0]
+    output_paths = [
+        output_path for key, output_path in output_config.items() if "output_file" in key
+    ]
+
+    for output_path in output_paths:
+        remove_file_if_exists(output_path)
+
+    patched_runner.start()
+
+    for index, output_path in enumerate(output_paths):
+        parsed_outputs[index] = parse_jsonl(output_path)
+        remove_file_if_exists(output_path)
+
+    return parsed_outputs
+
+
+def get_patched_runner(config_path, logger):
+    """
+    Creates a patched runner that bypasses check to obtain non singleton instance and the runner
+    won't continue iterating on an empty pipeline.
+
+    Parameters
+    ----------
+    config_path : str
+        The logprep configuration that should be used for the patched runner
+    logger : Logger
+        The application logger the runner should use
+
+    Returns
+    -------
+    runner : Runner
+        The patched logprep runner
+    """
+    runner = Runner(bypass_check_to_obtain_non_singleton_instance=True)
+    runner.set_logger(logger)
+    runner.load_configuration(config_path)
+
+    # patch runner to stop on empty pipeline
+    def keep_iterating():
+        """generator that stops on first iteration"""
+        return  # nosemgrep
+        yield
+
+    runner._keep_iterating = keep_iterating  # pylint: disable=protected-access
+
+    return runner
 
 
 def get_test_output(config_path):

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -947,3 +947,22 @@ output:
         assert len(raised.value.errors) == 3
         for error in raised.value.errors:
             assert "output 'kafka' does not exist in logprep outputs" in error.args[0]
+
+    def test_verify_pipeline_ignores_processor_outputs(self):
+        config = Configuration()
+        pipeline = [
+            {
+                "pd": {
+                    "type": "pre_detector",
+                    "generic_rules": ["tests/testdata/unit/pre_detector/rules/generic"],
+                    "specific_rules": ["tests/testdata/unit/pre_detector/rules/specific"],
+                    "outputs": [{"kafka": "pre_detector_alerts"}],
+                    "alert_ip_list_path": "tests/testdata/unit/pre_detector/alert_ips.yml",
+                }
+            },
+        ]
+        config.update({"pipeline": pipeline, "output": {}})
+        try:
+            config._verify_pipeline(logger=logger, ignore_processor_outputs=True)
+        except InvalidConfigurationErrors as error:
+            assert False, f"Shouldn't raise output does not exist error: '{error}'"

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -659,7 +659,7 @@ class TestConfiguration:
         config = deepcopy(self.config)
         config.update(config_dict)
         if raised_errors is not None:
-            errors = config._perform_verfification_and_get_errors(logger)
+            errors = config._check_for_errors(logger)
             collected_errors = []
             for error in errors:
                 collected_errors += error.errors
@@ -948,7 +948,7 @@ output:
         for error in raised.value.errors:
             assert "output 'kafka' does not exist in logprep outputs" in error.args[0]
 
-    def test_verify_pipeline_ignores_processor_outputs(self):
+    def test_verify_pipeline_without_processor_outputs_ignores_processor_output_errors(self):
         config = Configuration()
         pipeline = [
             {
@@ -963,6 +963,6 @@ output:
         ]
         config.update({"pipeline": pipeline, "output": {}})
         try:
-            config._verify_pipeline(logger=logger, ignore_processor_outputs=True)
+            config.verify_pipeline_without_processor_outputs(logger=logger)
         except InvalidConfigurationErrors as error:
             assert False, f"Shouldn't raise output does not exist error: '{error}'"

--- a/tests/unit/util/test_rule_dry_runner.py
+++ b/tests/unit/util/test_rule_dry_runner.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=attribute-defined-outside-init
 import json
 import logging
 import os
+import re
 import tempfile
 from unittest import mock
 
@@ -68,7 +68,7 @@ class TestRunLogprep:
             json.dump(test_json, input_file)
 
         dry_runner = DryRunner(
-            dry_run=input_json_file,
+            input_file_path=input_json_file,
             config_path=self.config_path,
             full_output=True,
             use_json=True,
@@ -87,7 +87,7 @@ class TestRunLogprep:
             json.dump(test_json, input_file)
 
         dry_runner = DryRunner(
-            dry_run=input_json_file,
+            input_file_path=input_json_file,
             config_path=self.config_path,
             full_output=True,
             use_json=True,
@@ -109,7 +109,7 @@ class TestRunLogprep:
             input_file.writelines(test_jsonl)
 
         dry_runner = DryRunner(
-            dry_run=input_jsonl_file,
+            input_file_path=input_jsonl_file,
             config_path=self.config_path,
             full_output=True,
             use_json=False,
@@ -135,7 +135,7 @@ class TestRunLogprep:
             json.dump(test_json, input_file)
 
         dry_runner = DryRunner(
-            dry_run=input_json_file,
+            input_file_path=input_json_file,
             config_path=self.config_path,
             full_output=True,
             use_json=True,
@@ -146,8 +146,7 @@ class TestRunLogprep:
         captured = capsys.readouterr()
         assert "------ PROCESSED EVENT ------" in captured.out
         assert "------ TRANSFORMED EVENTS: 1/1 ------" in captured.out
-        assert "------ ALL PSEUDONYMS ------" in captured.out
-        assert "------ ALL PRE-DETECTIONS ------" in captured.out
+        assert "------ CUSTOM OUTPUTS ------" in captured.out
 
     def test_dry_run_prints_predetection(self, tmp_path, capsys):
         test_json = {
@@ -161,7 +160,7 @@ class TestRunLogprep:
             json.dump(test_json, input_file)
 
         dry_runner = DryRunner(
-            dry_run=input_json_file,
+            input_file_path=input_json_file,
             config_path=self.config_path,
             full_output=True,
             use_json=True,
@@ -172,8 +171,7 @@ class TestRunLogprep:
         captured = capsys.readouterr()
         assert "------ PROCESSED EVENT ------" in captured.out
         assert "------ TRANSFORMED EVENTS: 1/1 ------" in captured.out
-        assert "------ ALL PSEUDONYMS ------" in captured.out
-        assert "------ ALL PRE-DETECTIONS ------" in captured.out
+        assert "------ CUSTOM OUTPUTS ------" in captured.out
 
     @mock.patch("logprep.processor.labeler.processor.Labeler.process", side_effect=BaseException)
     def test_dry_run_prints_errors(self, _, tmp_path, capsys):
@@ -188,7 +186,7 @@ class TestRunLogprep:
             json.dump(test_json, input_file)
 
         dry_runner = DryRunner(
-            dry_run=input_json_file,
+            input_file_path=input_json_file,
             config_path=self.config_path,
             full_output=True,
             use_json=True,
@@ -197,4 +195,4 @@ class TestRunLogprep:
         dry_runner.run()
 
         captured = capsys.readouterr()
-        assert "------ ERROR ------" in captured.out
+        assert not re.match(r".*A critical error occured for processor Labeler", captured.err)


### PR DESCRIPTION
- change dry_runner to use the logprep pipeline instead of the patched_runner
- move patched_runner code to test util.py (can be deleted once the old acceptance tests are revised)
- allow config validation without processor outputs

closes #350 #340 