### PR TITLE
improve pipeline performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Harmonize error messages and handling for processors and connectors
 * Add ability to schedule periodic tasks to all components
+* Improve performance of pipeline processing by switching form builtin `json` to `msgspec` in pipeline and kafka connectors
 
 ### Bugfix
 

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -5,7 +5,6 @@ They can be multi-processed.
 
 """
 # pylint: disable=logging-fstring-interpolation
-import json
 import queue
 import warnings
 from ctypes import c_bool, c_double, c_ulonglong
@@ -16,6 +15,7 @@ from time import time
 from typing import Any, List, Tuple
 
 import attrs
+import msgspec
 import numpy as np
 
 from logprep._version import get_versions
@@ -227,6 +227,7 @@ class Pipeline:
         if log_handler and not isinstance(log_handler, Handler):
             raise MustProvideALogHandlerError
         self._logprep_config = config
+        self._timeout = config.get("timeout")
         self._log_handler = log_handler
         self._continue_iterating = Value(c_bool)
 
@@ -236,6 +237,8 @@ class Pipeline:
         self._used_server_ports = used_server_ports
         self._metric_targets = metric_targets
         self.pipeline_index = pipeline_index
+        self._encoder = msgspec.json.Encoder()
+        self._decoder = msgspec.json.Decoder()
 
     @cached_property
     def _process_name(self) -> str:
@@ -338,6 +341,7 @@ class Pipeline:
                 self._input.server.config.port += 1
             self._used_server_ports.update({self._input.server.config.port: self._process_name})
         self.logger.debug(f"Finished creating connectors ({self._process_name})")
+        _ = self._pipeline
 
     def _create_processor(self, entry: dict) -> "Processor":
         processor_name = list(entry.keys())[0]
@@ -378,12 +382,10 @@ class Pipeline:
     @_handle_pipeline_error
     def process_pipeline(self) -> Tuple[dict, list]:
         """Retrieve next event, process event with full pipeline and store or return results"""
-        assert self._input, "Run process_pipeline only with an valid input connector"
         self._metrics_exposer.expose(self.metrics)
         Component.run_pending_tasks()
-        event = self._get_event()
         extra_outputs = []
-        if event:
+        if event := self._get_event():
             extra_outputs = self.process_event(event)
         if event and self._output:
             self._store_event(event)
@@ -396,7 +398,7 @@ class Pipeline:
                 self.logger.debug(f"Stored output in {output_name}")
 
     def _get_event(self) -> dict:
-        event, non_critical_error_msg = self._input.get_next(self._logprep_config.get("timeout"))
+        event, non_critical_error_msg = self._input.get_next(self._timeout)
         if non_critical_error_msg and self._output:
             for _, output in self._output.items():
                 if output.default:
@@ -410,7 +412,7 @@ class Pipeline:
     @TimeMeasurement.measure_time("pipeline")
     def process_event(self, event: dict):
         """process all processors for one event"""
-        event_received = json.dumps(event, separators=(",", ":"))
+        event_received = self._encoder.encode(event)
         extra_outputs = []
         for processor in self._pipeline:
             try:
@@ -425,7 +427,7 @@ class Pipeline:
                 self.logger.error(str(error))
                 for _, output in self._output.items():
                     if output.default:
-                        output.store_failed(str(error), json.loads(event_received), event)
+                        output.store_failed(str(error), self._decoder.decode(event_received), event)
             if not event:
                 break
         if self._processing_counter:

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -382,6 +382,7 @@ class Pipeline:
     @_handle_pipeline_error
     def process_pipeline(self) -> Tuple[dict, list]:
         """Retrieve next event, process event with full pipeline and store or return results"""
+        assert self._input, "Run process_pipeline only with an valid input connector"
         self._metrics_exposer.expose(self.metrics)
         Component.run_pending_tasks()
         extra_outputs = []

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -237,8 +237,8 @@ class Pipeline:
         self._used_server_ports = used_server_ports
         self._metric_targets = metric_targets
         self.pipeline_index = pipeline_index
-        self._encoder = msgspec.json.Encoder()
-        self._decoder = msgspec.json.Decoder()
+        self._encoder = msgspec.msgpack.Encoder()
+        self._decoder = msgspec.msgpack.Decoder()
 
     @cached_property
     def _process_name(self) -> str:
@@ -417,10 +417,9 @@ class Pipeline:
         extra_outputs = []
         for processor in self._pipeline:
             try:
-                extra_data = processor.process(event)
-                if extra_data and self._output:
-                    self._store_extra_data(extra_data)
-                if extra_data:
+                if extra_data := processor.process(event):
+                    if self._output:
+                        self._store_extra_data(extra_data)
                     extra_outputs.append(extra_data)
             except ProcessingWarning as error:
                 self.logger.warning(str(error))

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -137,14 +137,10 @@ def get_dotted_field_value(event: dict, dotted_field: str) -> Optional[Union[dic
         The value of the requested dotted field.
     """
     try:
