### PR TITLE
remove direct python-dateutil dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 * Bump `requests` to `>=2.31.0` to circumvent `CVE-2023-32681`
 * Include a lucene representation of the rule filter into the predetector results. The
-representation is not completely lucene compatible due to non-existing regex functionality.  
+representation is not completely lucene compatible due to non-existing regex functionality.
+* Remove direct dependency of `python-dateutil`
 
 ### Bugfix
 

--- a/logprep/processor/pre_detector/ip_alerter.py
+++ b/logprep/processor/pre_detector/ip_alerter.py
@@ -1,16 +1,14 @@
 """This module is used to generate alerts if an IP matches a pattern in a list."""
 
-from typing import Union, List
-
-from ipaddress import ip_network, ip_address, IPv4Network
 from datetime import datetime
+from ipaddress import ip_network, ip_address, IPv4Network
 from os.path import isfile
-
-from dateutil import parser, tz
+from typing import Union, List
 
 from logprep.processor.pre_detector.rule import PreDetectorRule
 from logprep.util.getter import GetterFactory
 from logprep.util.helper import get_dotted_field_value
+from logprep.util.time import TimeParser, UTC
 
 
 class IPAlerter:
@@ -51,8 +49,8 @@ class IPAlerter:
     def _filter_non_expired_alert_ips(self, full_alert_ip_list: dict):
         for alert_ip, expiration_date_str in full_alert_ip_list.items():
             if expiration_date_str:
-                expiration_date = parser.isoparse(expiration_date_str)
-                now = datetime.now(tz.UTC)
+                expiration_date = TimeParser.from_string(expiration_date_str)
+                now = datetime.now(UTC)
                 if expiration_date > now:
                     self._alert_ips_map[alert_ip] = expiration_date_str
             else:
@@ -61,16 +59,16 @@ class IPAlerter:
     def _single_is_not_expired(self, ip_str: str) -> bool:
         expiration_date_str = self._alert_ips_map[ip_str]
         if expiration_date_str:
-            expiration_date = parser.isoparse(expiration_date_str)
-            now = datetime.now(tz.UTC)
+            expiration_date = TimeParser.from_string(expiration_date_str)
+            now = datetime.now(UTC)
             return now < expiration_date
         return True
 
     def _network_is_not_expired(self, network: IPv4Network) -> bool:
         expiration_date_str = self._alert_ips_map[network.exploded]
         if expiration_date_str:
-            expiration_date = parser.isoparse(expiration_date_str)
-            now = datetime.now(tz.UTC)
+            expiration_date = TimeParser.from_string(expiration_date_str)
+            now = datetime.now(UTC)
             return now < expiration_date
         return True
 

--- a/logprep/processor/timestamper/processor.py
+++ b/logprep/processor/timestamper/processor.py
@@ -48,7 +48,9 @@ class Timestamper(FieldManager):
         parsed_successfully = False
         for source_format in source_formats:
             try:
-                parsed_datetime = TimeParser.parse_datetime(source_field, source_format, source_timezone)
+                parsed_datetime = TimeParser.parse_datetime(
+                    source_field, source_format, source_timezone
+                )
             except TimeParserException:
                 continue
             result = parsed_datetime.astimezone(target_timezone).isoformat().replace("+00:00", "Z")

--- a/logprep/processor/timestamper/processor.py
+++ b/logprep/processor/timestamper/processor.py
@@ -30,7 +30,7 @@ from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.field_manager.processor import FieldManager
 from logprep.processor.timestamper.rule import TimestamperRule
 from logprep.util.helper import get_dotted_field_value
-from logprep.util.time import TimeParser, TimeParserException
+from logprep.util.time import TimeParserException, TimeParser
 
 
 class Timestamper(FieldManager):
@@ -48,7 +48,7 @@ class Timestamper(FieldManager):
         parsed_successfully = False
         for source_format in source_formats:
             try:
