### PR TITLE
fix UNIXPATH grok pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ In case of positive detection results, rule attributions are now inserted in the
 ### Bugfix
 
 * Fix lucene rule filter representation such that it is aligned with opensearch lucene query syntax
-* Fix grok pattern `UNIXPATH`
+* Fix grok pattern `UNIXPATH` by internally converting `[[:alnum:]]` to `\w"`
 
 ## v6.5.1
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In case of positive detection results, rule attributions are now inserted in the
 ### Bugfix
 
 * Fix lucene rule filter representation such that it is aligned with opensearch lucene query syntax
+* Fix grok pattern `UNIXPATH`
 
 ## v6.5.1
 ### Bugfix

--- a/logprep/util/grok/patterns/ecs-v1/grok-patterns
+++ b/logprep/util/grok/patterns/ecs-v1/grok-patterns
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths (only absolute paths are matched)
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/[\w_%!$@:.,+~-]*)+
+UNIXPATH (/[[[:alnum:]]_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+

--- a/logprep/util/grok/patterns/ecs-v1/grok-patterns
+++ b/logprep/util/grok/patterns/ecs-v1/grok-patterns
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths (only absolute paths are matched)
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/[[[:alnum:]]_%!$@:.,+~-]*)+
+UNIXPATH (/[\w_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+

--- a/tests/unit/util/test_grok_pattern.py
+++ b/tests/unit/util/test_grok_pattern.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-docstring
+import re
+
+import pytest
+
+from logprep.util.grok_pattern_loader import GrokPatternLoader
+
+
+@pytest.fixture(name="pattern")
+def grok_pattern():
+    loader = GrokPatternLoader()
+    return loader.load_from_dir("logprep/util/grok/patterns/ecs-v1")
+
+
+class TestGrokPattern:
+
+    @pytest.mark.parametrize("test_string, matches", (
+        ["/usr/http/http-client.log", True],
+        ["/usr.log", True],
+        ["/usr/./foo.log", True],
+        ["/../user.log", True],
+        ["/path with spaces/log.file", True],
+        ["//path//log.file", True],
+        ["///path///log.file", True],
+        ["/path///log.file", True],
+        ["/path/with/NUMBERS/123/lo3g.file", True],
+        ["/path/with/utf8/öüä/log.file", True],
+        ["/path///", True],
+        ["./user.log", False],
+        ["~/user.log", False],
+        [",/.", False],
+        ["+/.../", False],
+        [".", False],
+        ["..", False],
+        ["something", False],
+        ["something with spaces", False],
+        [r"\windows\path", False],
+        ["\\windows\\path", False],
+        [r"\\windows\\\path", False],
+    ))
+    def test_unixpath_pattern(self, pattern, test_string, matches):
+        grok = pattern.get("UNIXPATH")
+        if matches:
+            assert re.match(grok, test_string)
+        else:
+            assert not re.match(grok, test_string)

--- a/tests/unit/util/test_grok_pattern.py
+++ b/tests/unit/util/test_grok_pattern.py
@@ -13,31 +13,33 @@ def grok_pattern():
 
 
 class TestGrokPattern:
-
-    @pytest.mark.parametrize("test_string, matches", (
-        ["/usr/http/http-client.log", True],
-        ["/usr.log", True],
-        ["/usr/./foo.log", True],
-        ["/../user.log", True],
-        ["/path with spaces/log.file", True],
-        ["//path//log.file", True],
-        ["///path///log.file", True],
-        ["/path///log.file", True],
-        ["/path/with/NUMBERS/123/lo3g.file", True],
-        ["/path/with/utf8/öüä/log.file", True],
-        ["/path///", True],
-        ["./user.log", False],
-        ["~/user.log", False],
-        [",/.", False],
-        ["+/.../", False],
-        [".", False],
-        ["..", False],
-        ["something", False],
-        ["something with spaces", False],
-        [r"\windows\path", False],
-        ["\\windows\\path", False],
-        [r"\\windows\\\path", False],
-    ))
+    @pytest.mark.parametrize(
+        "test_string, matches",
+        (
+            ["/usr/http/http-client.log", True],
+            ["/usr.log", True],
+            ["/usr/./foo.log", True],
+            ["/../user.log", True],
+            ["/path with spaces/log.file", True],
+            ["//path//log.file", True],
+            ["///path///log.file", True],
+            ["/path///log.file", True],
+            ["/path/with/NUMBERS/123/lo3g.file", True],
+            ["/path/with/utf8/öüä/log.file", True],
+            ["/path///", True],
+            ["./user.log", False],
+            ["~/user.log", False],
+            [",/.", False],
+            ["+/.../", False],
+            [".", False],
+            ["..", False],
+            ["something", False],
+            ["something with spaces", False],
+            [r"\windows\path", False],
+            ["\\windows\\path", False],
+            [r"\\windows\\\path", False],
+        ),
+    )
     def test_unixpath_pattern(self, pattern, test_string, matches):
         grok = pattern.get("UNIXPATH")
         if matches:

--- a/tests/unit/util/test_grok_pattern_loader.py
+++ b/tests/unit/util/test_grok_pattern_loader.py
@@ -1,84 +1,104 @@
+# pylint: disable=missing-docstring
+from unittest import mock
+
 import pytest
 
 from logprep.util.grok_pattern_loader import GrokPatternLoader, GrokPatternLoaderError
 
 
-@pytest.fixture
+@pytest.fixture(name="pattern_loader")
 def grok_pattern_loader():
     return GrokPatternLoader()
 
 
 class TestGrokPatternLoader:
-    def test_load_empty_patterns_file_succeeds(self, grok_pattern_loader):
-        expected = dict()
-        patterns = grok_pattern_loader.load_from_file(
+    def test_load_empty_patterns_file_succeeds(self, pattern_loader):
+        expected = {}
+        patterns = pattern_loader.load_from_file(
             "tests/testdata/unit/grok_pattern_loader/patterns_empty.dat"
         )
-
         assert patterns == expected
 
-    def test_load_single_pattern_succeeds(self, grok_pattern_loader):
+    def test_load_single_pattern_succeeds(self, pattern_loader):
         expected = {"TEST": ".*"}
-        patterns = grok_pattern_loader.load_from_file(
+        patterns = pattern_loader.load_from_file(
             "tests/testdata/unit/grok_pattern_loader/patterns_single.dat"
         )
-
         assert patterns == expected
 
-    def test_load_single_pattern_succeeds_with_comment(self, grok_pattern_loader):
+    def test_load_single_pattern_succeeds_with_comment(self, pattern_loader):
         expected = {"TEST": ".*"}
-        patterns = grok_pattern_loader.load_from_file(
+        patterns = pattern_loader.load_from_file(
             "tests/testdata/unit/grok_pattern_loader/patterns_single_with_comment.dat"
         )
-
         assert patterns == expected
 
-    def test_load_multiple_patterns_succeeds(self, grok_pattern_loader):
+    def test_load_multiple_patterns_succeeds(self, pattern_loader):
         expected = {"TEST1": ".*", "TEST2": ".*", "TEST3": ".*"}
-        patterns = grok_pattern_loader.load_from_file(
+        patterns = pattern_loader.load_from_file(
             "tests/testdata/unit/grok_pattern_loader/patterns_multiple.dat"
         )
-
         assert patterns == expected
 
-    def test_load_multiple_patterns_with_blank_lines_succeeds(self, grok_pattern_loader):
+    def test_load_multiple_patterns_with_blank_lines_succeeds(self, pattern_loader):
         expected = {"TEST1": ".*", "TEST2": ".*", "TEST3": ".*"}
-        patterns = grok_pattern_loader.load_from_file(
+        patterns = pattern_loader.load_from_file(
             "tests/testdata/unit/grok_pattern_loader/patterns_multiple_with_gap.dat"
         )
-
         assert patterns == expected
 
-    def test_load_patterns_with_duplicate_fails(self, grok_pattern_loader):
+    def test_load_patterns_with_duplicate_fails(self, pattern_loader):
         with pytest.raises(GrokPatternLoaderError):
-            grok_pattern_loader.load_from_file(
+            pattern_loader.load_from_file(
                 "tests/testdata/unit/grok_pattern_loader/patterns_duplicate.dat"
             )
 
-    def test_load_multiple_patterns_from_dir_succeeds(self, grok_pattern_loader):
+    def test_load_multiple_patterns_from_dir_succeeds(self, pattern_loader):
         expected = {"HOLLA": ".*", "Hi": ".*", "SALUT": ".*"}
-        patterns = grok_pattern_loader.load_from_dir(
+        patterns = pattern_loader.load_from_dir(
             "tests/testdata/unit/grok_pattern_loader/multiple_patterns/without_duplicates"
         )
-
         assert patterns == expected
 
     def test_load_multiple_patterns_from_dir_with_duplicates_across_files_fails(
-        self, grok_pattern_loader
+        self, pattern_loader
     ):
         with pytest.raises(GrokPatternLoaderError):
-            grok_pattern_loader.load_from_dir(
+            pattern_loader.load_from_dir(
                 "tests/testdata/unit/grok_pattern_loader/multiple_patterns/with_duplicates"
             )
 
-    def test_load_patterns_from_dir_detects_type(self, grok_pattern_loader):
+    def test_load_patterns_from_dir_detects_type(self, pattern_loader):
         assert (
-            grok_pattern_loader.load("tests/testdata/unit/grok_pattern_loader/patterns_single.dat")
+            pattern_loader.load("tests/testdata/unit/grok_pattern_loader/patterns_single.dat")
             is not None
         )
         assert (
-            grok_pattern_loader.load(
+            pattern_loader.load(
                 "tests/testdata/unit/grok_pattern_loader/multiple_patterns/without_duplicates"
             )
             is not None
         )
+
+    @mock.patch(
+        "logprep.util.grok_pattern_loader.PATTERN_CONVERSION",
+        [
+            ("[[:alnum:]]", r"\w"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ["given_pattern", "expected_pattern"],
+        [
+            (".*", ".*"),
+            ("[a-zA-Z]", "[a-zA-Z]"),
+            ("(/[[[:alnum:]]_%!$@:.,+~-]*)+", r"(/[\w_%!$@:.,+~-]*)+"),
+            ("(/[[[:anum:]]_%!$@:.,+~-]*)+", "(/[[[:anum:]]_%!$@:.,+~-]*)+"),
+            ("(/[_%!$@:.,+~-]*)+", r"(/[_%!$@:.,+~-]*)+"),
+            (r"(/[[[:alnum:]]\w_%!$@:.,+~-]*)+", r"(/[\w\w_%!$@:.,+~-]*)+"),
+        ],
+    )
+    def test_update_pattern(self, pattern_loader, given_pattern, expected_pattern):
+        given = {"pattern": given_pattern}
+        expected = {"pattern": expected_pattern}
+        updated_pattern = pattern_loader._update_pattern(given)  # pylint: disable=protected-access
+        assert updated_pattern == expected


### PR DESCRIPTION
The previous regex pattern wasn't supported in python.

closes #413 