### PR TITLE
Fix processing of generic rules after an error in the specific rules

### DIFF
--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -288,13 +288,15 @@ class Processor(Component):
         else:
             self._logger.warning(str(ProcessingWarning(self, str(error), rule, event)))
 
-    def _check_for_missing_values(self, event, rule, source_field_dict):
+    def _has_missing_values(self, event, rule, source_field_dict):
         missing_fields = list(
             dict(filter(lambda x: x[1] in [None, ""], source_field_dict.items())).keys()
         )
         if missing_fields:
             error = BaseException(f"{self.name}: no value for fields: {missing_fields}")
             self._handle_warning_error(event, rule, error)
+            return True
+        return False
 
     def _write_target_field(self, event: dict, rule: "Rule", result: any) -> None:
         add_successful = add_field_to(

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -284,8 +284,9 @@ class Processor(Component):
         else:
             add_and_overwrite(event, "tags", sorted(list({*tags, *rule.failure_tags})))
         if isinstance(error, ProcessingWarning):
-            raise error
-        raise ProcessingWarning(self, str(error), rule, event) from error
+            self._logger.warning(str(error))
+        else:
+            self._logger.warning(str(ProcessingWarning(self, str(error), rule, event)))
 
     def _check_for_missing_values(self, event, rule, source_field_dict):
         missing_fields = list(

--- a/logprep/processor/dissector/processor.py
+++ b/logprep/processor/dissector/processor.py
@@ -56,7 +56,7 @@ class Dissector(Processor):
                         f"dissector: mapping field '{source_field}' does not exist"
                     )
                     self._handle_warning_error(event, rule, error)
-            if delimeter is not None:
+            if delimeter is not None and loop_content is not None:
                 content, _, loop_content = loop_content.partition(delimeter)
             else:
                 content = loop_content

--- a/logprep/processor/field_manager/processor.py
+++ b/logprep/processor/field_manager/processor.py
@@ -37,7 +37,8 @@ class FieldManager(Processor):
         source_fields = rule.source_fields
         target_field = rule.target_field
         field_values = self._get_field_values(event, rule)
-        self._check_for_missing_fields(event, rule, source_fields, field_values)
+        if self._has_missing_fields(event, rule, source_fields, field_values):
+            return
         extend_target_list = rule.extend_target_list
         overwrite_target = rule.overwrite_target
         args = (event, target_field, field_values)
@@ -76,10 +77,12 @@ class FieldManager(Processor):
         target_field_value = self._get_deduplicated_sorted_flatten_list(lists, other)
         add_and_overwrite(event, target_field, target_field_value)
 
-    def _check_for_missing_fields(self, event, rule, source_fields, field_values):
+    def _has_missing_fields(self, event, rule, source_fields, field_values):
         if None in field_values:
             error = self._get_missing_fields_error(source_fields, field_values)
             self._handle_warning_error(event, rule, error)
+            return True
+        return False
 
     def _get_field_values(self, event, rule):
         return [get_dotted_field_value(event, source_field) for source_field in rule.source_fields]

--- a/logprep/util/auto_rule_tester/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_tester.py
@@ -78,9 +78,6 @@ if TYPE_CHECKING:
     from logprep.abc.processor import Processor
 
 
-logger = getLogger()
-logger.disabled = True
-
 yaml = YAML(typ="safe", pure=True)
 
 
@@ -180,6 +177,9 @@ class AutoRuleTester:
         self._custom_tests = []
         self._missing_custom_tests = []
 
+        self._logger = getLogger()
+        self._logger.disabled = True
+
     def run(self):
         """Perform auto-tests."""
         rules_dirs = self._get_rule_dirs_by_processor_name()
@@ -245,7 +245,7 @@ class AutoRuleTester:
         processors_without_custom_test = OrderedDict()
         for processor_in_pipeline in self._config_yml["pipeline"]:
             name, processor_cfg = next(iter(processor_in_pipeline.items()))
-            processor = self._get_processor_instance(name, processor_cfg, logger)
+            processor = self._get_processor_instance(name, processor_cfg, self._logger)
             if processor.has_custom_tests:
                 processors_with_custom_test[processor] = name
             else:
@@ -256,7 +256,7 @@ class AutoRuleTester:
         processor_uses_own_tests = {}
         for processor_in_pipeline in self._config_yml["pipeline"]:
             name, processor_cfg = next(iter(processor_in_pipeline.items()))
-            processor = self._get_processor_instance(name, processor_cfg, logger)
+            processor = self._get_processor_instance(name, processor_cfg, self._logger)
             processor_uses_own_tests[processor_cfg["type"]] = processor.has_custom_tests
         return processor_uses_own_tests
 

--- a/logprep/util/pre_detector_rule_matching_tester.py
+++ b/logprep/util/pre_detector_rule_matching_tester.py
@@ -12,14 +12,12 @@ from typing import Any, List, Tuple
 import regex as re
 from colorama import Fore
 from ruamel.yaml import YAML, YAMLError
+
+from logprep.factory import Factory
 from logprep.framework.rule_tree.rule_tree import RuleTree
 from logprep.processor.pre_detector.processor import PreDetector
 from logprep.processor.pre_detector.rule import PreDetectorRule
-from logprep.factory import Factory
 from logprep.util.helper import print_fcolor
-
-logger = logging.getLogger()
-logger.disabled = True
 
 yaml = YAML(typ="safe", pure=True)
 
@@ -134,7 +132,8 @@ class RuleMatchingTester:
             "tree_config": "",
             "pre_detector_topic": "",
         }
