### PR TITLE
Allow same target names in grokker mapping list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfix
 
 * Fix error handling of missing source fields in grokker
+* Fix using same output fields in list of grok pattern in grokker
 
 ## v6.2.0
 

--- a/logprep/processor/grokker/processor.py
+++ b/logprep/processor/grokker/processor.py
@@ -62,7 +62,7 @@ class Grokker(Processor):
                 self._handle_warning_error(event=event, rule=rule, error=error)
                 continue
             result = grok.match(field_value)
-            if result is None:
+            if result is None or result == {}:
                 continue
             matches.append(True)
             for dotted_field, value in result.items():

--- a/logprep/processor/grokker/rule.py
+++ b/logprep/processor/grokker/rule.py
@@ -82,11 +82,10 @@ def _dotted_field_to_logstash_converter(mapping: dict) -> dict:
         if isinstance(pattern, list):
             pattern = list(map(_transform, pattern))
         else:
-            pattern = _transform(pattern)
+            pattern = [_transform(pattern)]
         return pattern
 
-    foo = {dotted_field: _replace_pattern(pattern) for dotted_field, pattern in mapping.items()}
-    return foo
+    return {dotted_field: _replace_pattern(pattern) for dotted_field, pattern in mapping.items()}
 
 
 class GrokkerRule(DissectorRule):
@@ -101,12 +100,11 @@ class GrokkerRule(DissectorRule):
                 validators.instance_of(dict),
                 validators.deep_mapping(
                     key_validator=validators.instance_of(str),
-                    value_validator=validators.instance_of((str, list)),
+                    value_validator=validators.deep_iterable(
+                        member_validator=validators.matches_re(MAPPING_VALIDATION_REGEX),
+                        iterable_validator=validators.instance_of(list),
+                    ),
                 ),
-                # validators.deep_mapping(
-                #     key_validator=validators.instance_of(str),
-                #     value_validator=validators.matches_re(MAPPING_VALIDATION_REGEX),
-                # ),
                 validators.deep_iterable(
                     member_validator=validators.instance_of(str),
                     iterable_validator=validators.min_len(1),

--- a/logprep/processor/grokker/rule.py
+++ b/logprep/processor/grokker/rule.py
@@ -116,8 +116,8 @@ class GrokkerRule(DissectorRule):
         Dotted field notation is possible in key and in the grok pattern.
         Additionally logstash field notation is possible in grok pattern.
         The value can be a list of search patterns or a single search pattern.
-        Lists of search pattern will be joined by :code:`|` and only the first matching pattern
-        will return values.
+        Lists of search pattern will be checked in the order of the list until the first matching
+        pattern.
         It is possible to use `oniguruma` regex pattern with or without grok patterns in the
         patterns part.
         Logstashs ecs conform grok patterns are used to resolve the here used grok patterns.
@@ -132,7 +132,7 @@ class GrokkerRule(DissectorRule):
             ],
             factory=dict,
         )
-        """(Optional) additional grok patterns as mapping. E.g. :code:`CUSTOM_PATTERN: [^\s]*`
+        r"""(Optional) additional grok patterns as mapping. E.g. :code:`CUSTOM_PATTERN: [^\s]*`
         if you want to use special target fields, you are able to use them an usual in the
         mapping sections. Here you only have to declare the matching regex without named groups.
         """

--- a/logprep/processor/grokker/rule.py
+++ b/logprep/processor/grokker/rule.py
@@ -69,7 +69,7 @@ def _dotted_field_to_logstash_converter(mapping: dict) -> dict:
     if not mapping:
         return mapping
 
-    def _transform(pattern):
+    def _transform(pattern):  # nosemgrep
         fields = re.findall(FIELD_PATTERN, pattern)
         for dotted_field, _ in fields:
             splitted_field = dotted_field.split(".")

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -96,7 +96,11 @@ class Grok:
             matches = list(map(self._map_types, matches))
         # deduplicate matches
         matches = [dict(tup) for tup in {tuple(match.items()) for match in matches}]
-        return {self.field_mapper[field_hash]: value for match in matches for field_hash, value in match.items() }
+        return {
+            self.field_mapper[field_hash]: value
+            for match in matches
+            for field_hash, value in match.items()
+        }
 
     def _map_types(self, matches):
         for key, match in matches.items():

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -86,12 +86,12 @@ class Grok:
         """
 
         if self.fullmatch:
