### PR TITLE
Change timestamp conversion

### DIFF
--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -133,4 +133,6 @@ class TimeParser:
             parsed_datetime = cls.from_format(timestamp, source_format).replace(
                 tzinfo=source_timezone
             )
+            if parsed_datetime.year == 1900:
+                parsed_datetime = parsed_datetime.replace(year=datetime.now().year)
         return parsed_datetime

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -103,7 +103,7 @@ class TimeParser:
 
     @classmethod
     def parse_datetime(
-        cls, timestamp: str, source_format: str, source_timezone: [str, tzinfo]
+        cls, timestamp: str, source_format: str, source_timezone: Union[str, tzinfo]
     ) -> datetime:
         """
         Parses a timestamp based on different formats, besides a format string 'ISO8601' and
@@ -125,10 +125,12 @@ class TimeParser:
             The parsed timestamp as datetime object.
         """
         if source_format == "ISO8601":
-            parsed_datetime = cls.from_string(timestamp).astimezone(source_timezone)
+            parsed_datetime = cls.from_string(timestamp).replace(tzinfo=source_timezone)
         elif source_format == "UNIX":
             parsed_datetime = int(timestamp) if len(timestamp) <= 10 else int(timestamp) / 1000
-            parsed_datetime = cls.from_timestamp(parsed_datetime).astimezone(source_timezone)
+            parsed_datetime = cls.from_timestamp(parsed_datetime).replace(tzinfo=source_timezone)
         else:
-            parsed_datetime = cls.from_format(timestamp, source_format).astimezone(source_timezone)
+            parsed_datetime = cls.from_format(timestamp, source_format).replace(
+                tzinfo=source_timezone
+            )
         return parsed_datetime

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -669,7 +669,7 @@ class TestNormalizer(BaseProcessorTestCase):
 
     def test_normalization_from_timestamp_berlin_to_utc(self):
         expected = {
-            "@timestamp": "1999-12-12T12:12:22Z",
+            "@timestamp": "1999-12-12T11:12:22Z",
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
@@ -1000,11 +1000,11 @@ class TestNormalizer(BaseProcessorTestCase):
 
     def test_normalization_from_timestamp_with_collision(self):
         expected = {
-            "@timestamp": "1999-12-12T12:12:22Z",
+            "@timestamp": "1999-12-12T11:12:22Z",
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"some_timestamp_utc": "1999 12 12 - 12:12:22"},
+                "event_data": {"some_timestamp_berlin": "1999 12 12 - 12:12:22"},
             },
         }
 
@@ -1013,14 +1013,14 @@ class TestNormalizer(BaseProcessorTestCase):
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"some_timestamp_utc": "1999 12 12 - 12:12:22"},
+                "event_data": {"some_timestamp_berlin": "1999 12 12 - 12:12:22"},
             },
         }
 
         rule = {
             "filter": "winlog.event_id: 123456789",
             "normalize": {
-                "winlog.event_data.some_timestamp_utc": {
+                "winlog.event_data.some_timestamp_berlin": {
                     "timestamp": {
                         "destination": "@timestamp",
                         "source_formats": ["%Y", "%Y %m %d - %H:%M:%S"],

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -87,7 +87,7 @@ test_cases = [  # testcase, rule, event, expected
         {
             "filter": "winlog.event_id: 123456789",
             "timestamper": {
-                "source_fields": ["winlog.event_data.some_timestamp_utc"],
+                "source_fields": ["winlog.event_data.some_timestamp_berlin"],
                 "target_field": "@timestamp",
                 "source_format": "%Y %m %d - %H:%M:%S",
                 "source_timezone": "Europe/Berlin",
@@ -98,15 +98,15 @@ test_cases = [  # testcase, rule, event, expected
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"some_timestamp_utc": "1999 12 12 - 12:12:22"},
+                "event_data": {"some_timestamp_berlin": "1999 12 12 - 12:12:22"},
             }
         },
         {
-            "@timestamp": "1999-12-12T12:12:22Z",
+            "@timestamp": "1999-12-12T11:12:22Z",
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"some_timestamp_utc": "1999 12 12 - 12:12:22"},
+                "event_data": {"some_timestamp_berlin": "1999 12 12 - 12:12:22"},
             },
         },
     ),

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -104,6 +104,19 @@ class TestTimeParser:
                 ZoneInfo("Europe/Berlin"),
                 {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),
+            (
+                "03 13 - 11:23:13",
+                "%m %d - %H:%M:%S",
+                ZoneInfo("UTC"),
+                {
+                    "year": datetime.now().year,
+                    "month": 3,
+                    "day": 13,
+                    "hour": 11,
+                    "minute": 23,
+                    "second": 13,
+                },
+            ),
         ],
     )
     def test_parse_datetime(self, timestamp, source_format, source_timezone, expected):

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -112,11 +112,11 @@ class TestTimeParser:
                 {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),
             (
-                    "2021 03 13 - 11:23:13 -03:00",
-                    "%Y %m %d - %H:%M:%S %z",
-                    ZoneInfo("Europe/Berlin"),
-                    "UTC-03:00",
-                    {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+                "2021 03 13 - 11:23:13 -03:00",
+                "%Y %m %d - %H:%M:%S %z",
+                ZoneInfo("Europe/Berlin"),
+                "UTC-03:00",
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),
             (
                 "03 13 - 11:23:13",

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -64,3 +64,50 @@ class TestTimeParser:
         assert time_object.tzinfo is None
         time_object = TimeParser._set_utc_if_timezone_is_missing(time_object)
         assert time_object.tzinfo is ZoneInfo("UTC")
+
+    @pytest.mark.parametrize(
+        "timestamp, source_format, source_timezone, expected",
+        [
+            (
+                "1615634593",
+                "UNIX",
+                ZoneInfo("UTC"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "1615634593",
+                "UNIX",
+                ZoneInfo("Europe/Berlin"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "2021-03-13T11:23:13Z",
+                "ISO8601",
+                ZoneInfo("Europe/Berlin"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "2021-03-13T11:23:13Z",
+                "ISO8601",
+                ZoneInfo("UTC"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "2021 03 13 - 11:23:13",
+                "%Y %m %d - %H:%M:%S",
+                ZoneInfo("UTC"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "2021 03 13 - 11:23:13",
+                "%Y %m %d - %H:%M:%S",
+                ZoneInfo("Europe/Berlin"),
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+        ],
+    )
+    def test_parse_datetime(self, timestamp, source_format, source_timezone, expected):
+        timestamp = TimeParser.parse_datetime(timestamp, source_format, source_timezone)
+        assert timestamp.tzinfo == source_timezone
+        for attribute, value in expected.items():
+            assert getattr(timestamp, attribute) == value


### PR DESCRIPTION
Make the timestamper and normalizer timestamp normalization yield results like before the TimeParser was added.

- The source timezone will be replaced and not converted in the TimeParser. Conversion happens in the normalizer/timestamper. Before this change, the absence of a timezone implied UTC, which does not have to be the case (except for UNIX timestamp). Instead the source_timezone is assumed.
- The TimeParser sets the current year instead of 1900 if no year was present in the timestamp, since it is far more likely that a missing year should be the current year instead of 1900.