### PR TITLE
prevent overwriting existing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In case of positive detection results, rule attributions are now inserted in the
 ### Bugfix
 
 * Fix lucene rule filter representation such that it is aligned with opensearch lucene query syntax
+* Fix overwriting of temporary tld-list with empty content  
 
 ## v6.5.1
 ### Bugfix

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -427,9 +427,12 @@ class Pipeline:
                 self.logger.warning(str(error))
             except ProcessingCriticalError as error:
                 self.logger.error(str(error))
-                for _, output in self._output.items():
-                    if output.default:
-                        output.store_failed(str(error), self._decoder.decode(event_received), event)
+                if self._output:
+                    for _, output in self._output.items():
+                        if output.default:
+                            output.store_failed(
+                                str(error), self._decoder.decode(event_received), event
+                            )
             if not event:
                 break
         if self._processing_counter:

--- a/logprep/processor/domain_label_extractor/processor.py
+++ b/logprep/processor/domain_label_extractor/processor.py
@@ -92,9 +92,10 @@ class DomainLabelExtractor(Processor):
                 logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
                 os.makedirs(logprep_tmp_dir, exist_ok=True)
                 list_path = logprep_tmp_dir / f"{self.name}-tldlist-{index}.dat"
-                with FileLock(list_path):
-                    list_path.touch()
-                    list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
+                if not os.path.isfile(list_path):
+                    with FileLock(list_path):
+                        list_path.touch()
+                        list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
                 downloaded_tld_lists_paths.append(f"file://{str(list_path.absolute())}")
             self._config.tld_lists = downloaded_tld_lists_paths
             self._logger.debug("finished tldlists download...")

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -158,9 +158,10 @@ class DomainResolver(Processor):
                 logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
                 os.makedirs(logprep_tmp_dir, exist_ok=True)
                 list_path = logprep_tmp_dir / f"{self.name}-tldlist-{index}.dat"
-                with FileLock(list_path):
-                    list_path.touch()
-                    list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
+                if not os.path.isfile(list_path):
+                    with FileLock(list_path):
+                        list_path.touch()
+                        list_path.write_bytes(GetterFactory.from_string(tld_list).get_raw())
                 downloaded_tld_lists_paths.append(f"file://{str(list_path.absolute())}")
             self._config.tld_lists = downloaded_tld_lists_paths
             self._logger.debug("finished tldlists download...")

--- a/logprep/processor/geoip_enricher/processor.py
+++ b/logprep/processor/geoip_enricher/processor.py
@@ -74,11 +74,12 @@ class GeoipEnricher(Processor):
             logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
             os.makedirs(logprep_tmp_dir, exist_ok=True)
             db_path_file = logprep_tmp_dir / f"{self.name}.mmdb"
-            with FileLock(db_path_file):
-                db_path_file.touch()
-                db_path_file.write_bytes(
-                    GetterFactory.from_string(str(self._config.db_path)).get_raw()
-                )
+            if not os.path.isfile(db_path_file):
+                with FileLock(db_path_file):
+                    db_path_file.touch()
+                    db_path_file.write_bytes(
+                        GetterFactory.from_string(str(self._config.db_path)).get_raw()
+                    )
             self._logger.debug("finished geoip database download.")
             self._config.db_path = str(db_path_file.absolute())
 

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -365,3 +366,23 @@ class TestDomainLabelExtractor(BaseProcessorTestCase):
         assert expected_checksum == downloaded_checksum
         # delete testfile
         shutil.rmtree(logprep_tmp_dir)
+
+    @responses.activate
+    def test_setup_doesnt_overwrite_already_existing_tld_list_file(self):
+        tld_list = "http://db-path-target/list.dat"
+        tld_list_content = "some content"
+        responses.add(responses.GET, tld_list, tld_list_content.encode("utf8"))
+
+        logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
+        os.makedirs(logprep_tmp_dir, exist_ok=True)
+        tld_temp_file = logprep_tmp_dir / f"{self.object.name}-tldlist-0.dat"
+
+        pre_existing_content = "file exists already"
+        tld_temp_file.touch()
+        tld_temp_file.write_bytes(pre_existing_content.encode("utf8"))
+        self.object._config.tld_lists = [tld_list]
+        self.object.setup()
+        assert tld_temp_file.exists()
+        assert tld_temp_file.read_bytes().decode("utf8") == pre_existing_content
+        assert tld_temp_file.read_bytes().decode("utf8") != tld_list_content
+        shutil.rmtree(logprep_tmp_dir)  # delete testfile

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 import hashlib
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -289,3 +290,23 @@ sth.ac.at
         assert expected_checksum == downloaded_checksum
         # delete testfile
         shutil.rmtree(logprep_tmp_dir)
+
+    @responses.activate
+    def test_setup_doesnt_overwrite_already_existing_tld_list_file(self):
+        tld_list = "http://db-path-target/list.dat"
+        tld_list_content = "some content"
+        responses.add(responses.GET, tld_list, tld_list_content.encode("utf8"))
+
+        logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
+        os.makedirs(logprep_tmp_dir, exist_ok=True)
+        tld_temp_file = logprep_tmp_dir / f"{self.object.name}-tldlist-0.dat"
+
+        pre_existing_content = "file exists already"
+        tld_temp_file.touch()
+        tld_temp_file.write_bytes(pre_existing_content.encode("utf8"))
+        self.object._config.tld_lists = [tld_list]
+        self.object.setup()
+        assert tld_temp_file.exists()
+        assert tld_temp_file.read_bytes().decode("utf8") == pre_existing_content
+        assert tld_temp_file.read_bytes().decode("utf8") != tld_list_content
+        shutil.rmtree(logprep_tmp_dir)  # delete testfile

--- a/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
+++ b/tests/unit/processor/geoip_enricher/test_geoip_enricher.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-statements
 import hashlib
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -385,3 +386,23 @@ class TestGeoipEnricher(BaseProcessorTestCase):
         assert expected_checksum == downloaded_checksum
         # delete testfile
         shutil.rmtree(logprep_tmp_dir)
+
+    @responses.activate
+    def test_setup_doesnt_overwrite_already_existing_geomap_file(self):
+        tld_list = "http://db-path-target/db_file.mmdb"
+        tld_list_content = "some content"
+        responses.add(responses.GET, tld_list, tld_list_content.encode("utf8"))
+
+        logprep_tmp_dir = Path(tempfile.gettempdir()) / "logprep"
+        os.makedirs(logprep_tmp_dir, exist_ok=True)
+        tld_temp_file = logprep_tmp_dir / f"{self.object.name}.mmdb"
+
+        pre_existing_content = "file exists already"
+        tld_temp_file.touch()
+        tld_temp_file.write_bytes(pre_existing_content.encode("utf8"))
+        self.object._config.tld_lists = [tld_list]
+        self.object.setup()
+        assert tld_temp_file.exists()
+        assert tld_temp_file.read_bytes().decode("utf8") == pre_existing_content
+        assert tld_temp_file.read_bytes().decode("utf8") != tld_list_content
+        shutil.rmtree(logprep_tmp_dir)  # delete testfile


### PR DESCRIPTION
The call `list_path.touch()` which initially creates the temporary file could be overwritten in the next processors `setup` call with empty content. A check if the file exists already prevents this. 