-            match_obj = list(map(lambda x: x.fullmatch(text), self.regex_obj))
+            match_obj = [regex_pattern.fullmatch(text) for regex_pattern in self.regex_obj]
         else:
-            match_obj = list(map(lambda x: x.search(text), self.regex_obj))
+            match_obj = [regex_pattern.search(text) for regex_pattern in self.regex_obj]
 
-        match_obj = list(filter(lambda x: x is not None, match_obj))
-        matches = list(map(lambda x: x.groupdict(), match_obj))
+        match_obj = [match for match in match_obj if match is not None]
+        matches = [match.groupdict() for match in match_obj]
         if self.type_mapper:
             matches = list(map(self._map_types, matches))
         # deduplicate matches

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -52,7 +52,7 @@ class Grok:
     grok_pattern = re.compile(GROK)
     oniguruma = re.compile(ONIGURUMA)
 
-    pattern: str = field(validator=validators.instance_of(str))
+    pattern: str = field(validator=validators.instance_of((str, list)))
     custom_patterns_dir: str = field(default="")
     custom_patterns: dict = field(factory=dict)
     fullmatch: bool = field(default=True)
@@ -79,26 +79,31 @@ class Grok:
     def match(self, text):
         """If text is matched with pattern, return variable names
         specified(%{pattern:variable name}) in pattern and their
-        corresponding values.If not matched, return None.
+        corresponding values. If not matched, return None.
         custom patterns can be passed in by
         custom_patterns(pattern name, pattern regular expression pair)
         or custom_patterns_dir.
         """
 
         if self.fullmatch:
-            match_obj = self.regex_obj.fullmatch(text)
+            match_obj = list(map(lambda x: x.fullmatch(text), self.regex_obj))
         else:
-            match_obj = self.regex_obj.search(text)
+            match_obj = list(map(lambda x: x.search(text), self.regex_obj))
 
-        if match_obj is None:
-            return None
-        matches = match_obj.groupdict()
+        match_obj = list(filter(lambda x: x is not None, match_obj))
+        matches = list(map(lambda x: x.groupdict(), match_obj))
         if self.type_mapper:
-            for key, match in matches.items():
-                type_ = INT_FLOAT.get(self.type_mapper.get(key))
-                if type_ is not None and match is not None:
-                    matches[key] = type_(match)
-        return {self.field_mapper[field_hash]: value for field_hash, value in matches.items()}
+            matches = list(map(self._map_types, matches))
+        # deduplicate matches
+        matches = [dict(tup) for tup in {tuple(match.items()) for match in matches}]
+        return {self.field_mapper[field_hash]: value for match in matches for field_hash, value in match.items() }
+
+    def _map_types(self, matches):
+        for key, match in matches.items():
+            type_ = INT_FLOAT.get(self.type_mapper.get(key))
+            if type_ is not None and match is not None:
+                matches[key] = type_(match)
+        return matches
 
     def set_search_pattern(self, pattern=None):
         """sets the search pattern"""
@@ -147,6 +152,12 @@ class Grok:
 
     def _load_search_pattern(self):
         py_regex_pattern = self.pattern
+        if isinstance(py_regex_pattern, list):
+            self.regex_obj = list(map(self._compile_pattern, py_regex_pattern))
+        else:
+            self.regex_obj = [self._compile_pattern(py_regex_pattern)]
+
+    def _compile_pattern(self, py_regex_pattern):
         while re.search(Grok.oniguruma, py_regex_pattern):
             py_regex_pattern = re.sub(
                 Grok.oniguruma,
@@ -161,8 +172,7 @@ class Grok:
                 py_regex_pattern,
                 count=1,
             )
-
-        self.regex_obj = re.compile(py_regex_pattern)
+        return re.compile(py_regex_pattern)
 
 
 def _reload_patterns(patterns_dirs):

--- a/tests/unit/processor/grokker/test_grok.py
+++ b/tests/unit/processor/grokker/test_grok.py
@@ -39,7 +39,7 @@ def test_one_pat_4():
     pat = "%{HOSTNAME:website}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match["website"] == text.strip(), f"grok match failed:{text}, {pat}"
+    assert match["website"] == text.strip(), f"grok match failed: {text}, {pat}"
 
 
 def test_one_pat_5():
