### PR TITLE
Update publish-release-to-pypi.yml to use trusted publishing 

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: "v8.0.0" # ${{ github.ref }}
 
       - name: Initialize Python
         uses: actions/setup-python@v1
@@ -41,6 +41,7 @@ jobs:
       url: https://test.pypi.org/p/logprep
     permissions:
       id-token: write
+    needs: build-wheel-and-tarball
     steps:
       - name: Download artifact from previous job
         uses: actions/download-artifact@master
@@ -60,6 +61,7 @@ jobs:
   #       python-version: ["3.9", "3.10", "3.11"]
 
   #   runs-on: ubuntu-latest
+  #   needs: publish-latest-release-to-pypi
   #   steps:
   #     - name: Checkout Code
   #       uses: actions/checkout@v3

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -5,14 +5,9 @@ on:
     types: [published]
 
 jobs:
-  publish-latest-release-to-pypi:
+  build-wheel-and-tarball:
     runs-on: ubuntu-latest
-    name: Publish release to PyPi
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/logprep
-    permissions:
-      id-token: write
+    name: Build Logprep
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,6 +25,27 @@ jobs:
 
       - name: Build binary wheel and a source tarball
         run: python setup.py sdist bdist_wheel
+
+      - name: Upload Artifact for next job
+        uses: actions/upload-artifact@master
+        with:
+          name: logprep-build
+          path: dist
+    
+  publish-latest-release-to-pypi:
+    runs-on: ubuntu-latest
+    name: Publish release to PyPi
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/logprep
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifact from previous job
+        uses: actions/download-artifact@master
+        with:
+          name: logprep-build
+          path: dist
 
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -8,6 +8,11 @@ jobs:
   publish-latest-release-to-pypi:
     runs-on: ubuntu-latest
     name: Publish release to PyPi
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/logprep
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,12 +31,11 @@ jobs:
       - name: Build binary wheel and a source tarball
         run: python setup.py sdist bdist_wheel
 
-      - name: Publish to Test PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Publish package distributions to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
 
   containerbuild:
     strategy:

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -1,9 +1,8 @@
 name: Publish release to PyPi
 
-# on:
-#   release:
-#     types: [published]
-on: push  # remove me again
+on:
+  release:
+    types: [published]
 
 jobs:
   build-wheel-and-tarball:
@@ -12,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "v8.0.0" # ${{ github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Initialize Python
         uses: actions/setup-python@v1
@@ -50,37 +49,37 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  # containerbuild:
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.9", "3.10", "3.11"]
+  containerbuild:
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
 
-  #   runs-on: ubuntu-latest
-  #   needs: publish-latest-release-to-pypi
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
+    runs-on: ubuntu-latest
+    needs: publish-latest-release-to-pypi
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
-  #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build and Push Docker Image
-  #       uses: docker/build-push-action@v3
-  #       with:
-  #         push: true # Will only build if this is not here
-  #         build-args: |
-  #           LOGPREP_VERSION=${{ github.ref_name }}
-  #           PYTHON_VERSION=${{ matrix.python-version }}
-  #         tags: |
-  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.ref_name }}
-  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-stable
-  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-latest
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          push: true # Will only build if this is not here
+          build-args: |
+            LOGPREP_VERSION=${{ github.ref_name }}
+            PYTHON_VERSION=${{ matrix.python-version }}
+          tags: |
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.ref_name }}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-stable
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-latest

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -1,8 +1,9 @@
 name: Publish release to PyPi
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
+on: push  # remove me again
 
 jobs:
   build-wheel-and-tarball:
@@ -48,36 +49,36 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  containerbuild:
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+  # containerbuild:
+  #   strategy:
+  #     matrix:
+  #       python-version: ["3.9", "3.10", "3.11"]
 
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout Code
+  #       uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to GitHub Container Registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v3
-        with:
-          push: true # Will only build if this is not here
-          build-args: |
-            LOGPREP_VERSION=${{ github.ref_name }}
-            PYTHON_VERSION=${{ matrix.python-version }}
-          tags: |
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.ref_name }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-stable
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-latest
+  #     - name: Build and Push Docker Image
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         push: true # Will only build if this is not here
+  #         build-args: |
+  #           LOGPREP_VERSION=${{ github.ref_name }}
+  #           PYTHON_VERSION=${{ matrix.python-version }}
+  #         tags: |
+  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.ref_name }}
+  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-stable
+  #           ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-latest

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish release to PyPi
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/logprep
+      name: pypi
+      url: https://pypi.org/p/logprep
     permissions:
       id-token: write
     needs: build-wheel-and-tarball
@@ -51,8 +51,6 @@ jobs:
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   containerbuild:
     strategy:


### PR DESCRIPTION
Change pypi publishing method to trusted publishers. Also splits the build and publishing into two jobs and sets inter-job dependencies. 

Publishing to `test.pypi.org` did work as can be seen here: https://test.pypi.org/project/logprep/