### PR TITLE
fix error handling of fieldmanager if no mapped source field exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 ### Bugfix
 
+* Fix error handling of FieldManager if no mapped source field exists in the event.
 
 ## v6.3.0
 ### Features

--- a/logprep/processor/field_manager/processor.py
+++ b/logprep/processor/field_manager/processor.py
@@ -75,6 +75,8 @@ class FieldManager(Processor):
         source_fields, targets = list(zip(*mapping.items()))
         source_field_values = self._get_field_values(event, mapping.keys())
         self._handle_missing_fields(event, rule, source_fields, source_field_values)
+        if not any(source_field_values):
+            return
         source_field_values, targets = self._filter_missing_fields(source_field_values, targets)
         self._write_to_multiple_targets(event, targets, source_field_values, rule, rule_args)
         if rule.delete_source_fields:

--- a/tests/unit/processor/field_manager/test_field_manager.py
+++ b/tests/unit/processor/field_manager/test_field_manager.py
@@ -471,6 +471,18 @@ failure_test_cases = [
         },
         ".*FieldExistsWarning.*",
     ),
+    (
+        "tries to move multiple fields to multiple target fields but none exists",
+        {
+            "filter": "no-mapped-field",
+            "field_manager": {
+                "mapping": {"field.one": "one", "field.two": "two", "field.three": "three"},
+            },
+        },
+        {"no-mapped-field": "exists"},
+        {"no-mapped-field": "exists", "tags": ["_field_manager_missing_field_warning"]},
+        ".*ProcessingWarning.*",
+    ),
 ]  # testcase, rule, event, expected, error
 
 


### PR DESCRIPTION
Fix error handling of FieldManager if no mapped source field exists in the event.