### PR TITLE
avoid string splitting during processing

### DIFF
--- a/logprep/framework/rule_tree/rule_parser.py
+++ b/logprep/framework/rule_tree/rule_parser.py
@@ -8,15 +8,16 @@ behavior, allowing a simpler construction of the rule tree.
 from typing import Union
 
 from logprep.filter.expression.filter_expression import (
-    Or,
-    CompoundFilterExpression,
-    Not,
-    And,
-    Exists,
-    StringFilterExpression,
-    FilterExpression,
     Always,
+    And,
+    CompoundFilterExpression,
+    Exists,
+    FilterExpression,
+    Not,
+    Or,
+    StringFilterExpression,
 )
+from logprep.util.helper import get_dotted_field_list
 
 
 class RuleParserException(Exception):
@@ -514,7 +515,7 @@ class RuleParser:
 
         if ":" in tag_map_value:
             key, value = tag_map_value.split(":")
-            rule.insert(0, StringFilterExpression(key.split("."), value))
+            rule.insert(0, StringFilterExpression(get_dotted_field_list(key), value))
         else:
             rule.insert(0, Exists(tag_map_value.split(".")))
 

--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -86,9 +86,9 @@ The calc expression is not whitespace sensitive.
 """
 import re
 
-from attrs import field, define, validators
+from attrs import define, field, validators
 
-from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
+from logprep.processor.field_manager.rule import FIELD_PATTERN, FieldManagerRule
 
 
 class CalculatorRule(FieldManagerRule):
@@ -113,6 +113,7 @@ class CalculatorRule(FieldManagerRule):
 
         def __attrs_post_init__(self):
             self.source_fields = re.findall(FIELD_PATTERN, self.calc)
+            super().__attrs_post_init__()
 
     @property
     def calc(self):

--- a/logprep/processor/dissector/rule.py
+++ b/logprep/processor/dissector/rule.py
@@ -81,11 +81,11 @@ Examples for dissection and datatype conversion:
 import re
 from typing import Callable, List, Tuple
 
-from attrs import define, validators, field, Factory
+from attrs import Factory, define, field, validators
 
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.helper import append, add_and_overwrite
+from logprep.util.helper import add_and_overwrite, append
 
 START = r"%\{"
 END = r"\}"
@@ -165,6 +165,7 @@ class DissectorRule(FieldManagerRule):
 
         def __attrs_post_init__(self):
             self.source_fields = list(self.mapping.keys())  # pylint: disable=no-member
+            super().__attrs_post_init__()
 
     _actions_mapping: dict = {
         None: add_and_overwrite,

--- a/logprep/processor/domain_label_extractor/rule.py
+++ b/logprep/processor/domain_label_extractor/rule.py
@@ -50,10 +50,8 @@ will result in the following output
     }
 
 """
-import warnings
 
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 
 
 class DomainLabelExtractorRule(FieldManagerRule):

--- a/logprep/processor/domain_resolver/rule.py
+++ b/logprep/processor/domain_resolver/rule.py
@@ -21,10 +21,9 @@ In the following example the URL from the field :code:`url` will be extracted an
         source_fields: [url]
       description: '...'
 """
-import warnings
 from attrs import define, field, fields
+
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 
 
 class DomainResolverRule(FieldManagerRule):

--- a/logprep/processor/dropper/rule.py
+++ b/logprep/processor/dropper/rule.py
@@ -43,11 +43,11 @@ the fields :code:`keep_me` and :code:`keep_me.keep_me_too` are kept.
 """
 
 from typing import List
-import warnings
+
 from attrs import define, field, validators
 
 from logprep.processor.base.rule import Rule
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
+from logprep.util.helper import get_dotted_field_value
 
 
 class DropperRule(Rule):
@@ -61,6 +61,11 @@ class DropperRule(Rule):
         """List of fields to drop"""
         drop_full: bool = field(validator=validators.instance_of(bool), default=True)
         """Drop recursive? defaults to [True]"""