-                parsed_datetime = self._parse_datetime(source_field, source_format, source_timezone)
+                parsed_datetime = TimeParser.parse_datetime(source_field, source_format, source_timezone)
             except TimeParserException:
                 continue
             result = parsed_datetime.astimezone(target_timezone).isoformat().replace("+00:00", "Z")
@@ -67,18 +67,3 @@ class Timestamper(FieldManager):
             )
 
         return source_field_value
-
-    def _parse_datetime(self, source_field, source_format, source_timezone):
-        if source_format == "ISO8601":
-            parsed_datetime = TimeParser.from_string(source_field).astimezone(source_timezone)
-        elif source_format == "UNIX":
-            parsed_datetime = (
-                int(source_field) if len(source_field) <= 10 else int(source_field) / 1000
-            )
-            parsed_datetime = TimeParser.from_timestamp(parsed_datetime).astimezone(source_timezone)
-        else:
-            parsed_datetime = TimeParser.from_format(source_field, source_format).astimezone(
-                source_timezone
-            )
-
-        return parsed_datetime

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -78,7 +78,7 @@ class DryRunner:
 
     @cached_property
     def _input_documents(self):
-        return GetterFactory.from_string(self._input_file_path).get_yaml()
+        return GetterFactory.from_string(self._input_file_path).get_jsonl()
 
     def __init__(
         self, input_file_path: str, config_path: str, full_output: bool, use_json: bool, logger

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -1,5 +1,5 @@
 """logprep time helpers module"""
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import Union
 from zoneinfo import ZoneInfo
 
@@ -100,3 +100,35 @@ class TimeParser:
         if time_object.tzinfo is None:
             time_object = time_object.replace(tzinfo=UTC)
         return time_object
+
+    @classmethod
+    def parse_datetime(
+        cls, timestamp: str, source_format: str, source_timezone: [str, tzinfo]
+    ) -> datetime:
+        """
+        Parses a timestamp based on different formats, besides a format string 'ISO8601' and
+        'UNIX' are allowed formats.
+
+        Parameters
+        ----------
+        timestamp : str
+            The timestamp string that should be parsed
+        source_format : str
+            The format which should be used to parse the timestamp string. Besides a format string
+            'ISO8601' and 'UNIX' are allowed formats.
+        source_timezone : str
+
+
+        Returns
+        -------
+        datetime
+            The parsed timestamp as datetime object.
+        """
+        if source_format == "ISO8601":
+            parsed_datetime = cls.from_string(timestamp).astimezone(source_timezone)
+        elif source_format == "UNIX":
+            parsed_datetime = int(timestamp) if len(timestamp) <= 10 else int(timestamp) / 1000
+            parsed_datetime = cls.from_timestamp(parsed_datetime).astimezone(source_timezone)
+        else:
+            parsed_datetime = cls.from_format(timestamp, source_format).astimezone(source_timezone)
+        return parsed_datetime

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,6 @@ prometheus_client
 protobuf>=3.20.2
 pycryptodome
 pyparsing
-python-dateutil
 pytz # can be removed with normalizer code
 scikit-learn>=1.2.0
 scipy>=1.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.8.4
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.6.2
+anyio==3.7.0
     # via starlette
 async-timeout==4.0.2
     # via aiohttp
@@ -16,9 +16,9 @@ attrs==23.1.0
     # via
     #   -r requirements.in
     #   aiohttp
-boto3==1.26.138
+boto3==1.26.146
     # via -r requirements.in
-botocore==1.29.138
+botocore==1.29.146
     # via
     #   boto3
     #   s3transfer
@@ -44,7 +44,9 @@ deepdiff==6.3.0
     # via -r requirements.in
 elasticsearch==7.17.9
     # via -r requirements.in
-fastapi==0.95.2
+exceptiongroup==1.1.1
+    # via anyio
+fastapi==0.96.0
     # via -r requirements.in
 filelock==3.12.0
     # via
@@ -102,7 +104,7 @@ platformdirs==3.5.1
     # via urlextract
 ply==3.11
     # via luqum
-prometheus-client==0.16.0
+prometheus-client==0.17.0
     # via -r requirements.in
 protobuf==3.20.3
     # via
@@ -110,7 +112,7 @@ protobuf==3.20.3
     #   mysql-connector-python
 pycryptodome==3.18.0
     # via -r requirements.in
-pydantic==1.10.7
+pydantic==1.10.8
     # via fastapi
 pygrok==1.0.0
     # via -r requirements.in
@@ -118,14 +120,13 @@ pyparsing==3.0.9
     # via -r requirements.in
 python-dateutil==2.8.2
     # via
-    #   -r requirements.in
     #   botocore
     #   opensearch-py
 pytz==2023.3
     # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in
-regex==2023.5.5
+regex==2023.6.3
     # via pygrok
 requests==2.31.0
     # via
@@ -136,7 +137,7 @@ requests==2.31.0
     #   tldextract
 requests-file==1.5.1
     # via tldextract
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.31
     # via -r requirements.in
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -163,7 +164,7 @@ threadpoolctl==3.1.0
     # via scikit-learn
 tldextract==3.4.4
     # via -r requirements.in
-typing-extensions==4.6.0
+typing-extensions==4.6.3
     # via
     #   pydantic
     #   starlette

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ aiosignal==1.3.1
     # via
     #   -r requirements.txt
     #   aiohttp
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   -r requirements.txt
     #   httpcore
@@ -37,9 +37,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.138
+boto3==1.26.146
     # via -r requirements.txt
-botocore==1.29.138
+botocore==1.29.146
     # via
     #   -r requirements.txt
     #   boto3
@@ -76,7 +76,7 @@ colorama==0.4.6
     #   semgrep
 confluent-kafka==2.1.1
     # via -r requirements.txt
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via pytest-cov
 deepdiff==6.3.0
     # via -r requirements.txt
@@ -87,10 +87,13 @@ dill==0.3.6
 elasticsearch==7.17.9
     # via -r requirements.txt
 exceptiongroup==1.1.1
-    # via pytest
+    # via
+    #   -r requirements.txt
+    #   anyio
+    #   pytest
 face==22.0.0
     # via glom
-fastapi==0.95.2
+fastapi==0.96.0
     # via -r requirements.txt
 filelock==3.12.0
     # via
@@ -153,7 +156,7 @@ luqum==0.13.0
     # via -r requirements.txt
 markdown-it-py==2.2.0
     # via rich
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 maxminddb==2.3.0
     # via
@@ -206,7 +209,7 @@ ply==3.11
     # via
     #   -r requirements.txt
     #   luqum
-prometheus-client==0.16.0
+prometheus-client==0.17.0
     # via -r requirements.txt
 protobuf==3.20.3
     # via
@@ -214,7 +217,7 @@ protobuf==3.20.3
     #   mysql-connector-python
 pycryptodome==3.18.0
     # via -r requirements.txt
-pydantic==1.10.7
+pydantic==1.10.8
     # via
     #   -r requirements.txt
     #   fastapi
@@ -232,7 +235,7 @@ pytest==7.3.1
     # via
     #   -r requirements_dev.in
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements_dev.in
 python-dateutil==2.8.2
     # via
@@ -247,7 +250,7 @@ pyyaml==6.0
     # via
     #   -r requirements.txt
     #   responses
-regex==2023.5.5
+regex==2023.6.3
     # via
     #   -r requirements.txt
     #   pygrok
@@ -266,9 +269,9 @@ requests-file==1.5.1
     #   tldextract
 responses==0.23.1
     # via -r requirements_dev.in
-rich==13.3.5
+rich==13.4.1
     # via semgrep
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.31
     # via
     #   -r requirements.txt
     #   semgrep
@@ -288,7 +291,7 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scikit-learn
-semgrep==1.22.0
+semgrep==1.24.1
     # via -r requirements_dev.in
 six==1.16.0
     # via
@@ -323,7 +326,7 @@ tomlkit==0.11.8
     # via pylint
 types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.6.0
+typing-extensions==4.6.3
     # via
     #   -r requirements.txt
     #   astroid

--- a/tests/unit/processor/datetime_extractor/test_datetime_extractor.py
+++ b/tests/unit/processor/datetime_extractor/test_datetime_extractor.py
@@ -4,10 +4,8 @@
 # pylint: disable=wrong-import-order
 import logging
 import re
-from datetime import datetime
 
-from dateutil.parser import parse
-from dateutil.tz import tzlocal, tzutc
+from dateutil.tz import tzutc
 
 from logprep.processor.datetime_extractor.processor import DatetimeExtractor
 from tests.unit.processor.base import BaseProcessorTestCase
@@ -36,27 +34,17 @@ class TestDatetimeExtractor(BaseProcessorTestCase):
 
         self.object.process(document)
 
-        # Two different timezones need to be used in the test to account for daylight savings
-        # Use current timezone here, since the processor initializes with timezone on the system
-        tz_local_name = datetime.now(tzlocal()).strftime("%z")
-        _, _, local_timezone = self._parse_local_tz(tz_local_name)
-
-        # Use timestamps timezone here, since processor uses timezones of each timestamp for deltas
-        parsed_timestamp = parse(timestamp).astimezone(tzlocal())
-        tz_local_name = parsed_timestamp.strftime("%z")
-        ts_hour_delta, ts_minute_delta, _ = self._parse_local_tz(tz_local_name)
-
         expected = {
             "@timestamp": timestamp,
             "winlog": {"event_id": 123},
             "split_@timestamp": {
                 "day": 30,
-                "hour": 14 + ts_hour_delta,
+                "hour": 14,
                 "microsecond": 861000,
-                "minute": 37 + ts_minute_delta,
+                "minute": 37,
                 "month": 7,
                 "second": 42,
-                "timezone": local_timezone,
+                "timezone": "UTC",
                 "weekday": "Tuesday",
                 "year": 2019,
             },
@@ -71,27 +59,17 @@ class TestDatetimeExtractor(BaseProcessorTestCase):
 
         self.object.process(document)
 
-        # Two different timezones need to be used in the test to account for daylight savings
-        # Use current timezone here, since the processor initializes with timezone on the system
-        tz_local_name = datetime.now(tzlocal()).strftime("%z")
-        _, _, local_timezone = self._parse_local_tz(tz_local_name)
-
-        # Use timestamps timezone here, since processor uses timezones of each timestamp for deltas
-        parsed_timestamp = parse(timestamp).astimezone(tzlocal())
-        tz_local_name = parsed_timestamp.strftime("%z")
-        ts_hour_delta, ts_minute_delta, _ = self._parse_local_tz(tz_local_name)
-
         expected = {
             "@timestamp": timestamp,
             "winlog": {"event_id": 123},
             "split_@timestamp": {
                 "day": 30,
-                "hour": 13 + ts_hour_delta,  # 13 ist hour of src timestamp in UTC
+                "hour": 14,
                 "microsecond": 861000,
-                "minute": 37 + ts_minute_delta,
+                "minute": 37,
                 "month": 7,
                 "second": 42,
-                "timezone": local_timezone,
+                "timezone": "UTC+01:00",
                 "weekday": "Tuesday",
                 "year": 2019,
             },

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -669,7 +669,7 @@ class TestNormalizer(BaseProcessorTestCase):
 
     def test_normalization_from_timestamp_berlin_to_utc(self):
         expected = {
-            "@timestamp": "1999-12-12T11:12:22Z",
+            "@timestamp": "1999-12-12T12:12:22Z",
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
@@ -1000,7 +1000,7 @@ class TestNormalizer(BaseProcessorTestCase):
 
     def test_normalization_from_timestamp_with_collision(self):
         expected = {
-            "@timestamp": "1999-12-12T11:12:22Z",
+            "@timestamp": "1999-12-12T12:12:22Z",
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,


### PR DESCRIPTION
replace with python native functions wrapped in `time.py` the requirement of `python-dateutil` still remains as it is used by other dependencies.

Due to this change some test had to be adjusted as every timestamp that does not have a timezone associated with it is considered to be a `UTC` timestamp instead of the timestamp of the local system. 

Closes #378 