### PR TITLE
Fix time_measurement for empty events after deleter deleted the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 ### Bugfix
 
+* Fix writing time measurements into the event after the deleter has deleted the event. The bug only
+happened when the `metrics.measure_time.append_to_event` configuration was set to `true`.
+
 ## v6.8.0
 ### Features
 

--- a/logprep/util/time_measurement.py
+++ b/logprep/util/time_measurement.py
@@ -45,6 +45,8 @@ class TimeMeasurement:
                 return func(*args, **kwargs)
 
             def add_processing_times_to_event(event, processing_time, caller, name):  # nosemgrep
+                if caller.name == "deleter" and not event:
+                    return
                 if not event.get("processing_times"):
                     event["processing_times"] = {}
                 if name is None:

--- a/tests/unit/util/test_time_measurement.py
+++ b/tests/unit/util/test_time_measurement.py
@@ -10,6 +10,7 @@ from logprep.util.time_measurement import TimeMeasurement
 class TestTimeMeasurement:
     def setup_method(self):
         self.event = {"test_key": "test_val"}
+        self.name = "TestTimeMeasurement"
 
     @TimeMeasurement.measure_time("test")
     def dummy_method(self, event):  # pylint: disable=unused-argument
@@ -33,6 +34,14 @@ class TestTimeMeasurement:
         timestamp = processing_times.get("test")
         assert timestamp is not None
         assert isinstance(timestamp, float)
+
+    def test_time_measurement_decorator_doesn_not_append_processing_time_to_event_after_deleter_deletes_event(self):
+        TimeMeasurement.TIME_MEASUREMENT_ENABLED = True
+        TimeMeasurement.APPEND_TO_EVENT = True
+        self.name = "deleter"  # setting the caller name to deleter, simulates a call of the deleter
+        event = {}
+        self.dummy_method(event)
+        assert not event
 
     def test_deactivated_decorator_does_not_do_a_thing(self):
         TimeMeasurement.TIME_MEASUREMENT_ENABLED = False

--- a/tests/unit/util/test_time_measurement.py
+++ b/tests/unit/util/test_time_measurement.py
@@ -35,7 +35,9 @@ class TestTimeMeasurement:
         assert timestamp is not None
         assert isinstance(timestamp, float)
 
-    def test_time_measurement_decorator_doesn_not_append_processing_time_to_event_after_deleter_deletes_event(self):
+    def test_time_measurement_decorator_does_not_append_processing_time_to_event_after_deleter_deletes_event(
+        self,
+    ):
         TimeMeasurement.TIME_MEASUREMENT_ENABLED = True
         TimeMeasurement.APPEND_TO_EVENT = True
         self.name = "deleter"  # setting the caller name to deleter, simulates a call of the deleter


### PR DESCRIPTION
Fix writing time measurements into the event after the deleter has deleted the event. The bug only
happened when the `metrics.measure_time.append_to_event` configuration was set to `true`.