### PR TITLE
Fix rule corpus tester processor caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@
 * add `kafka_config` option to `confluent_kafka_input` and `confluent_kafka_output` connectors to provide additional config options to `librdkafka`
 
 ### Improvements
+
 * Harmonize error messages and handling for processors and connectors
 * Add ability to schedule periodic tasks to all components
 
+### Bugfix
+
+* Fix resetting processor caches in the `auto_rule_corpus_tester` by initializing all processors
+between test cases.
 
 ## v6.0.0
 

--- a/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
@@ -187,6 +187,7 @@ class RuleCorpusTester:
         """
         print(Style.BRIGHT + "# Test Cases Summary:" + Style.RESET_ALL)
         for test_case_id, test_case in self._test_cases.items():
+            _ = [processor.setup() for processor in self._pipeline._pipeline]
             parsed_event, extra_outputs = self._pipeline.process_pipeline()
             extra_outputs = self._align_extra_output_formats(extra_outputs)
             test_case.generated_output = parsed_event

--- a/tests/unit/util/test_auto_rule_corpus_tester.py
+++ b/tests/unit/util/test_auto_rule_corpus_tester.py
@@ -19,16 +19,19 @@ def fixture_auto_rule_corpus_tester():
     return corpus_tester
 
 
+def write_test_case_data_tmp_files(test_data_dir, test_case_name, test_data):
+    input_data_path = test_data_dir / f"{test_case_name}_in.json"
+    input_data_path.write_text(json.dumps(test_data.get("input")))
+    expected_output_data_path = test_data_dir / f"{test_case_name}_out.json"
+    expected_output_data_path.write_text(json.dumps(test_data.get("expected_output")))
+    expected_extra_output_data_path = test_data_dir / f"{test_case_name}_out_extra.json"
+    expected_extra_output_data_path.write_text(json.dumps(test_data.get("expected_extra_output")))
+
+
 def prepare_corpus_tester(corpus_tester, tmp_path, test_data):
-    case_name = "rule_auto_corpus_test"
     test_data_dir = tmp_path / "test_data"
     os.makedirs(test_data_dir, exist_ok=True)
-    input_data_path = test_data_dir / f"{case_name}_in.json"
-    input_data_path.write_text(json.dumps(test_data.get("input")))
-    expected_output_data_path = test_data_dir / f"{case_name}_out.json"
-    expected_output_data_path.write_text(json.dumps(test_data.get("expected_output")))
-    expected_extra_output_data_path = test_data_dir / f"{case_name}_out_extra.json"
-    expected_extra_output_data_path.write_text(json.dumps(test_data.get("expected_extra_output")))
+    write_test_case_data_tmp_files(test_data_dir, "rule_auto_corpus_test", test_data)
     corpus_tester._input_test_data_path = test_data_dir
     corpus_tester._tmp_dir = tmp_path
 
@@ -414,6 +417,47 @@ class TestAutoRuleTester:
         prepare_corpus_tester(corpus_tester, tmp_path, test_data)
         corpus_tester.run()
         console_output, console_error = capsys.readouterr()
+        for expected_print in expected_prints:
+            assert expected_print in console_output
+        mock_exit.assert_called_with(0)
+
+    @mock.patch("logprep.util.auto_rule_tester.auto_rule_corpus_tester.sys.exit")
+    def test_corpus_tests_dont_share_cache_between_runs_by_resetting_processors(
+        self, mock_exit, tmp_path, capsys
+    ):
+        test_case_data = {
+            "input": {
+                "winlog": {"event_id": "2222", "event_data": {"IpAddress": "1.2.3.4"}},
+            },
+            "expected_output": {
+                "winlog": {"event_id": "2222", "event_data": {"IpAddress": "<IGNORE_VALUE>"}},
+            },
+            "expected_extra_output": [
+                {
+                    "({'kafka_output': 'pseudonyms'},)": {
+                        "origin": "<IGNORE_VALUE>",
+                        "pseudonym": "<IGNORE_VALUE>",
+                    }
+                },
+            ],
+        }
+        test_data_dir = tmp_path / "test_data"
+        os.makedirs(test_data_dir, exist_ok=True)
+        # run one test case two times to trigger the pseudonymizer cache.
+        # Without reinitializing the processors the second test wouldn't create an extra output, as
+        # the cache realizes it as an existing pseudonym already.
+        write_test_case_data_tmp_files(test_data_dir, "test_case_one", test_case_data)
+        write_test_case_data_tmp_files(test_data_dir, "test_case_two", test_case_data)
+        config_path = "tests/testdata/config/config.yml"
+        corpus_tester = RuleCorpusTester(config_path, test_data_dir)
+        corpus_tester.run()
+        console_output, console_error = capsys.readouterr()
+        assert console_error == ""
+        expected_prints = [
+            "PASSED",
+            "Total test cases: 2",
+            "Success rate: 100.00%",
+        ]
         for expected_print in expected_prints:
             assert expected_print in console_output
         mock_exit.assert_called_with(0)

--- a/tests/unit/util/test_auto_rule_corpus_tester.py
+++ b/tests/unit/util/test_auto_rule_corpus_tester.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+# pylint: disable=too-many-arguments
 import json
 import os
 from json import JSONDecodeError
@@ -321,12 +322,13 @@ class TestAutoRuleTester:
         else:
             corpus_tester.run()
         console_output, console_error = capsys.readouterr()
+        assert console_error == ""
         for expected_print in expected_prints:
             assert expected_print in console_output, test_case
         mock_exit.assert_called_with(exit_code)
 
     @mock.patch("logprep.util.auto_rule_tester.auto_rule_corpus_tester.parse_json")
-    def test_run_logs_json_decoding_error(self, mock_parse_json, tmp_path, corpus_tester, capsys):
+    def test_run_logs_json_decoding_error(self, mock_parse_json, tmp_path, corpus_tester):
         test_data = {"input": {}, "expected_output": {}, "expected_extra_output": []}
         prepare_corpus_tester(corpus_tester, tmp_path, test_data)
         mock_parse_json.side_effect = JSONDecodeError("Some Error", "in doc", 0)
@@ -359,6 +361,7 @@ class TestAutoRuleTester:
         os.remove(tmp_path / "test_data" / "rule_auto_corpus_test_out.json")
         corpus_tester.run()
         console_output, console_error = capsys.readouterr()
+        assert console_error == ""
         for expected_print in expected_prints:
             assert expected_print in console_output
         mock_exit.assert_called_with(0)
@@ -417,6 +420,7 @@ class TestAutoRuleTester:
         prepare_corpus_tester(corpus_tester, tmp_path, test_data)
         corpus_tester.run()
         console_output, console_error = capsys.readouterr()
+        assert console_error == ""
         for expected_print in expected_prints:
             assert expected_print in console_output
         mock_exit.assert_called_with(0)


### PR DESCRIPTION
Until now the tester used the caches of previous runs which led to changing results depending on which test data combination was executed. This pull request fixes the auto rule corpus tester cache handling by resetting all processors between test runs. Sadly this makes the auto rule corpus tester slower again as every test case has to setup all processors again.