### PR TITLE
fix release pipeline

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -10,8 +10,6 @@ jobs:
     name: Build Logprep
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
 
       - name: Initialize Python
         uses: actions/setup-python@v1

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.10
-          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Initialize Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
as quoted here in usage the `ref` key is not needed. perhaps we are on the wrong commit somehow

https://github.com/actions/checkout