### PR TITLE
Fix packaging of logprep to include grok default pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 
 ### Bugfix
+* Fix missing default grok patterns in packaged logprep version
 
 
 ## v6.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include logprep/_version.py
+include logprep/util/grok/patterns/ecs-v1/*
+include logprep/util/grok/patterns/legacy/*

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Documentation": "https://logprep.readthedocs.io/en/latest/",
     },
     packages=find_packages(),
+    include_package_data=True,
     install_requires=["setuptools"] + requirements,
     python_requires=">=3.9",
     entry_points={


### PR DESCRIPTION
The MANIFEST.in didn't include the grok pattern, such that logprep, if installed through pypi, didn't include the grok patterns.

I did test this through the [pypi test server](https://test.pypi.org/project/logprep/6.1.0.dev0/#files). It can be verified by running the following command in a new venv:

```bash
pip install --no-deps -i https://test.pypi.org/simple/ logprep==6.1.0.dev1
```
Afterwards you can check the installed site-packages of the venv. There you should find the logprep install with the grok patterns.