### PR TITLE
Make multiple applications of rules by the same processor optional

### DIFF
--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -59,6 +59,10 @@ class Processor(Component):
         )
         """Path to a JSON file with a valid rule tree configuration.
         For string format see :ref:`getters`"""
+        apply_rules_multiple_times: Optional[bool] = field(
+            default=None, validator=[validators.optional(validators.instance_of(bool))]
+        )
+        """Decide if rules can be applied multiple times per processor"""
 
     @define(kw_only=True)
     class ProcessorMetrics(Metric):
@@ -108,10 +112,11 @@ class Processor(Component):
     _specific_tree: RuleTree
     _generic_tree: RuleTree
 
-    _strategy = SpecificGenericProcessStrategy()
+    _strategy = None
 
     def __init__(self, name: str, configuration: "Processor.Config", logger: Logger):
         super().__init__(name, configuration, logger)
+        self._strategy = SpecificGenericProcessStrategy(self._config.apply_rules_multiple_times)
         self.metric_labels, specific_tree_labels, generic_tree_labels = self._create_metric_labels()
         self._specific_tree = RuleTree(
             config_path=self._config.tree_config, metric_labels=specific_tree_labels

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -59,10 +59,11 @@ class Processor(Component):
         )
         """Path to a JSON file with a valid rule tree configuration.
         For string format see :ref:`getters`"""
-        apply_rules_multiple_times: Optional[bool] = field(
-            default=None, validator=[validators.optional(validators.instance_of(bool))]
+        apply_multiple_times: Optional[bool] = field(
+            default=False, validator=[validators.optional(validators.instance_of(bool))]
         )
-        """Decide if rules can be applied multiple times per processor"""
+        """Set if the processor should be applied multiple times. This enables further processing
+        of an output with the same processor."""
 
     @define(kw_only=True)
     class ProcessorMetrics(Metric):
@@ -111,12 +112,11 @@ class Processor(Component):
     _event: dict
     _specific_tree: RuleTree
     _generic_tree: RuleTree
-
     _strategy = None
 
     def __init__(self, name: str, configuration: "Processor.Config", logger: Logger):
         super().__init__(name, configuration, logger)
-        self._strategy = SpecificGenericProcessStrategy(self._config.apply_rules_multiple_times)
+        self._strategy = SpecificGenericProcessStrategy(self._config.apply_multiple_times)
         self.metric_labels, specific_tree_labels, generic_tree_labels = self._create_metric_labels()
         self._specific_tree = RuleTree(
             config_path=self._config.tree_config, metric_labels=specific_tree_labels

--- a/logprep/processor/processor_strategy.py
+++ b/logprep/processor/processor_strategy.py
@@ -31,6 +31,9 @@ class SpecificGenericProcessStrategy(ProcessStrategy):
     specific_rules >> generic_rules
     """
 
+    def __init__(self, apply_rules_multiple_times=False):
+        self._apply_rules_multiple_times = apply_rules_multiple_times
+
     def process(self, event: dict, **kwargs):
         specific_tree = kwargs.get("specific_tree")
         generic_tree = kwargs.get("generic_tree")
@@ -78,6 +81,9 @@ class SpecificGenericProcessStrategy(ProcessStrategy):
                 rule.metrics.update_mean_processing_time(processing_time)
                 processor_metrics.update_mean_processing_time_per_event(processing_time)
                 applied_rules.add(rule)
-            matching_rules = tree.get_matching_rules(event)
-            if not set(matching_rules).difference(applied_rules):
+            if self._apply_rules_multiple_times:
+                matching_rules = tree.get_matching_rules(event)
+                if not set(matching_rules).difference(applied_rules):
+                    break
+            else:
                 break

--- a/tests/unit/processor/test_processor_strategy.py
+++ b/tests/unit/processor/test_processor_strategy.py
@@ -53,7 +53,7 @@ class TestSpecificGenericProcessStrategy:
             "type": "dissector",
             "specific_rules": [],
             "generic_rules": [],
-            "apply_rules_multiple_times": True,
+            "apply_multiple_times": True,
         }
         processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
         rule_one_dict = {

--- a/tests/unit/processor/test_processor_strategy.py
+++ b/tests/unit/processor/test_processor_strategy.py
@@ -49,7 +49,12 @@ class TestSpecificGenericProcessStrategy:
         assert call_order == [mock_process_specific, mock_process_generic]
 
     def test_apply_processor_multiple_times_until_no_new_rule_matches(self):
-        config = {"type": "dissector", "specific_rules": [], "generic_rules": []}
+        config = {
+            "type": "dissector",
+            "specific_rules": [],
+            "generic_rules": [],
+            "apply_rules_multiple_times": True,
+        }
         processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
         rule_one_dict = {
             "filter": "message",
@@ -68,6 +73,38 @@ class TestSpecificGenericProcessStrategy:
             "message": "time [proto col] url",
             "proto": "proto",
             "col": "col",
+            "protocol": "proto col",
+            "time": "time",
+            "url": "url",
+        }
+        processor._strategy.process(
+            event,
+            generic_tree=processor._generic_tree,
+            specific_tree=processor._specific_tree,
+            callback=processor._apply_rules_wrapper,
+            processor_stats=mock.Mock(),
+            processor_metrics=mock.MagicMock(),
+        )
+        assert expected_event == event
+
+    def test_apply_processor_multiple_times_not_enabled(self):
+        config = {"type": "dissector", "specific_rules": [], "generic_rules": []}
+        processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
+        rule_one_dict = {
+            "filter": "message",
+            "dissector": {"mapping": {"message": "%{time} [%{protocol}] %{url}"}},
+        }
+        rule_two_dict = {
+            "filter": "protocol",
+            "dissector": {"mapping": {"protocol": "%{proto} %{col}"}},
+        }
+        rule_one = DissectorRule._create_from_dict(rule_one_dict)
+        rule_two = DissectorRule._create_from_dict(rule_two_dict)
+        processor._specific_tree.add_rule(rule_one)
+        processor._specific_tree.add_rule(rule_two)
+        event = {"message": "time [proto col] url"}
+        expected_event = {
+            "message": "time [proto col] url",
             "protocol": "proto col",
             "time": "time",
             "url": "url",


### PR DESCRIPTION
Applying rules multiple times requires to match the rules at least 2 times.
Once for the 1. match and once to check if another match is necessary.
This can reduce the performance of Logprep significantly.
Therefore, this feature is made optional with this pull-request.
It is disabled per default and can be enabled on a processor basis by setting `apply_rules_multiple_times` to true.