@@ -47,7 +47,7 @@ def test_one_pat_5():
     pat = "%{TIMESTAMP_ISO8601:ts}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match["ts"] == text.strip(), f"grok match failed:{text}, {pat}"
+    assert match["ts"] == text.strip(), f"grok match failed: {text}, {pat}"
 
 
 def test_one_pat_6():
@@ -55,7 +55,7 @@ def test_one_pat_6():
     pat = "%{WORD}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match == {}, f"grok match failed:{text}, {pat}"
+    assert match == {}, f"grok match failed: {text}, {pat}"
     # you get nothing because variable name is not set,
     # compare "%{WORD}" and "%{WORD:variable_name}"
 
@@ -65,7 +65,7 @@ def test_one_pat_7():
     pat = "%{NUMBER:test_num}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match is None, f"grok match failed:{text}, {pat}"
+    assert match == {}, f"grok match failed: {text}, {pat}"
     # not match
 
 
@@ -98,7 +98,7 @@ def test_multiple_pats():
     pat = "%{WORD:name} %{INT:age} %{QUOTEDSTRING:motto}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match is None, f"grok match failed:{text}, {pat}"
+    assert match == {}, f"grok match failed:{text}, {pat}"
 
     # nginx log
     text = (

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -112,7 +112,7 @@ test_cases = [  # testcase, rule, event, expected
                     "winlog.event_data.normalize me!": [
                         "%{IP:some_ip_1} %{NUMBER:port_1:int} foo",
                         "%{IP:some_ip_2} %{NUMBER:port_2:int} bar",
-                        "%{IP:some_ip_3} %{NUMBER:port_3:int} bar",
+                        "%{IP:some_ip_2} %{NUMBER:port_2:int} bar",
                     ]
                 }
             },
@@ -132,6 +132,36 @@ test_cases = [  # testcase, rule, event, expected
             },
             "some_ip_2": "123.123.123.123",
             "port_2": 1234,
+        },
+    ),
+    (
+        "grok list match first matching after skipping non matching with same target fields",
+        {
+            "filter": "winlog.event_id: 123456789",
+            "grokker": {
+                "mapping": {
+                    "winlog.event_data.normalize me!": [
+                        "%{IP:some_ip} %{NUMBER:port:int} foo",
+                        "%{IP:some_ip} %{NUMBER:port:int} bar",
+                    ]
+                }
+            },
+        },
+        {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234 bar"},
+            }
+        },
+        {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234 bar"},
+            },
+            "some_ip": "123.123.123.123",
+            "port": 1234,
         },
     ),
     (

--- a/tests/unit/processor/grokker/test_grokker_rule.py
+++ b/tests/unit/processor/grokker/test_grokker_rule.py
@@ -296,7 +296,7 @@ class TestGrokkerRule:
                         "mapping": {"message": "this is a %{USER:[user][username]}"},
                     },
                 },
-                {"message": "this is a %{USER:[user][username]}"},
+                {"message": ["this is a %{USER:[user][username]}"]},
             ),
             (
                 {
@@ -305,7 +305,7 @@ class TestGrokkerRule:
                         "mapping": {"message": "this is a %{USER:user.username}"},
                     },
                 },
-                {"message": "this is a %{USER:[user][username]}"},
+                {"message": ["this is a %{USER:[user][username]}"]},
             ),
             (
                 {
@@ -314,7 +314,7 @@ class TestGrokkerRule:
                         "mapping": {"message": "this is a %{USER:user.username.firstname}"},
                     },
                 },
-                {"message": "this is a %{USER:[user][username][firstname]}"},
+                {"message": ["this is a %{USER:[user][username][firstname]}"]},
             ),
             (
                 {
@@ -323,7 +323,7 @@ class TestGrokkerRule:
                         "mapping": {"message": "this is a %{USER:user}"},
                     },
                 },
-                {"message": "this is a %{USER:user}"},
+                {"message": ["this is a %{USER:user}"]},
             ),
         ],
     )


### PR DESCRIPTION
Previously it was not possible to use a list of grok pattern that try to write into the same output fields. This was because the list of grok pattern was merged to one large regex-pattern with the `|` operator. This pull request changes this behavior by considering each list element as a separate regex pattern. That way it is possible to write a grokker rule with multiple grok-pattern that all try to write to the same output field.