### PR TITLE
Dev allow repeating events for dummy inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next release
 ### Features
+
+* Add option to repeat input documents for the following connectors: `DummyInput`, `JsonInput`,
+`JsonlInput`. This enables easier debugging by introducing a continues input stream of documents.
+
 ### Improvements
 ### Bugfix
 

--- a/logprep/connector/json/input.py
+++ b/logprep/connector/json/input.py
@@ -17,10 +17,13 @@ Example
       myjsoninput:
         type: json_input
         documents_path: path/to/a/document.json
+        repeat_documents: true
 """
-
+import copy
 from functools import cached_property
+from typing import Optional
 
+from attr import field, validators
 from attrs import define
 
 from logprep.abc.input import Input
@@ -38,7 +41,12 @@ class JsonInput(DummyInput):
         documents_path: str
         """A path to a file in json format, with can also include multiple jsons
         dicts wrapped in a list."""
+        repeat_documents: Optional[bool] = field(
+            validator=validators.instance_of(bool), default=False
+        )
+        """If set to :code:`true`, then the given input documents will be repeated after the last
+        one is reached. Default: :code:`False`"""
 
     @cached_property
     def _documents(self):
-        return parse_json(self._config.documents_path)
+        return copy.copy(parse_json(self._config.documents_path))

--- a/logprep/connector/jsonl/input.py
+++ b/logprep/connector/jsonl/input.py
@@ -17,8 +17,9 @@ Example
       myjsonlinput:
         type: jsonl_input
         documents_path: path/to/a/document.jsonl
-
+        repeat_documents: true
 """
+import copy
 from functools import cached_property
 
 from logprep.connector.json.input import JsonInput
@@ -30,4 +31,4 @@ class JsonlInput(JsonInput):
 
     @cached_property
     def _documents(self):
-        return parse_jsonl(self._config.documents_path)
+        return copy.copy(parse_jsonl(self._config.documents_path))

--- a/logprep/connector/jsonl/output.py
+++ b/logprep/connector/jsonl/output.py
@@ -13,9 +13,9 @@ Example
     output:
       my_jsonl_output:
         type: jsonl_output
-        output_file = path/to/output.file
-        output_file_custom = ""
-        output_file_error = ""
+        output_file: path/to/output.file
+        output_file_custom: ""
+        output_file_error: ""
 """
 
 import json

--- a/tests/unit/connector/test_dummy_input.py
+++ b/tests/unit/connector/test_dummy_input.py
@@ -1,9 +1,12 @@
 # pylint: disable=missing-docstring
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=protected-access
+import copy
+
 from pytest import raises
 
 from logprep.abc.input import SourceDisconnectedError
+from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
 
 
@@ -39,3 +42,13 @@ class TestDummyInput(BaseInputTestCase):
         self.object._config.documents = [BaseException]
         with raises(BaseException):
             self.object.get_next(self.timeout)
+
+    def test_repeat_documents_repeats_documents(self):
+        config = copy.deepcopy(self.CONFIG)
+        config["repeat_documents"] = True
+        object = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+        object._config.documents = [{"order": 0}, {"order": 1}, {"order": 2}]
+
+        for order in range(0, 9):
+            event, _ = object.get_next(self.timeout)
+            assert event.get("order") == order % 3

--- a/tests/unit/connector/test_json_input.py
+++ b/tests/unit/connector/test_json_input.py
@@ -1,10 +1,13 @@
 # pylint: disable=missing-docstring
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=protected-access
+import copy
 from unittest import mock
 
 import pytest
+
 from logprep.abc.input import CriticalInputError
+from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
 
 
@@ -53,3 +56,14 @@ class TestJsonInput(BaseInputTestCase):
             _, _ = self.object.get_next(self.timeout)
             _, _ = self.object.get_next(self.timeout)
             _, _ = self.object.get_next(self.timeout)
+
+    @mock.patch(parse_function)
+    def test_repeat_documents_repeats_documents(self, mock_parse):
+        config = copy.deepcopy(self.CONFIG)
+        config["repeat_documents"] = True
+        mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
+        object = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+
+        for order in range(0, 9):
+            event, _ = object.get_next(self.timeout)
+            assert event.get("order") == order % 3

--- a/tests/unit/connector/test_jsonl_input.py
+++ b/tests/unit/connector/test_jsonl_input.py
@@ -1,10 +1,13 @@
 # pylint: disable=missing-docstring
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=protected-access
+import copy
 from unittest import mock
 
 import pytest
+
 from logprep.abc.input import CriticalInputError
+from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
 
 
@@ -47,3 +50,14 @@ class TestJsonlInput(BaseInputTestCase):
             _ = self.object.get_next(self.timeout)
             _ = self.object.get_next(self.timeout)
             _ = self.object.get_next(self.timeout)
+
+    @mock.patch(parse_function)
+    def test_repeat_documents_repeats_documents(self, mock_parse):
+        config = copy.deepcopy(self.CONFIG)
+        config["repeat_documents"] = True
+        mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
+        object = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+
+        for order in range(0, 9):
+            event, _ = object.get_next(self.timeout)
+            assert event.get("order") == order % 3


### PR DESCRIPTION
Add option to repeat input documents for the following connectors: `DummyInput`, `JsonInput`,
`JsonlInput`. This enables easier debugging by introducing a continues input stream of documents.