-        return reduce(_get_item, (event, *get_dotted_field_list(dotted_field)))
-    except KeyError:
-        return None
-    except ValueError:
-        return None
-    except TypeError:
-        return None
-    except IndexError:
+        for field in get_dotted_field_list(dotted_field):
+            event = _get_item(event, field)
+        return event
+    except (KeyError, ValueError, TypeError, IndexError):
         return None
 
 

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -80,7 +80,7 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
 
     if overwrite_output_field:
         target_field = reduce(_add_and_overwrite_key, output_field_path)
-        target_field.update({target_key: content})
+        target_field |= {target_key: content}
         return True
 
     try:
@@ -90,13 +90,13 @@ def add_field_to(event, output_field, content, extends_lists=False, overwrite_ou
 
     target_field_value = target_field.get(target_key)
     if target_field_value is None:
-        target_field.update({target_key: content})
+        target_field |= {target_key: content}
         return True
     if extends_lists:
         if not isinstance(target_field_value, list):
             return False
         if isinstance(content, list):
-            target_field.update({target_key: [*target_field_value, *content]})
+            target_field |= {target_key: [*target_field_value, *content]}
         else:
             target_field_value.append(content)
         return True

--- a/tests/acceptance/test_http_input.py
+++ b/tests/acceptance/test_http_input.py
@@ -10,8 +10,8 @@ from logprep.util.json_handling import dump_config_as_file
 from tests.acceptance.util import (
     get_default_logprep_config,
     start_logprep,
-    wait_for_output,
     stop_logprep,
+    wait_for_output,
 )
 
 basicConfig(level=DEBUG, format="%(asctime)-15s %(name)-5s %(levelname)-8s: %(message)s")
@@ -61,7 +61,7 @@ def test_http_input_accepts_message_for_single_pipeline(tmp_path, config):
     config_path = str(tmp_path / "generated_config.yml")
     dump_config_as_file(config_path, config)
     proc = start_logprep(config_path)
-    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9000")
+    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9000", test_timeout=15)
     # nosemgrep
     requests.post("https://127.0.0.1:9000/plaintext", data="my message", verify=False, timeout=5)
     time.sleep(0.5)  # nosemgrep
@@ -76,7 +76,7 @@ def test_http_input_accepts_message_for_two_pipelines(tmp_path, config):
     config_path = str(tmp_path / "generated_config.yml")
     dump_config_as_file(config_path, config)
     proc = start_logprep(config_path)
-    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9001")
+    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9001", test_timeout=15)
     # nosemgrep
     requests.post(
         "https://127.0.0.1:9000/plaintext",
@@ -105,7 +105,7 @@ def test_http_input_accepts_message_for_three_pipelines(tmp_path, config):
     config_path = str(tmp_path / "generated_config.yml")
     dump_config_as_file(config_path, config)
     proc = start_logprep(config_path)
-    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9002", test_timeout=10)
+    wait_for_output(proc, "Uvicorn running on https://127.0.0.1:9002", test_timeout=15)
     # nosemgrep
     requests.post(
         "https://127.0.0.1:9000/plaintext",


### PR DESCRIPTION
Baseline of main:

```
2.1283082099980675                                                                                                                                                                                            
2.162810495996382
2.1795665249956073
```

this PR:
```
1.560745990005671                                                                                                                                                                                    
1.5640459910064237
1.5819058579945704
```

testcode:

```python
from timeit import timeit

setup_code = """
import logging
logging.disable(logging.CRITICAL)
import json
from pathlib import Path
from logprep.framework.pipeline import Pipeline
from logprep.util.configuration import Configuration

input_data = Path("kafka_messages").read_text().splitlines()[:100000]
input_data = [json.loads(item) for item in input_data]
config = Configuration.create_from_yaml("config/pipeline.yml")
del config["output"]
config.update({"input": {"dummy": {"type": "dummy_input", "documents": input_data}}})
pipeline = Pipeline(config=config)
pipeline.process_pipeline()
"""

profile_code = """
for i in input_data:
    extra_outputs = pipeline.process_pipeline()
"""

print(timeit(stmt=profile_code, setup=setup_code, number=1))
print(timeit(stmt=profile_code, setup=setup_code, number=1))
print(timeit(stmt=profile_code, setup=setup_code, number=1))

```