-
+        logger = logging.getLogger()
+        logger.disabled = True
         processor = Factory.create(processor_cfg, logger)
         return processor
 

--- a/tests/unit/processor/base.py
+++ b/tests/unit/processor/base.py
@@ -2,11 +2,9 @@
 # pylint: disable=protected-access
 
 import json
-from abc import ABC
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
-from typing import Iterable
 from unittest import mock
 
 import pytest

--- a/tests/unit/processor/calculator/test_calculator.py
+++ b/tests/unit/processor/calculator/test_calculator.py
@@ -1,9 +1,10 @@
 # pylint: disable=missing-docstring
+import logging
 import math
+import re
 
 import pytest
 
-from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.calculator.fourFn import BNF
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -177,7 +178,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "field3": 2,
             "tags": ["_calculator_failure"],
         },
-        r"expression 'not parsable \+ 4 \* 2' could not be parsed",
+        r"ProcessingWarning.*expression 'not parsable \+ 4 \* 2' could not be parsed",
     ),
     (
         "Tags failure if target_field exist",
@@ -196,7 +197,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "result": "exists",
             "tags": ["_calculator_failure"],
         },
-        "one or more subfields existed and could not be extended: result",
+        "FieldExistsWarning.*one or more subfields existed and could not be extended: result",
     ),
     (
         "Tags failure if source_field missing",
@@ -213,7 +214,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "field3": 2,
             "tags": ["_calculator_failure"],
         },
-        r"no value for fields: \['field1'\]",
+        r"ProcessingWarning.*no value for fields: \['field1'\]",
     ),
     (
         "Tags failure if source_field is empty",
@@ -231,7 +232,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "field3": 2,
             "tags": ["_calculator_failure"],
         },
-        r"no value for fields: \['field1'\]",
+        r"ProcessingWarning.*no value for fields: \['field1'\]",
     ),
     (
         "Tags failure try to escape",
@@ -249,7 +250,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "field3": 2,
             "tags": ["_calculator_failure"],
         },
-        r"could not be parsed",
+        r"ProcessingWarning.*could not be parsed",
     ),
     (
         "division by zero",
@@ -267,7 +268,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "field2": 4.5,
             "tags": ["_calculator_failure"],
         },
-        r"'3/0' => '3/0' results in division by zero",
+        r"ProcessingWarning.*'3/0' => '3/0' results in division by zero",
     ),
     (
         "raises timout",
@@ -283,7 +284,7 @@ failure_test_cases = [  # testcase, rule, event, expected, error_message
             "message": "This is a message",
             "tags": ["_calculator_failure"],
         },
-        r"Timer expired",
+        r"ProcessingWarning.*Timer expired",
     ),
 ]
 
