### PR TITLE
fix lucene filter representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 * Replace rule_filter with lucene_filter in predetector output. The old internal logprep rule 
 representation is not present anymore in the predetector output, the name `rule_filter` will stay
-in place of the `lucene_filter` name.
+in place of the `lucene_filter` name. 
 
 ### Bugfix
+
+* Fix lucene rule filter representation such that it is aligned with opensearch lucene query syntax
 
 ## v6.5.1
 ### Bugfix

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -308,7 +308,7 @@ class RegExFilterExpression(FilterExpression):
         self._matcher = re.compile(self._regex)
 
     def __repr__(self) -> str:
-        return f"{self.as_dotted_string(self.key)}:/{self._regex}/"
+        return f"{self.as_dotted_string(self.key)}:/{self._regex.strip('^$')}/"
 
     @staticmethod
     def _normalize_regex(regex: str) -> str:
@@ -338,7 +338,7 @@ class Exists(FilterExpression):
         self.split_field = value
 
     def __repr__(self) -> str:
-        return f'"{self.as_dotted_string(self.split_field)}": *'
+        return f"{self.as_dotted_string(self.split_field)}: *"
 
     def does_match(self, document: dict) -> bool:
         if not self.split_field:

--- a/logprep/framework/rule_tree/rule_parser.py
+++ b/logprep/framework/rule_tree/rule_parser.py
@@ -408,7 +408,7 @@ class RuleParser:
             try:
                 return priority_dict[expr.as_dotted_string(expr.split_field)]
             except KeyError:
-                return repr(expr)[1:-1]
+                return repr(expr)
         else:
             try:
                 return priority_dict[expr.as_dotted_string(expr.key)]

--- a/tests/unit/exceptions/processor/test_processing_warning.py
+++ b/tests/unit/exceptions/processor/test_processing_warning.py
@@ -16,7 +16,7 @@ class TestProcessingWarning:
     exception = ProcessingWarning
 
     error_message = """ProcessingWarning in Dissector (my_dissector): the error message
-Rule: filename=None, filter='"message": *', Rule.Config(description='', regex_fields=[], tests=[], tag_on_failure=['_rule_failure']),
+Rule: filename=None, filter='message: *', Rule.Config(description='', regex_fields=[], tests=[], tag_on_failure=['_rule_failure']),
 Event: {'message': 'test_event'}
 """
 
@@ -43,7 +43,7 @@ Event: {'message': 'test_event'}
 class TestFieldExsitsWarning(TestProcessingWarning):
     exception = FieldExistsWarning
     error_message = """FieldExistsWarning in Dissector (my_dissector): The following fields could not be written, because one or more subfields existed and could not be extended: my_field
-Rule: filename=None, filter='"message": *', Rule.Config(description='', regex_fields=[], tests=[], tag_on_failure=[\'_rule_failure\']),
+Rule: filename=None, filter='message: *', Rule.Config(description='', regex_fields=[], tests=[], tag_on_failure=[\'_rule_failure\']),
 Event: {'message': 'test_event'}
 """
 

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -86,8 +86,8 @@ class TestNot:
 
 class TestAnd:
     def test_string_representation(self):
-        assert str(And(Exists(["foo"]))) == '("foo": *)'
-        assert str(And(Exists(["foo"]), Exists(["bar"]))) == '("foo": * AND "bar": *)'
+        assert str(And(Exists(["foo"]))) == "(foo: *)"
+        assert str(And(Exists(["foo"]), Exists(["bar"]))) == "(foo: * AND bar: *)"
 
     def test_different_objects_with_same_payload_are_equal(self):
         and_filter1 = And(Always(False))
@@ -125,8 +125,8 @@ class TestAnd:
 
 class TestOr:
     def test_string_representation(self):
-        assert str(Or(Exists(["foo"]))) == '("foo": *)'
-        assert str(Or(Exists(["foo"]), Exists(["bar"]))) == '("foo": * OR "bar": *)'
+        assert str(Or(Exists(["foo"]))) == "(foo: *)"
+        assert str(Or(Exists(["foo"]), Exists(["bar"]))) == "(foo: * OR bar: *)"
 
     def test_different_objects_with_same_payload_are_equal(self):
         or_filter1 = Or(Always(False))
@@ -284,7 +284,7 @@ class TestRegExFilterExpression(ValueBasedFilterExpressionTest):
         self.filter_identical = RegExFilterExpression(["key1", "key2"], self.regex)
 
     def test_string_representation(self):
-        assert str(self.filter) == "key1.key2:/^start.*end$/"
+        assert str(self.filter) == "key1.key2:/start.*end/"
 
     def test_does_not_match_if_key_is_missing(self):
         assert not self.filter.matches({"not": {"the": {"key": "to match"}}})
@@ -342,7 +342,7 @@ class TestExistsFilterExpression(ValueBasedFilterExpressionTest):
         self.filter_identical = Exists(["key1", "key2"])
 
     def test_string_representation(self):
-        assert str(self.filter) == '"key1.key2": *'
+        assert str(self.filter) == "key1.key2: *"
 
     def test_matches_any_value(self):
         filter = Exists(["key1", "key2"])
@@ -530,11 +530,11 @@ class TestLuceneRepresentation:
     @pytest.mark.parametrize(
         "logprep_filter_language, special_fields, expected_lucene_filter_query",
         [
-            ("exist_field", None, '"exist_field": *'),
+            ("exist_field", None, "exist_field: *"),
             ("key: value", None, 'key:"value"'),
             ("dotted.key: value", None, 'dotted.key:"value"'),
             ("*", None, "*"),
-            ("NOT key", None, 'NOT ("key": *)'),
+            ("NOT key", None, "NOT (key: *)"),
             ("NOT key: value", None, 'NOT (key:"value")'),
             ("key: value1 AND keyy: value2", None, '(key:"value1" AND keyy:"value2")'),
             (
@@ -561,11 +561,11 @@ class TestLuceneRepresentation:
             ("key: val*", None, 'key:"val*"'),
             ("key: 1", None, 'key:"1"'),
             ("key: 1.0", None, 'key:"1.0"'),
-            (r"key: field\[\d\].*", {"regex_fields": ["key"]}, r"key:/^field\[\d\].*$/"),
+            (r"key: field\[\d\].*", {"regex_fields": ["key"]}, r"key:/field\[\d\].*/"),
             (
                 r"nonRegexKey: something AND key: field\[\d\].*",
                 {"regex_fields": ["key"]},
-                r'(nonRegexKey:"something" AND key:/^field\[\d\].*$/)',
+                r'(nonRegexKey:"something" AND key:/field\[\d\].*/)',
             ),
         ],
     )


### PR DESCRIPTION
- fields shouldn't be wrapped in quotes
- lucene regex query in opensearch doesn't return results with `^` and `$`