### PR TITLE
fix crash on invalid json input in kafka input connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Improvements
 ### Bugfix
 
+* Fix restarting of logprep every time the kafka input connector receives events that aren't valid
+json documents. Now the documents will be written to the error output.
+
 ## v6.7.0
 ### Improvements
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -35,6 +35,13 @@ class CriticalInputError(InputError):
         super().__init__(input_connector, f"{message} -> {raw_input}")
 
 
+class CriticalInputParsingError(CriticalInputError):
+    """The input couldn't be parsed correctly."""
+
+    def __init__(self, input_connector: "Input", message, raw_input):
+        super().__init__(input_connector, message, raw_input)
+
+
 class FatalInputError(InputError):
     """Must not be catched."""
 

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -205,6 +205,8 @@ class Processor(Component):
             self._apply_rules(event, rule)
         except ProcessingWarning as error:
             self._handle_warning_error(event, rule, error)
+        except ProcessingCriticalError as error:
+            raise error
         except BaseException as error:
             raise ProcessingCriticalError(self, str(error), event) from error
         if not hasattr(rule, "delete_source_fields"):

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -35,7 +35,7 @@ import msgspec
 from attrs import define, field, validators
 from confluent_kafka import Consumer, KafkaException, TopicPartition
 
-from logprep.abc.input import CriticalInputError, Input
+from logprep.abc.input import CriticalInputError, Input, CriticalInputParsingError
 from logprep.abc.output import FatalOutputError
 from logprep.util.validators import dict_with_keys_validator
 
@@ -230,11 +230,11 @@ class ConfluentKafkaInput(Input):
         try:
             event_dict = self._decoder.decode(raw_event)
         except msgspec.DecodeError as error:
-            raise CriticalInputError(
+            raise CriticalInputParsingError(
                 self, "Input record value is not a valid json string", raw_event
             ) from error
         if not isinstance(event_dict, dict):
-            raise CriticalInputError(
+            raise CriticalInputParsingError(
                 self, "Input record value could not be parsed as dict", event_dict
             )
         return event_dict, raw_event

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -4,6 +4,8 @@ Pipelines contain a list of processors that can be executed in order to process 
 They can be multi-processed.
 
 """
+import copy
+
 # pylint: disable=logging-fstring-interpolation
 import queue
 import warnings
@@ -27,6 +29,7 @@ from logprep.abc.input import (
     Input,
     SourceDisconnectedError,
     WarningInputError,
+    CriticalInputParsingError,
 )
 from logprep.abc.output import (
     CriticalOutputError,
@@ -388,7 +391,17 @@ class Pipeline:
         self._metrics_exposer.expose(self.metrics)
         Component.run_pending_tasks()
         extra_outputs = []
-        if event := self._get_event():
+        event = None
+        try:
+            event = self._get_event()
+        except CriticalInputParsingError as error:
+            input_data = error.raw_input
+            if isinstance(input_data, bytes):
+                input_data = input_data.decode("utf8")
+            error_event = self._encoder.encode({"invalid_json": input_data})
+            self._store_failed_event(error, "", error_event)
+            self.logger.error(f"{error}, event was written to error output")
+        if event:
             extra_outputs = self.process_event(event)
         if event and self._output:
             self._store_event(event)
@@ -399,6 +412,11 @@ class Pipeline:
             if output.default:
                 output.store(event)
                 self.logger.debug(f"Stored output in {output_name}")
+
+    def _store_failed_event(self, error, event, event_received):
+        for _, output in self._output.items():
+            if output.default:
+                output.store_failed(str(error), self._decoder.decode(event_received), event)
 
     def _get_event(self) -> dict:
         event, non_critical_error_msg = self._input.get_next(self._timeout)
@@ -428,11 +446,7 @@ class Pipeline:
             except ProcessingCriticalError as error:
                 self.logger.error(str(error))
                 if self._output:
-                    for _, output in self._output.items():
-                        if output.default:
-                            output.store_failed(
-                                str(error), self._decoder.decode(event_received), event
-                            )
+                    self._store_failed_event(error, copy.deepcopy(event), event_received)
             if not event:
                 break
         if self._processing_counter:

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -5,7 +5,6 @@ They can be multi-processed.
 
 """
 import copy
-
 # pylint: disable=logging-fstring-interpolation
 import queue
 import warnings
@@ -447,6 +446,7 @@ class Pipeline:
                 self.logger.error(str(error))
                 if self._output:
                     self._store_failed_event(error, copy.deepcopy(event), event_received)
+                    event.clear()
             if not event:
                 break
         if self._processing_counter:

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -5,6 +5,7 @@ They can be multi-processed.
 
 """
 import copy
+
 # pylint: disable=logging-fstring-interpolation
 import queue
 import warnings

--- a/logprep/processor/base/exceptions.py
+++ b/logprep/processor/base/exceptions.py
@@ -61,7 +61,9 @@ class ProcessingCriticalError(ProcessingError):
 
     def __init__(self, processor: "Processor", message: str, event: dict):
         processor.metrics.number_of_errors += 1
-        super().__init__(processor, f"{message} -> event was send to error output and further processing stopped")
+        super().__init__(
+            processor, f"{message} -> event was send to error output and further processing stopped"
+        )
 
 
 class ProcessingWarning(Warning):

--- a/logprep/processor/base/exceptions.py
+++ b/logprep/processor/base/exceptions.py
@@ -60,9 +60,8 @@ class ProcessingCriticalError(ProcessingError):
     """A critical error occurred - stop processing of this event"""
 
     def __init__(self, processor: "Processor", message: str, event: dict):
-        event.clear()
         processor.metrics.number_of_errors += 1
-        super().__init__(processor, f"{message} -> event was deleted")
+        super().__init__(processor, f"{message} -> event was send to error output and further processing stopped")
 
 
 class ProcessingWarning(Warning):

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 import pytest
 
-from logprep.abc.input import CriticalInputError
+from logprep.abc.input import CriticalInputError, CriticalInputParsingError
 from logprep.abc.output import FatalOutputError
 from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
@@ -157,3 +157,9 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self.object._config.kafka_config = config
         with pytest.raises(FatalOutputError, match="No such configuration property"):
             self.object.setup()
+
+    def test_get_next_raises_critical_input_parsing_error(self):
+        return_value = b'{"invalid": "json'
+        self.object._get_raw_event = mock.MagicMock(return_value=return_value)
+        with pytest.raises(CriticalInputParsingError, match="is not a valid json"):
+            self.object.get_next(0.01)


### PR DESCRIPTION
closes #424 
furthermore, `ProcessingCriticalError` aren't wrapped again inside `ProcessingCriticalError` and `events` are only cleared after they were written to the error output.