### PR TITLE
Remove all geoip enricher fields if they are None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@
 
 * Harmonize error messages and handling for processors and connectors
 * Add ability to schedule periodic tasks to all components
-* Improve performance of pipeline processing by switching form builtin `json` to `msgspec` in pipeline and kafka connectors
-* Remove fields with `None` values from results of the geoip enricher to ensure the same data type for those fields across different events 
+* Improve performance of pipeline processing by switching form builtin `json` to `msgspec` in pipeline and kafka connectors 
 
 ### Bugfix
 
 * Fix resetting processor caches in the `auto_rule_corpus_tester` by initializing all processors
 between test cases.
 * Fix processing of generic rules after there was an error inside the specific rules.
+* Remove coordinate fields from results of the geoip enricher if one of them has `None` values
 
 ## v6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Harmonize error messages and handling for processors and connectors
 * Add ability to schedule periodic tasks to all components
 * Improve performance of pipeline processing by switching form builtin `json` to `msgspec` in pipeline and kafka connectors
+* Remove fields with `None` values from results of the geoip enricher to ensure the same data type for those fields across different events 
 
 ### Bugfix
 

--- a/logprep/processor/geoip_enricher/rule.py
+++ b/logprep/processor/geoip_enricher/rule.py
@@ -19,18 +19,14 @@ In the following example the IP in :code:`client.ip` will be enriched with geoip
       source_fields: [client.ip]
     description: '...'
 """
-
-import warnings
-
 from attr import Factory
 from attrs import define, field, validators
 
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.helper import add_and_overwrite, pop_dotted_field_value
 
 GEOIP_DATA_STUBS = {
     "type": "Feature",
-    "geometry.type": "Point",
+    "geometry.type": None,
     "geometry.coordinates": None,
     "properties.accuracy_radius": None,
     "properties.continent": None,


### PR DESCRIPTION
Remove all geoip fields that are `None` from the geoip results, so that the results for different events always have the same data types. This was missing for the geoip enricher coordinates.