@@ -302,10 +303,11 @@ class TestCalculator(BaseProcessorTestCase):
         assert event == expected
 
     @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
-    def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message):
+    def test_testcases_failure_handling(self, caplog, testcase, rule, event, expected, error_message):
         self._load_specific_rule(rule)
-        with pytest.raises(ProcessingWarning, match=error_message):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+            assert re.match(fr".*{error_message}", caplog.text)
         assert event == expected, testcase
 
     @pytest.mark.parametrize(

--- a/tests/unit/processor/dissector/test_dissector.py
+++ b/tests/unit/processor/dissector/test_dissector.py
@@ -1,7 +1,9 @@
 # pylint: disable=missing-docstring
+import logging
+import re
+
 import pytest
 
-from logprep.processor.base.exceptions import ProcessingWarning
 from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [  # testcase, rule, event, expected
@@ -583,8 +585,9 @@ class TestDissector(BaseProcessorTestCase):
         assert event == expected
 
     @pytest.mark.parametrize("testcase, rule, event, expected", failure_test_cases)
-    def test_testcases_failure_handling(self, testcase, rule, event, expected):
+    def test_testcases_failure_handling(self, caplog, testcase, rule, event, expected):
         self._load_specific_rule(rule)
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+        assert re.match(".*ProcessingWarning.*", caplog.text)
         assert event == expected, testcase

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 import hashlib
+import logging
+import re
 from copy import deepcopy
 from multiprocessing import current_process
 from os.path import exists
@@ -11,7 +13,7 @@ import pytest
 import responses
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
+from logprep.processor.base.exceptions import ProcessingWarning
 from tests.unit.processor.base import BaseProcessorTestCase
 
 REL_TLD_LIST_PATH = "tests/testdata/external/public_suffix_list.dat"
@@ -219,11 +221,12 @@ sth.ac.at
         assert document == expected
 
     @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_duplication_error(self, _):
+    def test_duplication_error(self, _, caplog):
         document = {"client": "google.de"}
 
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
     @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
     def test_no_duplication_error(self, _):

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -3,7 +3,9 @@
 # pylint: disable=unused-argument
 # pylint: disable=too-many-arguments
 import json
+import logging
 import os
+import re
 import tempfile
 import time
 from copy import deepcopy
@@ -15,7 +17,6 @@ from logprep.factory import Factory
 from logprep.factory_error import InvalidConfigurationError
 from logprep.processor.base.exceptions import (
     InvalidRuleDefinitionError,
-    ProcessingWarning,
 )
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -391,11 +392,12 @@ class TestGenericAdder(BaseProcessorTestCase):
 
     @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
     def test_generic_adder_testcases_failure_handling(
-        self, testcase, rule, event, expected, error_message
+        self, testcase, rule, event, expected, error_message, caplog
     ):
         self._load_specific_rule(rule)
-        with pytest.raises(ProcessingWarning, match=error_message):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+        assert re.match(fr".*FieldExistsWarning.*{error_message}", caplog.text)
         assert event == expected, testcase
 
     def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
@@ -582,7 +584,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         assert document_1 == expected
         assert document_2 == expected
 
-    def test_sql_database_raises_exception_on_duplicate(self):
+    def test_sql_database_raises_exception_on_duplicate(self, caplog):
         expected = {
             "add_from_sql_db_table": "Test",
             "source": "TEST_0.test.123",
@@ -592,8 +594,9 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         document = {"add_from_sql_db_table": "Test", "source": "TEST_0.test.123"}
 
         self.object.process(document)
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
         assert document == expected
 

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -2,11 +2,13 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
 # pylint: disable=wrong-import-position
+import logging
+import re
 from collections import OrderedDict
 
 import pytest
 
-from logprep.processor.base.exceptions import ProcessingCriticalError, ProcessingWarning
+from logprep.processor.base.exceptions import ProcessingCriticalError
 from logprep.processor.generic_resolver.processor import GenericResolver
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -389,7 +391,7 @@ class TestGenericResolver(BaseProcessorTestCase):
         assert document == expected
 
     def test_resolve_dotted_src_and_dest_field_and_conflict_match(
-        self,
+        self, caplog
     ):
         rule = {
             "filter": "to.resolve",
@@ -409,8 +411,9 @@ class TestGenericResolver(BaseProcessorTestCase):
             "to": {"resolve": "something HELLO1"},
             "re": {"solved": "I already exist!"},
         }
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
         assert document == expected
 

--- a/tests/unit/processor/hyperscan_resolver/test_hyperscan_resolver.py
+++ b/tests/unit/processor/hyperscan_resolver/test_hyperscan_resolver.py
@@ -2,12 +2,14 @@
 # pylint: disable=missing-docstring
 # pylint: disable=wrong-import-position
 # pylint: disable=wrong-import-order
+import logging
+import re
 from collections import OrderedDict
 from copy import deepcopy
 
 import pytest
 
-from logprep.processor.base.exceptions import ProcessingCriticalError, ProcessingWarning
+from logprep.processor.base.exceptions import ProcessingCriticalError
 
 pytest.importorskip("hyperscan")
 
@@ -21,7 +23,6 @@ pytest.importorskip("logprep.processor.hyperscan_resolver")
 
 from logprep.processor.hyperscan_resolver.processor import (
     HyperscanResolver,
-    HyperscanResolverError,
 )
 
 
@@ -342,7 +343,7 @@ class TestHyperscanResolverProcessor(BaseProcessorTestCase):
 
         assert document == expected
 
-    def test_resolve_dotted_and_dest_field_with_conflict_match(self):
+    def test_resolve_dotted_and_dest_field_with_conflict_match(self, caplog):
         rule = {
             "filter": "to.resolve",
             "hyperscan_resolver": {
@@ -360,8 +361,9 @@ class TestHyperscanResolverProcessor(BaseProcessorTestCase):
             "tags": ["_hyperscan_resolver_failure"],
         }
 
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
         assert document == expected
 

--- a/tests/unit/processor/ip_informer/test_ip_informer.py
+++ b/tests/unit/processor/ip_informer/test_ip_informer.py
@@ -1,9 +1,11 @@
 # pylint: disable=missing-docstring
 # pylint: disable=line-too-long
-import pytest
-from logprep.processor.base.exceptions import ProcessingWarning
-from tests.unit.processor.base import BaseProcessorTestCase
+import logging
+import re
 
+import pytest
+
+from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [
     (
@@ -379,8 +381,9 @@ class TestIpInformer(BaseProcessorTestCase):
         assert event == expected, testcase
 
     @pytest.mark.parametrize("testcase, rule, event, expected", failure_test_cases)
-    def test_testcases_failure_handling(self, testcase, rule, event, expected):
+    def test_testcases_failure_handling(self, testcase, rule, event, expected, caplog):
         self._load_specific_rule(rule)
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+        assert re.match(".*ProcessingWarning.*", caplog.text)
         assert event == expected, testcase

--- a/tests/unit/processor/key_checker/test_key_checker.py
+++ b/tests/unit/processor/key_checker/test_key_checker.py
@@ -1,9 +1,11 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=import-error
+import logging
+import re
+
 import pytest
 
-from logprep.processor.base.exceptions import FieldExistsWarning
 from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [  # testcase, rule, event, expected
@@ -254,7 +256,7 @@ class TestKeyChecker(BaseProcessorTestCase):
         self.object.process(event)
         assert event == expected
 
-    def test_raises_duplication_error(self):
+    def test_raises_duplication_error(self, caplog):
         rule_dict = {
             "filter": "*",
             "key_checker": {
@@ -271,5 +273,6 @@ class TestKeyChecker(BaseProcessorTestCase):
             "randomkey2": "randomvalue2",
             "missing_fields": ["i.exists.already"],
         }
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -1,10 +1,11 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import pytest
+import logging
+import re
+
 import responses
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from tests.unit.processor.base import BaseProcessorTestCase
 
 
@@ -141,7 +142,7 @@ class TestListComparison(BaseProcessorTestCase):
             len(document.get("dotted", {}).get("preexistent_output_field", {}).get("in_list")) == 1
         )
 
-    def test_target_field_exists_and_cant_be_extended(self):
+    def test_target_field_exists_and_cant_be_extended(self, caplog):
         assert self.object.metrics.number_of_processed_events == 0
         document = {"dot_channel": "test", "user": "Franz", "dotted": "dotted_Franz"}
         expected = {
@@ -162,11 +163,12 @@ class TestListComparison(BaseProcessorTestCase):
         }
         self._load_specific_rule(rule_dict)
         self.object.setup()
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
         assert document == expected
 
-    def test_intermediate_output_field_is_wrong_type(self):
+    def test_intermediate_output_field_is_wrong_type(self, caplog):
         assert self.object.metrics.number_of_processed_events == 0
         document = {
             "dot_channel": "test",
@@ -191,8 +193,9 @@ class TestListComparison(BaseProcessorTestCase):
         }
         self._load_specific_rule(rule_dict)
         self.object.setup()
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
         assert document == expected
 
     def test_check_in_dotted_subfield(self):
@@ -233,7 +236,7 @@ class TestListComparison(BaseProcessorTestCase):
         self.object.process(document)
         assert document == expected
 
-    def test_overwrite_target_field(self):
+    def test_overwrite_target_field(self, caplog):
         document = {"user": "Franz"}
         expected = {"user": "Franz", "tags": ["_list_comparison_failure"]}
         rule_dict = {
@@ -248,9 +251,9 @@ class TestListComparison(BaseProcessorTestCase):
         }
         self._load_specific_rule(rule_dict)
         self.object.setup()
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
-
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
         assert document == expected
 
     @responses.activate

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -5,7 +5,9 @@
 import calendar
 import copy
 import json
+import logging
 import os
+import re
 import tempfile
 from copy import deepcopy
 
@@ -13,8 +15,7 @@ import arrow
 import pytest
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
-from logprep.processor.normalizer.processor import NormalizerError
+from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.normalizer.rule import (
     InvalidGrokDefinition,
     InvalidNormalizationDefinition,
@@ -62,7 +63,7 @@ class TestNormalizer(BaseProcessorTestCase):
             == "Existing and normalized have the same value"
         )
 
-    def test_process_normalized_field_already_exists_with_different_content(self):
+    def test_process_normalized_field_already_exists_with_different_content(self, caplog):
         document = {
             "winlog": {
                 "api": "wineventlog",
@@ -71,8 +72,9 @@ class TestNormalizer(BaseProcessorTestCase):
             },
             "test_normalized": {"something": "I already exist but I am different!"},
         }
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
         assert document["test_normalized"]["something"] == "I already exist but I am different!"
 
@@ -621,7 +623,7 @@ class TestNormalizer(BaseProcessorTestCase):
             "winlog>event_data>normalize me!": "123.123.123.123 1234"
         }
 
-    def test_normalization_from_grok_onto_existing(self):
+    def test_normalization_from_grok_onto_existing(self, caplog):
         event = {
             "winlog": {
                 "api": "wineventlog",
@@ -639,8 +641,9 @@ class TestNormalizer(BaseProcessorTestCase):
 
         self._load_specific_rule(rule)
 
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
     def test_incorrect_grok_identifier_definition(self):
         rule = {
@@ -963,7 +966,7 @@ class TestNormalizer(BaseProcessorTestCase):
 
         assert event == expected
 
-    def test_normalization_from_timestamp_with_non_matching_patterns(self):
+    def test_normalization_from_timestamp_with_non_matching_patterns(self, caplog):
         event = {
             "winlog": {
                 "api": "wineventlog",
@@ -990,9 +993,9 @@ class TestNormalizer(BaseProcessorTestCase):
         }
 
         self._load_specific_rule(rule)
-        with pytest.raises(NormalizerError):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
-
+        assert re.match(".*NormalizerError.*", caplog.text)
         assert event == expected
 
     def test_normalization_from_timestamp_with_collision(self):
@@ -1034,7 +1037,7 @@ class TestNormalizer(BaseProcessorTestCase):
         assert event == expected
 
     def test_normalization_from_timestamp_with_collision_without_allow_override_fails(
-        self,
+        self, caplog
     ):
         event = {
             "@timestamp": "2200-02-01T16:19:22Z",
@@ -1064,9 +1067,9 @@ class TestNormalizer(BaseProcessorTestCase):
         }
 
         self._load_specific_rule(rule)
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
-
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
         assert event == expected
 
     def test_normalization_with_replace_html_entity(self):

--- a/tests/unit/processor/string_splitter/test_string_splitter.py
+++ b/tests/unit/processor/string_splitter/test_string_splitter.py
@@ -1,8 +1,10 @@
 # pylint: disable=missing-docstring
-import pytest
-from logprep.processor.base.exceptions import ProcessingWarning
-from tests.unit.processor.base import BaseProcessorTestCase
+import logging
+import re
 
+import pytest
+
+from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [
     (
@@ -38,6 +40,7 @@ failure_test_cases = [
         },
         {"message": ["this", "is", "the", "message"]},
         {"message": ["this", "is", "the", "message"], "tags": ["_string_splitter_failure"]},
+        ".*ProcessingWarning.*"
     ),
     (
         "splits without delimeter on whitespace",
@@ -47,8 +50,9 @@ failure_test_cases = [
         },
         {"message": "this is the message"},
         {"message": "this is the message", "tags": ["_string_splitter_failure"]},
+        ".*FieldExistsWarning.*"
     ),
-]  # testcase, rule, event, expected
+]  # testcase, rule, event, expected, error_message
 
 
 class TestStringSplitter(BaseProcessorTestCase):
@@ -64,9 +68,10 @@ class TestStringSplitter(BaseProcessorTestCase):
         self.object.process(event)
         assert event == expected
 
-    @pytest.mark.parametrize("testcase, rule, event, expected", failure_test_cases)
-    def test_testcases_failure_handling(self, testcase, rule, event, expected):
+    @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
+    def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message, caplog):
         self._load_specific_rule(rule)
-        with pytest.raises(ProcessingWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(event)
+        assert re.match(error_message, caplog.text)
         assert event == expected, testcase

--- a/tests/unit/processor/template_replacer/test_template_replacer.py
+++ b/tests/unit/processor/template_replacer/test_template_replacer.py
@@ -1,10 +1,11 @@
 # pylint: disable=missing-module-docstring
+import logging
+import re
 from copy import deepcopy
 
 import pytest
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.processor.template_replacer.processor import TemplateReplacerError
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -144,7 +145,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
         assert document["dotted"].get("message")
         assert document["dotted"]["message"] == "Test %1 Test %2"
 
-    def test_replace_incompatible_existing_dotted_message_parent_via_template(self):
+    def test_replace_incompatible_existing_dotted_message_parent_via_template(self, caplog):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
         self.object = Factory.create({"test instance": config}, self.logger)
@@ -154,8 +155,9 @@ class TestTemplateReplacer(BaseProcessorTestCase):
             "dotted": "foo",
         }
 
-        with pytest.raises(FieldExistsWarning):
+        with caplog.at_level(logging.WARNING):
             self.object.process(document)
+        assert re.match(".*FieldExistsWarning.*", caplog.text)
 
     def test_replace_fails_with_invalid_template(self):
         config = deepcopy(self.CONFIG)


### PR DESCRIPTION
The generic rule tree wasn't processed once there was an error in the specific rule tree. This was because the `_handle_warning_error` continued to raise the error which was thrown through the processing strategy and only captured in the pipeline itself. This pull request prevents that the errors will be thrown again in the `_handle_warning_error` and instead are handled there directly by logging them. This allows logprep to continue to work even after there was an error inside one single rule.

closes #361 