+
+        def __attrs_post_init__(self):
+            # to ensure no split operations during processing
+            for dotted_field in self.drop:  # pylint: disable=not-an-iterable
+                get_dotted_field_value({}, dotted_field)
 
     @property
     def fields_to_drop(self) -> List[str]:

--- a/logprep/processor/field_manager/rule.py
+++ b/logprep/processor/field_manager/rule.py
@@ -80,7 +80,9 @@ Examples for field_manager:
 
 """
 from attrs import define, field, validators
+
 from logprep.processor.base.rule import Rule
+from logprep.util.helper import get_dotted_field_value
 
 FIELD_PATTERN = r"\$\{([+&?]?[^${}]*)\}"
 
@@ -112,6 +114,12 @@ class FieldManagerRule(Rule):
         If the target field does not exist, a new field will be added with the
         source field value as list. Defaults to :code:`False`.
         """
+
+        def __attrs_post_init__(self):
+            # ensures no split operations during processing
+            for dotted_field in self.source_fields:  # pylint: disable=not-an-iterable
+                get_dotted_field_value({}, dotted_field)
+            get_dotted_field_value({}, self.target_field)
 
     # pylint: disable=missing-function-docstring
     @property

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -37,7 +37,6 @@ target field :code:`List_comparison.example`.
 """
 import os.path
 from string import Template
-import warnings
 from typing import List, Optional
 
 from attrs import define, field, validators
@@ -45,7 +44,6 @@ from attrs import define, field, validators
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 
 
 class ListComparisonRule(FieldManagerRule):

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -45,7 +45,11 @@ from logprep.abc.processor import Processor
 from logprep.processor.base.exceptions import FieldExsistsWarning, ProcessingWarning
 from logprep.processor.normalizer.rule import NormalizerRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import add_field_to, get_dotted_field_value
+from logprep.util.helper import (
+    add_field_to,
+    get_dotted_field_list,
+    get_dotted_field_value,
+)
 from logprep.util.validators import directory_validator
 
 
@@ -189,7 +193,7 @@ class Normalizer(Processor):
         return target, value
 
     def _add_field(self, event: dict, dotted_field: str, value: Union[str, int]):
-        fields = dotted_field.split(".")
+        fields = get_dotted_field_list(dotted_field)
         missing_fields = json.loads(json.dumps(fields))
         for event_field in fields:
             if isinstance(event, dict) and event_field in event:

--- a/logprep/processor/normalizer/processor.py
+++ b/logprep/processor/normalizer/processor.py
@@ -219,7 +219,7 @@ class Normalizer(Processor):
 
     @staticmethod
     def _replace_field(event: dict, dotted_field: str, value: str):
-        fields = dotted_field.split(".")
+        fields = get_dotted_field_list(dotted_field)
         reduce(lambda dict_, key: dict_[key], fields[:-1], event)[fields[-1]] = value
 
     def process(self, event: dict):

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -45,6 +45,7 @@ from logprep.processor.pseudonymizer.rule import PseudonymizerRule
 from logprep.util.cache import Cache
 from logprep.util.getter import GetterFactory
 from logprep.util.hasher import SHA256Hasher
+from logprep.util.helper import get_dotted_field_list
 from logprep.util.validators import list_of_urls_validator
 
 
@@ -227,7 +228,7 @@ class Pseudonymizer(Processor):
 
     @staticmethod
     def _innermost_field(dotted_field: str, event: dict) -> Tuple[Union[dict, Any], str]:
-        keys = dotted_field.split(".")
+        keys = get_dotted_field_list(dotted_field)
         for i in range(len(keys) - 1):
             event = event[keys[i]]
         return event, keys[-1]

--- a/logprep/processor/pseudonymizer/rule.py
+++ b/logprep/processor/pseudonymizer/rule.py
@@ -40,10 +40,9 @@ in a capture group and therefore pseudonymizes it completely.
 """
 
 from typing import List
