### PR TITLE
mark not used fields with init=False, repr=False, eq=False

### DIFF
--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -103,7 +103,7 @@ class CalculatorRule(FieldManagerRule):
         )
         """The calculation expression. Fields from the event can be used by
         surrounding them with :code:`${` and :code:`}`."""
-        source_fields: list = field(factory=list)
+        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
         extend_target_list: bool = field(validator=validators.instance_of(bool), default=False)
         """If the target field exists and is a list, the list will be extended with the values
         of the source fields.

--- a/logprep/processor/datetime_extractor/rule.py
+++ b/logprep/processor/datetime_extractor/rule.py
@@ -21,9 +21,7 @@ In the following example the timestamp will be extracted from
       target_field: 'split_@timestamp'
     description: '...'
 """
-import warnings
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 
 
 class DatetimeExtractorRule(FieldManagerRule):

--- a/logprep/processor/deleter/rule.py
+++ b/logprep/processor/deleter/rule.py
@@ -13,12 +13,10 @@ The example below deletes the log message if the message field equals "foo".
         delete: true
     description: '...'
 """
-import warnings
 
 from attrs import define, field, validators
 
 from logprep.processor.base.rule import Rule
-from logprep.util.helper import pop_dotted_field_value, add_and_overwrite
 
 
 class DeleterRule(Rule):
@@ -30,6 +28,7 @@ class DeleterRule(Rule):
 
         delete: bool = field(validator=validators.instance_of(bool))
         """Delete or not"""
+        target_field = field(init=False, repr=False, eq=False)
 
     @property
     def delete_event(self) -> bool:

--- a/logprep/processor/dissector/rule.py
+++ b/logprep/processor/dissector/rule.py
@@ -133,8 +133,8 @@ class DissectorRule(FieldManagerRule):
     class Config(FieldManagerRule.Config):
         """Config for Dissector"""
 
-        source_fields: list = field(factory=list, init=False)
-        target_field: str = field(default="", init=False)
+        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
+        target_field: str = field(default="", init=False, repr=False, eq=False)
 
         mapping: dict = field(
             validator=[

--- a/logprep/processor/selective_extractor/rule.py
+++ b/logprep/processor/selective_extractor/rule.py
@@ -153,11 +153,11 @@ class SelectiveExtractorRule(FieldManagerRule):
         """The path or url to a file with a flat list of fields to extract.
         For string format see :ref:`getters`."""
 
-        target_field: str = field(default="", init=False)
+        target_field: str = field(default="", init=False, repr=False, eq=False)
 
-        overwrite_target: bool = field(default=False, init=False)
+        overwrite_target: bool = field(default=False, init=False, repr=False, eq=False)
 
-        extend_target_list: bool = field(default=False, init=False)
+        extend_target_list: bool = field(default=False, init=False, repr=False, eq=False)
 
         def __attrs_post_init__(self):
             super().__attrs_post_init__()

--- a/logprep/processor/timestamp_differ/rule.py
+++ b/logprep/processor/timestamp_differ/rule.py
@@ -55,6 +55,9 @@ class TimestampDifferRule(FieldManagerRule):
     class Config(FieldManagerRule.Config):
         """Config for TimestampDiffer"""
 
+        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
+        source_field_formats: list = field(factory=list, init=False, repr=False, eq=False)
+
         diff: str = field(
             validator=[
                 validators.instance_of(str),
@@ -67,8 +70,6 @@ class TimestampDifferRule(FieldManagerRule):
         :code:`${dotted.field.path}`, then the default parsing mechanism of the python library
         arrow will be used. For more information see the
         `Arrow documentation <https://arrow.readthedocs.io/en/latest/guide.html#creation>`_."""
-        source_fields: list = field(factory=list)
-        source_field_formats: list = field(factory=list)
         output_format: str = field(
             default="seconds",
             validator=[


### PR DESCRIPTION
* mark inherited but not used fields in rules with `init=False, repr=False, eq=False` to signal, that they do not need to be rendered in external UI tools.

