### PR TITLE
fix and revise logprep quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ allowing further applications besides log handling.
 This readme provides basic information about the following topics:
 - [About Logprep](#about-logprep)    
 - [Getting Started](#getting-started)
-- [Docker Quickstart](#docker-quickstart-environment)
+- [Docker Quickstart](#logprep-quickstart-environment)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
@@ -395,55 +395,58 @@ If the configuration does not pass a consistency check, then an error message is
 Logprep keeps running with the previous configuration.
 The configuration should be then checked and corrected on the basis of the error message.
 
-## Docker Quickstart Environment
+## Logprep Quickstart Environment
 
-Logprep was designed to work with the Elastic Stack or Opensearch and Kafka.
-This repository comes with a docker-compose file that builds a pre-configured Elastic Stack with 
-Kafka and Logprep.
-To get it running docker and docker-compose (version >= 1.28) must be first installed.
-The docker-compose file is located in the directory quickstart.
+To demonstrate the functionality of logprep this repo comes with a complete `kafka`, `lokgprep` and
+`opensearch` stack. 
+To get it running `docker` and `docker-compose` (version >= 1.28) must be first installed.
+The docker-compose file is located in the directory `quickstart`.
+A prerequisite is to run `sysctl -w vm.max_map_count=262144`, otherwise Opensearch might not
+properly start.
 
-### Running the Test Environment
+The environment can either be started with a Logprep container or without one:
 
-Before running, docker-compose `sysctl -w vm.max_map_count=262144` must be executed.
-Otherwise, Opensearch is not properly started.
-The environment can either be started with a Logprep container or without one.
+### Run without Logprep Container (default)
 
-#### Running Test Environment without Logprep Container (default way)
+  1. Run from within the `quickstart` directory: 
+     ```bash
+     docker-compose up -d
+     ```
+     It starts and connects `Kafka`, `logprep`, `Opensearch` and `Opensearch Dashboards`.
+  2. Run Logprep against loaded environment from main `Logprep` directory:
+     ```bash
+     logprep quickstart/exampledata/config/pipeline.yml
+     ```
 
-  * Run from within the `quickstart` directory: `docker-compose up -d` 
-    * It starts and connects Kafka, Logstash, Opensearch and Opensearch Dashboards.
-  * Run Logprep against loaded environment from main `Logprep` directory: `logprep quickstart/exampledata/config/pipeline.yml`
+### Run with Logprep Container
 
-#### Running Test Environment with Logprep Container
-
-  * Run from within the `quickstart` directory: `docker-compose --profile logprep up -d`
-    * (maybe needs change of config path in container)
+  * Run from within the `quickstart` directory: 
+    ```bash
+    docker-compose --profile logprep up -d
+    ```
 
 ### Interacting with the Quickstart Environment
 
-It is now possible to write JSON events into Kafka and read the processed events in Opensearch Dashboards.
+The start up takes a few seconds to complete, but once everything is up
+and running it is possible to write JSON events into Kafka and read the processed events in
+Opensearch Dashboards. Following services are available after start up:
 
-Once everything has started, Opensearch Dashboards can be accessed by a web-browser with the 
-address `127.0.0.1:5601`.
-Kafka can be accessed with the console producer and consumer from Kafka with the 
-address `127.0.0.1:9092` or from within the docker container `Kafka`.
-The table below shows which ports have been exposed on localhost for the services.
-
-#### Table of Ports for Services
-
-|          | Kafka | Opensearch    | Dashboards |
-| ---      | ---   | ---           | ---        |
-| **Port** | 9092  | 9200          | 5601       |
+| Service | Location |
+|:----------|:----|
+| Kafka: | `localhost:9092` |
+| Logprep metrics: | `localhost:8000` |
+| Opensearch: | `localhost:9200` |
+| Opensearch Dashboards: | `localhost:5601` |
 
 The example rules that are used in the docker instance of Logprep can be found 
 in `quickstart/exampledata/rules`.
 Example events that trigger for the example rules can be found in 
 `quickstart/exampledata/input_logdata/test_input.jsonl`.
-These events can be added to Kafka with the Kafka console producer within the Kafka container by 
-executing the following command:
+These events can be added to Kafka with the following command:
 
-`(docker exec -i kafka /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server 127.0.0.1:9092 --topic consumer) < exampledata/input_logdata/test_input.jsonl`
+```bash
+(docker exec -i kafka kafka-console-producer.sh --bootstrap-server 127.0.0.1:9092 --topic consumer) < exampledata/input_logdata/test_input.jsonl
+```
 
 Once the events have been processed for the first time, the new indices *processed*, *sre* 
 and *pseudonyms* should be available in Opensearch Dashboards.

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -5,14 +5,14 @@ version: "3.9"
 
 services:
   opensearch:
-    image: public.ecr.aws/opensearchproject/opensearch:2.6.0
+    image: public.ecr.aws/opensearchproject/opensearch:2.8.0
     hostname: opensearch
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster # Name the cluster
       - node.name=opensearch # Name the node that will run in this container
       - discovery.seed_hosts=opensearch # Nodes to look for when discovering the cluster
-      - cluster.initial_cluster_manager_nodes=opensearch # Nodes eligibile to serve as cluster manager
+      - discovery.type=single-node
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
       - "DISABLE_INSTALL_DEMO_CONFIG=true" # Prevents execution of bundled demo script which installs demo certificates and security configurations to OpenSearch
@@ -26,32 +26,23 @@ services:
         hard: 65536
     volumes:
       - data:/usr/share/opensearch/data
-    ports:
-      - 9200:9200
-    networks:
-      - opensearch-net
+    network_mode: host
 
   dashboards:
-    image: public.ecr.aws/opensearchproject/opensearch-dashboards:2.6.0
+    image: public.ecr.aws/opensearchproject/opensearch-dashboards:2.8.0
     container_name: dashboards
-    ports:
-      - 5601:5601
     environment:
-      - 'OPENSEARCH_HOSTS=["http://opensearch:9200"]'
+      - 'OPENSEARCH_HOSTS=["http://localhost:9200"]'
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security dashboards plugin in OpenSearch Dashboards
-    networks:
-      - opensearch-net
+    network_mode: host
     depends_on:
       - opensearch
 
   kafka:
     image: bitnami/kafka:3.4.0
     container_name: kafka
-    ports:
-      - 9092:9092
     hostname: kafka
-    networks:
-      - opensearch-net
+    network_mode: host
     environment:
       - KAFKA_ENABLE_KRAFT=yes
       - KAFKA_CFG_NODE_ID=1
@@ -64,27 +55,24 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    command: sh -c "((sleep 15 && echo 'kafka up' && kafka-topics.sh --create --if-not-exists --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 --topic consumer)&) && /opt/bitnami/scripts/kafka/run.sh"
 
   logprep:
     build:
       context: ..
     image: logprep
     container_name: logprep
-    networks:
-      - opensearch-net
+    network_mode: host
     profiles:
       - logprep
     depends_on:
       - kafka
+      - opensearch
     volumes:
-      - ./exampledata/:/home/logprep/
+      - ../quickstart/:/home/logprep/quickstart/
     entrypoint:
       - logprep
-      - /home/logprep/config/pipeline.yml
+      - /home/logprep/quickstart/exampledata/config/pipeline.yml
 
 volumes:
   data:
-
-
-networks:
-  opensearch-net:

--- a/quickstart/exampledata/config/pipeline.yml
+++ b/quickstart/exampledata/config/pipeline.yml
@@ -4,6 +4,18 @@ timeout: 0.1
 logger:
   level: DEBUG
 
+metrics:
+  enabled: true
+  period: 10
+  cumulative: false
+  aggregate_processes: false
+  measure_time:
+    enabled: true
+    append_to_event: false
+  targets:
+    - prometheus:
+        port: 8000
+
 pipeline:
   - labelername:
       type: labeler


### PR DESCRIPTION
- upgrade opensearch version
- remove ports exposing and networks
- use network_mode host (otherwise logprep couldn't connect to opensearch)
- add kafka topic consumer on kafka start
- fix logprep volume and entrypoint, otherwise the rules weren't loaded properly
- add prometheus metrics to config
- revise readme documentation