### PR TITLE
Handle long-running grok pattern by introducing a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfix
 
 * Fix error when writing too large documents into Opensearch/Elasticsearch
+* Handle long-running grok pattern in the `Grokker` by introducing a timeout limit of one second  
 
 ## v6.6.0
 

--- a/logprep/processor/grokker/rule.py
+++ b/logprep/processor/grokker/rule.py
@@ -118,6 +118,9 @@ class GrokkerRule(DissectorRule):
         patterns part. When defining an `oniguruma` there is a limitation of three nested
         parentheses inside the pattern. Applying more nested parentheses is not possible.  
         Logstashs ecs conform grok patterns are used to resolve the here used grok patterns.
+        When writing patterns it is advised to be careful as the underlying regex can become complex
+        fast. If the execution and the resolving of the pattern takes more than one second a
+        matching timeout will be raised.
         """
         patterns: dict = field(
             validator=[

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -34,6 +34,8 @@ import numpy as np
 import pkg_resources
 from attrs import define, field, validators
 
+from logprep.util.decorators import timeout
+
 if sys.version_info.minor < 11:
     # because needed possessive quantifiers and atomic grouping
     # added to re module in python 3.11
@@ -80,6 +82,7 @@ class Grok:
 
         self._load_search_pattern()
 
+    @timeout(seconds=1)
     def match(self, text):
         """If text is matched with pattern, return variable names
         specified(%{pattern:variable name}) in pattern and their

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 
 from logprep.factory import Factory
+from logprep.processor.base.exceptions import ProcessingCriticalError
 from logprep.util.getter import GetterFactory
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -351,6 +352,20 @@ failure_test_cases = [
         },
         "no grok pattern matched",
     ),
+    (
+        "grok pattern timeout",
+        {
+            "filter": "url",
+            "grokker": {
+                "mapping": {
+                    "url": "^(%{URIPROTO:[network][protocol]}://)?%{IPORHOST:[url][domain]}(?::%{POSINT:[url][port]})?(?:%{URIPATHPARAM:[url][path]})?$"
+                }
+            }
+        },
+        {"url": "is-ascdwa-fv458.sdcfvfdaq.ascg:316"},
+        {"url": "is-ascdwa-fv458.sdcfvfdaq.ascg:316"},
+        ProcessingCriticalError
+    ),
 ]  # testcase, rule, event, expected
 
 
@@ -368,16 +383,20 @@ class TestGrokker(BaseProcessorTestCase):
         self.object.process(event)
         assert event == expected, testcase
 
-    @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
+    @pytest.mark.parametrize("testcase, rule, event, expected, error", failure_test_cases)
     def test_testcases_failure_handling(
-        self, caplog, testcase, rule, event, expected, error_message
+        self, caplog, testcase, rule, event, expected, error
     ):
         self._load_specific_rule(rule)
         self.object.setup()
-        with caplog.at_level(logging.WARNING):
-            self.object.process(event)
-            assert re.match(rf".*{error_message}", caplog.text)
-        assert event == expected, testcase
+        if isinstance(error, str):
+            with caplog.at_level(logging.WARNING):
+                self.object.process(event)
+                assert re.match(rf".*{error}", caplog.text)
+                assert event == expected, testcase
+        else:
+            with pytest.raises(error):
+                self.object.process(event)
 
     def test_load_custom_patterns_from_http_as_zip_file(self):
         rule = {

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -360,11 +360,11 @@ failure_test_cases = [
                 "mapping": {
                     "url": "^(%{URIPROTO:[network][protocol]}://)?%{IPORHOST:[url][domain]}(?::%{POSINT:[url][port]})?(?:%{URIPATHPARAM:[url][path]})?$"
                 }
-            }
+            },
         },
         {"url": "is-ascdwa-fv458.sdcfvfdaq.ascg:316"},
         {"url": "is-ascdwa-fv458.sdcfvfdaq.ascg:316"},
-        ProcessingCriticalError
+        ProcessingCriticalError,
     ),
 ]  # testcase, rule, event, expected
 