-import warnings
+
 from attrs import define, field, validators
 
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 from logprep.processor.base.rule import Rule
 
 

--- a/logprep/processor/requester/rule.py
+++ b/logprep/processor/requester/rule.py
@@ -65,7 +65,7 @@ import re
 import requests
 from attrs import define, field, validators
 
-from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
+from logprep.processor.field_manager.rule import FIELD_PATTERN, FieldManagerRule
 
 parameter_keys = inspect.signature(requests.Request).parameters.keys()
 REQUEST_CONFIG_KEYS = [
@@ -177,6 +177,7 @@ class RequesterRule(FieldManagerRule):
             data_fields = re.findall(FIELD_PATTERN, self.data)
             params_fields = re.findall(FIELD_PATTERN, json.dumps(self.params))
             self.source_fields = list({*url_fields, *json_fields, *data_fields, *params_fields})
+            super().__attrs_post_init__()
 
     # pylint: disable=missing-docstring
     @property

--- a/logprep/processor/selective_extractor/rule.py
+++ b/logprep/processor/selective_extractor/rule.py
@@ -95,6 +95,7 @@ It is possible to mix both extraction sources. They will be merged to one list w
 """
 
 from typing import List
+
 from attrs import define, field, validators
 
 from logprep.processor.base.rule import InvalidRuleDefinitionError
@@ -159,6 +160,7 @@ class SelectiveExtractorRule(FieldManagerRule):
         extend_target_list: bool = field(default=False, init=False)
 
         def __attrs_post_init__(self):
+            super().__attrs_post_init__()
             if not self.extract_from_file:
                 return
             try:

--- a/logprep/processor/template_replacer/processor.py
+++ b/logprep/processor/template_replacer/processor.py
@@ -35,7 +35,7 @@ from logprep.abc.processor import Processor
 from logprep.processor.base.exceptions import FieldExsistsWarning
 from logprep.processor.template_replacer.rule import TemplateReplacerRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import get_dotted_field_list, get_dotted_field_value
 
 
 class TemplateReplacerError(BaseException):
@@ -86,7 +86,7 @@ class TemplateReplacer(Processor):
         pattern = configuration.pattern
         template_path = configuration.template
         self._target_field = pattern["target_field"]
-        self._target_field_split = self._target_field.split(".")
+        self._target_field_split = get_dotted_field_list(self._target_field)
         self._fields = pattern["fields"]
         delimiter = pattern["delimiter"]
         allow_delimiter_field = pattern["allowed_delimiter_field"]

--- a/logprep/processor/timestamp_differ/rule.py
+++ b/logprep/processor/timestamp_differ/rule.py
@@ -45,7 +45,7 @@ import re
 from attr import field
 from attrs import define, validators
 
-from logprep.processor.field_manager.rule import FieldManagerRule, FIELD_PATTERN
+from logprep.processor.field_manager.rule import FIELD_PATTERN, FieldManagerRule
 
 
 class TimestampDifferRule(FieldManagerRule):
@@ -90,6 +90,7 @@ class TimestampDifferRule(FieldManagerRule):
             source_fields, source_field_formats = list(map(list, zip(*field_format_tuple)))
             self.source_fields = source_fields
             self.source_field_formats = source_field_formats
+            super().__attrs_post_init__()
 
     # pylint: disable=missing-function-docstring
     @property

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,14 +1,11 @@
 """This module contains helper functions that are shared by different modules."""
 import re
-import sys
-from functools import partial, reduce
+from functools import cache, partial, reduce
 from os import remove
 from typing import Optional, Union
 
 from colorama import Back, Fore
 from colorama.ansi import AnsiBack, AnsiFore
-
-dotted_field_loopup_table = {}
 
 
 def color_print_line(
@@ -153,6 +150,7 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         return None
 
 
+@cache
 def get_dotted_field_list(dotted_field: str) -> list[str]:
     """make lookup of dotted field in the dotted_field_lookup_table and ensures
     it is added if not found. Additionally the string will be interned for faster
@@ -168,12 +166,7 @@ def get_dotted_field_list(dotted_field: str) -> list[str]:
     list[str]
         a list with keys for dictionary iteration
     """
-    try:
-        return dotted_field_loopup_table[dotted_field]
-    except KeyError:
-        split_field_list = dotted_field.split(".")
-        dotted_field_loopup_table[sys.intern(dotted_field)] = split_field_list
-    return split_field_list
+    return dotted_field.split(".")
 
 
 def pop_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dict, list, str]]:

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,6 +1,6 @@
 """This module contains helper functions that are shared by different modules."""
 import re
-from functools import cache, partial, reduce
+from functools import lru_cache, partial, reduce
 from os import remove
 from typing import Optional, Union
 
@@ -148,7 +148,7 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         return None
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_dotted_field_list(dotted_field: str) -> list[str]:
     """make lookup of dotted field in the dotted_field_lookup_table and ensures
     it is added if not found. Additionally the string will be interned for faster

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,11 +1,14 @@
 """This module contains helper functions that are shared by different modules."""
 import re
+import sys
 from functools import partial, reduce
 from os import remove
 from typing import Optional, Union
 
-from colorama import Fore, Back
-from colorama.ansi import AnsiFore, AnsiBack
+from colorama import Back, Fore
+from colorama.ansi import AnsiBack, AnsiFore
+
+dotted_field_loopup_table = {}
 
 
 def color_print_line(
@@ -75,8 +78,8 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
     assert not (
         extends_lists and overwrite_output_field
     ), "An output field can't be overwritten and extended at the same time"
-
-    output_field_path = [event, *output_field.split(".")]
+    fields = get_dotted_field_list(output_field)
+    output_field_path = [event, *fields]
     target_key = output_field_path.pop()
 
     if overwrite_output_field:
@@ -137,10 +140,9 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
     dict_: dict, list, str
         The value of the requested dotted field.
     """
-
-    fields = [event, *dotted_field.split(".")]
+    fields = get_dotted_field_list(dotted_field)
     try:
-        return reduce(_get_item, fields)
+        return reduce(_get_item, (event, *fields))
     except KeyError:
         return None
     except ValueError:
@@ -149,6 +151,29 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         return None
     except IndexError:
         return None
+
+
+def get_dotted_field_list(dotted_field: str) -> list[str]:
+    """make lookup of dotted field in the dotted_field_lookup_table and ensures
+    it is added if not found. Additionally the string will be interned for faster
+    followup lookups.
+
+    Parameters
+    ----------
+    dotted_field : str
+        the dotted field input
+
+    Returns
+    -------
+    list[str]
+        a list with keys for dictionary iteration
+    """
+    try:
+        return dotted_field_loopup_table[dotted_field]
+    except KeyError:
+        split_field_list = dotted_field.split(".")
+        dotted_field_loopup_table[sys.intern(dotted_field)] = split_field_list
+    return split_field_list
 
 
 def pop_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dict, list, str]]:

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -75,8 +75,7 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
     assert not (
         extends_lists and overwrite_output_field
     ), "An output field can't be overwritten and extended at the same time"
-    fields = get_dotted_field_list(output_field)
-    output_field_path = [event, *fields]
+    output_field_path = [event, *get_dotted_field_list(output_field)]
     target_key = output_field_path.pop()
 
     if overwrite_output_field:
@@ -137,9 +136,8 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
     dict_: dict, list, str
         The value of the requested dotted field.
     """
-    fields = get_dotted_field_list(dotted_field)
     try:
-        return reduce(_get_item, (event, *fields))
+        return reduce(_get_item, (event, *get_dotted_field_list(dotted_field)))
     except KeyError:
         return None
     except ValueError:


### PR DESCRIPTION
this is a PR to improve logprep performance. the main idea behind this is, that splitting of string is an expensive operation and we could cache this easy. @ppcad could you please double check if this is really an improvement in performance. my local setup says it does.