### PR TITLE
add env variable enrichment preprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next release
 ### Features
+
+* add a preprocessor to enrich by systems env variables
+
 ### Improvements
 
 * `pre_detector` processor now adds the field `creation_timestamp` to pre-detections.

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -103,17 +103,6 @@ class TimeDeltaConfig:
     The calculation will be the arrival time minus the time of this reference field."""
 
 
-@define(kw_only=True)
-class EnvEnrichmentConfig:
-    """Enrichment Configurations
-    Works only if the preprocessor enrich_by_env_variable is set."""
-
-    target_field: field(validator=[validators.instance_of(str), lambda _, __, x: bool(x)])
-    """Defines the fieldname to which the env variable value should be written to."""
-    variable_name: field(validator=[validators.instance_of(str), lambda _, __, x: bool(x)])
-    """Defines the name of the env variable that should be used for the enrichment."""
-
-
 class Input(Connector):
     """Connect to a source for log data."""
 
@@ -189,6 +178,9 @@ class Input(Connector):
               containing the original message that was used to calculate the hmac in compressed and
               base64 encoded. In case the output field exists already in the original message an
               error is raised.
+        - `enrich_by_env_variables` - If required it is possible to automatically enrich incoming
+          events by environment variables. To activate this preprocessor the fields value has to be
+          a mapping from the target field name (key) to the environment variable name (value).
         """
 
         _version_information: dict = field(

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -38,9 +38,6 @@ class CriticalInputError(InputError):
 class CriticalInputParsingError(CriticalInputError):
     """The input couldn't be parsed correctly."""
 
-    def __init__(self, input_connector: "Input", message, raw_input):
-        super().__init__(input_connector, message, raw_input)
-
 
 class FatalInputError(InputError):
     """Must not be catched."""
@@ -219,7 +216,7 @@ class Input(Connector):
         )
         return log_arrival_time_target_field_present & log_arrival_timedelta_present
 
-    def _get_raw_event(self, timeout: float) -> bytearray:
+    def _get_raw_event(self, timeout: float) -> bytearray:  # pylint: disable=unused-argument
         """Implements the details how to get the raw event
 
         Parameters

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+# pylint: disable=line-too-long
 import base64
 import json
 import zlib
@@ -466,7 +467,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
-        assert test_event == {"any": "content"}
+        assert result == {"any": "content"}
 
     def test_get_next_returns_event_with_active_time_measurement(self):
         TimeMeasurement.TIME_MEASUREMENT_ENABLED = True

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -3,6 +3,7 @@
 # pylint: disable=line-too-long
 import base64
 import json
+import os
 import zlib
 from copy import deepcopy
 from logging import getLogger
@@ -479,6 +480,46 @@ class BaseInputTestCase(BaseConnectorTestCase):
         assert self.object.metrics.mean_processing_time_per_event > 0
         TimeMeasurement.TIME_MEASUREMENT_ENABLED = False
         TimeMeasurement.APPEND_TO_EVENT = False
+
+    def test_preprocessing_enriches_by_env_variable(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "enrich_by_env_variables": {
+                    "enriched_field": "TEST_ENV_VARIABLE",
+                },
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        test_event = {"any": "content"}
+        os.environ["TEST_ENV_VARIABLE"] = "test_value"
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result, _ = connector.get_next(0.01)
+        assert result == {"any": "content", "enriched_field": "test_value"}
+
+    def test_preprocessing_enriches_by_multiple_env_variables(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "enrich_by_env_variables": {
+                    "enriched_field1": "TEST_ENV_VARIABLE_FOO",
+                    "enriched_field2": "TEST_ENV_VARIABLE_BAR",
+                },
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        test_event = {"any": "content"}
+        os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
+        os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result, _ = connector.get_next(0.01)
+        assert result == {
+            "any": "content",
+            "enriched_field1": "test_value_foo",
+            "enriched_field2": "test_value_bar",
+        }
 
 
 class BaseOutputTestCase(BaseConnectorTestCase):


### PR DESCRIPTION
this PR adds a preprocessor to enrich incomming events by the systems running logprep env variables. This is useful to enrich the events with kubernetes pod names to show which pod handled the event.