@@ -384,9 +384,7 @@ class TestGrokker(BaseProcessorTestCase):
         assert event == expected, testcase
 
     @pytest.mark.parametrize("testcase, rule, event, expected, error", failure_test_cases)
-    def test_testcases_failure_handling(
-        self, caplog, testcase, rule, event, expected, error
-    ):
+    def test_testcases_failure_handling(self, caplog, testcase, rule, event, expected, error):
         self._load_specific_rule(rule)
         self.object.setup()
         if isinstance(error, str):


### PR DESCRIPTION
The `Grokker` implementation uses an updated set of Grok-Pattern compared the `Normalizer`. Some of these pattern are more complex which can lead to some edge cases where the underlying regex becomes quite complex as well, leading to a long run-time for matching strings. To handle these cases a timeout of one second will be added here. If the timeout is reached a `ProcessingError` is raised, as the normalization is not possible anymore.

To test the effect of the different pattern following code can be used. Switch the `new_pattern` and `old_pattern` in the `mock.patch` statements at the end to see different results. Furthermore, the `DOCUMENT` itself has an effect on the performance as well. The given example can lead to a processing time of 20 to 60 seconds, for the grokker and the normalizer, when using the `new_pattern`.
Consider when running this example that you might have to change the path to the venv. Also it is advised to try this with the `main` branch, as this merge-requests branch already includes the timeout of one second.

```python
import os
import tempfile
import time
from copy import deepcopy
from pathlib import Path
from unittest import mock

from logprep.factory import Factory

DOCUMENT = {"message": "is-ascdwa-fv458.sdcfvfdaq.ascg:316"}

NORMALIZER_RULE = """---
filter: "message"
normalize:
  message:
    grok: ["^(%{URIPROTO:[network][protocol]}://)?%{IPORHOST:[url][domain]}(?::%{POSINT:[url][port]})?(?:%{URIPATHPARAM:[url][path]})?$"]
"""

GROKKER_RULE = """---
filter: "message"
grokker:
  mapping:
    message: "^(%{URIPROTO:[network][protocol]}://)?%{IPORHOST:[url][domain]}(?::%{POSINT:[url][port]})?(?:%{URIPATHPARAM:[url][path]})?$"
"""

rule_path = Path(tempfile.gettempdir()) / "grokker"
rule_path.mkdir(exist_ok=True)
rule_file = (rule_path / "grokker.yml").write_text(GROKKER_RULE)
grokker_config = {
    "mygrokker": {
        "type": "grokker",
        "specific_rules": [str(rule_path)],
        "generic_rules": ["/dev"],
    }
}

rule_path = Path(tempfile.gettempdir()) / "normalizer"
rule_path.mkdir(exist_ok=True)
rule_file = (rule_path / "normalizer.yml").write_text(NORMALIZER_RULE)
normalizer_config = {
    "mynormalizer": {
        "type": "normalizer",
        "specific_rules": [str(rule_path)],
        "generic_rules": ["/dev"],
        "regex_mapping": "quickstart/exampledata/rules/normalizer/normalizer_regex_mapping.yml",
    }
}

old_pattern = [os.path.abspath("venv/lib/python3.11/site-packages/pygrok/patterns/")]
new_pattern = [os.path.abspath("logprep/util/grok/patterns/ecs-v1")]

# Change the pattern via the mock for the pygrok library or the logprep implementation
with mock.patch("pygrok.pygrok.DEFAULT_PATTERNS_DIRS", old_pattern):
    with mock.patch("logprep.util.grok.grok.DEFAULT_PATTERNS_DIRS", old_pattern):
        grokker = Factory.create(grokker_config, mock.MagicMock())
        grokker.setup()
        normalizer = Factory.create(normalizer_config, mock.MagicMock())
        normalizer.setup()

        doc = deepcopy(DOCUMENT)
        start = time.time()
        grokker.process(doc)
        print(f"grokker: {time.time() - start:.5f}s")

        doc = deepcopy(DOCUMENT)
        start = time.time()
        normalizer.process(doc)
        print(f"normalizer: {time.time() - start:.5f}s")

```