### PR TITLE
Ensure no data is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## next release
 ### Breaking
 
+* remove `call_input_callback` parameter from s3 output connector
+
 ### Features
 
 
@@ -15,6 +17,9 @@
 
 * make the s3 connector raise `FatalOutputError` instead of warnings
 * make the s3 connector blocking by removing threading
+* do not call `batch_finished_callback` for extra data in s3, elasticsearch and opensearch output to prevent updating offsets for not fully processed events
+* do not call `batch_finished_callback` on `revoke_callback` in confluent kafka input to prevent possible data loss for not fully processed events
+* allow multiple default output connectors per input and ensure that the offset is only set for events that all outputs have written 
 
 ### Bugfix
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -9,7 +9,7 @@ import zlib
 from abc import abstractmethod
 from functools import partial
 from hmac import HMAC
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, List
 
 from attrs import define, field, validators
 
@@ -183,8 +183,8 @@ class Input(Connector):
         )
 
     pipeline_index: int
-    output_connector: Optional["Output"]
-    __slots__ = ["pipeline_index", "output_connector"]
+    output_connectors: List["Output"]
+    __slots__ = ["pipeline_index", "output_connectors"]
 
     @property
     def _add_hmac(self):
@@ -295,7 +295,7 @@ class Input(Connector):
             self._add_env_enrichment_to_event(event)
         return event, non_critical_error_msg
 
-    def batch_finished_callback(self):
+    def batch_finished_callback(self, output_name: str):
         """Can be called by output connectors after processing a batch of one or more records."""
 
     def _add_env_enrichment_to_event(self, event: dict):

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -443,7 +443,7 @@ class ConfluentKafkaInput(Input):
         if self._enable_auto_offset_store:
             return
 
-        self._remember_last_valid_records_for_output(output_name)
+        self._set_last_valid_records_for_output(output_name)
 
         output_names = [output_connector.name for output_connector in self.output_connectors]
         if any(name not in self._last_valid_records_per_output for name in output_names):
@@ -457,7 +457,7 @@ class ConfluentKafkaInput(Input):
         self._last_valid_records.clear()
         self._last_valid_records_per_output.clear()
 
-    def _remember_last_valid_records_for_output(self, output_name):
+    def _set_last_valid_records_for_output(self, output_name):
         self._last_valid_records_per_output[output_name] = {}
         for partition, message in self._last_valid_records.items():
             self._last_valid_records_per_output[output_name][partition] = message

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -504,7 +504,6 @@ class ConfluentKafkaInput(Input):
             )
         for output_connector in self.output_connectors:
             output_connector._write_backlog()
-            self.batch_finished_callback(output_connector.name)
 
     def _lost_callback(self, consumer, topic_partitions):
         for topic_partition in topic_partitions:

--- a/logprep/connector/confluent_kafka/output.py
+++ b/logprep/connector/confluent_kafka/output.py
@@ -247,7 +247,7 @@ class ConfluentKafkaOutput(Output):
         """
         self.store_custom(document, self._config.topic)
         if self.input_connector:
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
 
     @Metric.measure_time()
     def store_custom(self, document: dict, target: str) -> None:

--- a/logprep/connector/console/output.py
+++ b/logprep/connector/console/output.py
@@ -27,7 +27,7 @@ class ConsoleOutput(Output):
         pprint(document)
         self.metrics.number_of_processed_events += 1
         if self.input_connector:
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
 
     def store_custom(self, document: dict, target: str):
         self.metrics.number_of_processed_events += 1

--- a/logprep/connector/dummy/output.py
+++ b/logprep/connector/dummy/output.py
@@ -90,7 +90,7 @@ class DummyOutput(Output):
         self.events.append(document)
         self.metrics.number_of_processed_events += 1
         if self.input_connector:
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
 
     def store_custom(self, document: dict, target: str):
         """Store additional data in a custom location inside the output destination."""

--- a/logprep/connector/elasticsearch/output.py
+++ b/logprep/connector/elasticsearch/output.py
@@ -312,7 +312,7 @@ class ElasticsearchOutput(Output):
             chunk_size=len(self._message_backlog),
         )
         if self.input_connector and hasattr(self.input_connector, "batch_finished_callback"):
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
         self._message_backlog.clear()
 
     def _bulk(self, client, actions, *args, **kwargs):

--- a/logprep/connector/jsonl/output.py
+++ b/logprep/connector/jsonl/output.py
@@ -81,7 +81,7 @@ class JsonlOutput(Output):
         JsonlOutput._write_json(self._config.output_file, document)
         self.metrics.number_of_processed_events += 1
         if self.input_connector:
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
 
     def store_custom(self, document: dict, target: str):
         document = {target: document}

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -33,7 +33,6 @@ Example
         aws_secret_access_key:
         ca_cert: /path/to/cert.crt
         use_ssl:
-        call_input_callback:
         region_name:
 
 """
@@ -106,11 +105,6 @@ class S3Output(Output):
         """The path to a SSL ca certificate to verify the ssl context (optional)"""
         use_ssl: Optional[bool] = field(validator=validators.instance_of(bool), default=True)
         """Use SSL or not. Is set to true by default (optional)"""
-        call_input_callback: Optional[bool] = field(
-            validator=validators.instance_of(bool), default=True
-        )
-        """The input callback is called after the maximum backlog size has been reached 
-        if this is set to True (optional)"""
 
     @define(kw_only=True)
     class Metrics(Output.Metrics):
@@ -222,9 +216,6 @@ class S3Output(Output):
         for prefix_mb, document_batch in self._message_backlog.items():
             self._write_document_batch(document_batch, f"{prefix_mb}/{time()}-{uuid4()}")
         self._message_backlog.clear()
-
-        if not self._config.call_input_callback:
-            return
 
         if self.input_connector and hasattr(self.input_connector, "batch_finished_callback"):
             self.input_connector.batch_finished_callback()

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -131,7 +131,6 @@ class S3Output(Output):
     def __init__(self, name: str, configuration: "S3Output.Config", logger: Logger):
         super().__init__(name, configuration, logger)
         self._message_backlog = defaultdict(list)
-        self._writing_thread = None
         self._base_prefix = f"{self._config.base_prefix}/" if self._config.base_prefix else ""
         self._s3_resource = None
         self._setup_s3_resource()
@@ -189,29 +188,28 @@ class S3Output(Output):
         return prefix
 
     @Metric.measure_time()
-    def _write_to_s3_resource(self, document: dict, prefix: str):
-        """Writes a document into s3 bucket using given prefix.
+    def _write_to_s3_resource(self):
+        """Writes a document into s3 bucket using given prefix."""
+        if self._backlog_size >= self._config.message_backlog_size:
+            self._write_backlog()
+
+    def _add_to_backlog(self, document: dict, prefix: str):
+        """Adds document to backlog and adds a a prefix.
 
         Parameters
         ----------
         document : dict
-           Document to store.
+           Document to store in backlog.
         """
         prefix = self._add_dates(prefix)
         prefix = f"{self._base_prefix}{prefix}"
         self._message_backlog[prefix].append(document)
-
-        if self._backlog_size >= self._config.message_backlog_size:
-            self._write_backlog()
 
     def _write_backlog(self):
         """Write to s3 if it is not already writing."""
         if not self._message_backlog:
             return
 
-        self._bulk()
-
-    def _bulk(self):
         self._logger.info("Writing %s documents to s3", self._backlog_size)
         for prefix_mb, document_batch in self._message_backlog.items():
             self._write_document_batch(document_batch, f"{prefix_mb}/{time()}-{uuid4()}")
@@ -255,8 +253,8 @@ class S3Output(Output):
                 document, f"Prefix field '{self._config.prefix_field}' empty or missing in document"
             )
             prefix_value = self._config.default_prefix
-
-        self._write_to_s3_resource(document, prefix_value)
+        self._add_to_backlog(document, prefix_value)
+        self._write_to_s3_resource()
 
     @staticmethod
     def _build_no_prefix_document(message_document: dict, reason: str):
@@ -271,7 +269,12 @@ class S3Output(Output):
         return document
 
     def store_custom(self, document: dict, target: str):
-        """Write document into s3 bucket using the target prefix.
+        """Store document into backlog to be written into s3 bucket using the target prefix.
+
+        Only add to backlog instead of writing the batch and calling batch_finished_callback,
+        since store_custom can be called before the event has been fully processed.
+        Setting the offset or comiting before fully processing an event can lead to data loss if
+        Logprep terminates.
 
         Parameters
         ----------
@@ -281,8 +284,7 @@ class S3Output(Output):
             Prefix for the document.
 
         """
-        self.metrics.number_of_processed_events += 1
-        self._write_to_s3_resource(document, target)
+        self._add_to_backlog(document, target)
 
     def store_failed(self, error_message: str, document_received: dict, document_processed: dict):
         """Write errors into s3 bucket using error prefix for documents that failed processing.
@@ -304,4 +306,5 @@ class S3Output(Output):
             "processed": document_processed,
             "@timestamp": TimeParser.now().isoformat(),
         }
-        self._write_to_s3_resource(error_document, self._config.error_prefix)
+        self._add_to_backlog(error_document, self._config.error_prefix)
+        self._write_to_s3_resource()

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -218,7 +218,7 @@ class S3Output(Output):
         self._message_backlog.clear()
 
         if self.input_connector and hasattr(self.input_connector, "batch_finished_callback"):
-            self.input_connector.batch_finished_callback()
+            self.input_connector.batch_finished_callback(self.name)
 
     def _write_document_batch(self, document_batch: dict, identifier: str):
         try:

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -184,10 +184,11 @@ class Pipeline:
     @_handle_pipeline_error
     def _setup(self):
         self.logger.debug("Creating connectors")
+        self._input.output_connectors = []
         for _, output in self._output.items():
             output.input_connector = self._input
             if output.default:
-                self._input.output_connector = output
+                self._input.output_connectors.append(output)
         self.logger.debug(
             f"Created connectors -> input: '{self._input.describe()}',"
             f" output -> '{[output.describe() for _, output in self._output.items()]}'"

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -353,7 +353,6 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self.object._revoke_callback(mock_consumer, mock_partitions)
         for output_connector in self.object.output_connectors:
             output_connector._write_backlog.assert_called()
-        assert self.object.batch_finished_callback.call_count == output_count
 
     def test_set_last_valid_records_for_output(self):
         self.object._last_valid_records = {0: "message_1", 3: "message_2"}

--- a/tests/unit/connector/test_elasticsearch_output.py
+++ b/tests/unit/connector/test_elasticsearch_output.py
@@ -138,7 +138,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     ):
         self.object._config.message_backlog_size = 1
         self.object._handle_serialization_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_serialization_error.assert_called()
 
     @mock.patch(
@@ -148,7 +149,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_connection_error_if_connection_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_connection_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_connection_error.assert_called()
 
     @mock.patch(
@@ -158,7 +160,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_bulk_index_error_if_bulk_index_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_bulk_index_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_bulk_index_error.assert_called()
 
     @mock.patch("elasticsearch.helpers.bulk")

--- a/tests/unit/connector/test_opensearch_output.py
+++ b/tests/unit/connector/test_opensearch_output.py
@@ -152,7 +152,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     ):
         self.object._config.message_backlog_size = 1
         self.object._handle_serialization_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_serialization_error.assert_called()
 
     @mock.patch(
@@ -162,7 +163,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_connection_error_if_connection_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_connection_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_connection_error.assert_called()
 
     @mock.patch(
@@ -172,7 +174,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_bulk_index_error_if_bulk_index_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_bulk_index_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_bulk_index_error.assert_called()
 
     @mock.patch("opensearchpy.helpers.parallel_bulk")

--- a/tests/unit/connector/test_s3_output.py
+++ b/tests/unit/connector/test_s3_output.py
@@ -191,7 +191,8 @@ class TestS3Output(BaseOutputTestCase):
         s3_output = Factory.create({"s3": s3_config}, self.logger)
         assert self._calculate_backlog_size(s3_output) == 0
         for idx in range(1, message_backlog_size):
-            s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
+            s3_output._add_to_backlog({"dummy": "event"}, "write_to_s3")
+            s3_output._write_to_s3_resource()
             assert self._calculate_backlog_size(s3_output) == idx
 
     def test_write_to_s3_resource_sets_current_backlog_count_and_is_max_backlog(self):
@@ -205,27 +206,27 @@ class TestS3Output(BaseOutputTestCase):
 
         # Backlog not full
         for idx in range(message_backlog_size - 1):
-            s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-            self._wait_for_writing_thread(s3_output)
+            s3_output._add_to_backlog({"dummy": "event"}, "write_to_s3")
+            s3_output._write_to_s3_resource()
             assert self._calculate_backlog_size(s3_output) == idx + 1
         s3_output._write_document_batch.assert_not_called()
 
         # Backlog full then cleared
-        s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-        self._wait_for_writing_thread(s3_output)
+        s3_output._add_to_backlog({"dummy": "event"}, "write_to_s3")
+        s3_output._write_to_s3_resource()
         s3_output._write_document_batch.assert_called_once()
         assert self._calculate_backlog_size(s3_output) == 0
 
         # Backlog not full
         for idx in range(message_backlog_size - 1):
-            s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-            self._wait_for_writing_thread(s3_output)
+            s3_output._add_to_backlog({"dummy": "event"}, "write_to_s3")
+            s3_output._write_to_s3_resource()
             assert self._calculate_backlog_size(s3_output) == idx + 1
         s3_output._write_document_batch.assert_called_once()
 
         # Backlog full then cleared
-        s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-        self._wait_for_writing_thread(s3_output)
+        s3_output._add_to_backlog({"dummy": "event"}, "write_to_s3")
+        s3_output._write_to_s3_resource()
         assert s3_output._write_document_batch.call_count == 2
         assert self._calculate_backlog_size(s3_output) == 0
 
@@ -237,22 +238,13 @@ class TestS3Output(BaseOutputTestCase):
         self.object._s3_resource = mock.MagicMock()
         self.object.input_connector = mock.MagicMock()
         self.object.store({"message": "my event message"})
-        self._wait_for_writing_thread(self.object)
         self.object.input_connector.batch_finished_callback.assert_called()
-
-    def test_store_does_not_call_batch_finished_callback_if_disabled(self):
-        s3_config = deepcopy(self.CONFIG)
-        s3_config.update({"call_input_callback": False})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
-        s3_output._s3_resource = mock.MagicMock()
-        s3_output.input_connector = mock.MagicMock()
-        s3_output.store({"message": "my event message"})
-        s3_output.input_connector.batch_finished_callback.assert_not_called()
 
     def test_write_to_s3_resource_replaces_dates(self):
         expected_prefix = f'base_prefix/prefix-{TimeParser.now().strftime("%y:%m:%d")}'
         self.object._write_backlog = mock.MagicMock()
-        self.object._write_to_s3_resource({"foo": "bar"}, "base_prefix/prefix-%{%y:%m:%d}")
+        self.object._add_to_backlog({"foo": "bar"}, "base_prefix/prefix-%{%y:%m:%d}")
+        self.object._write_to_s3_resource()
         resulting_prefix = next(iter(self.object._message_backlog.keys()))
 
         assert expected_prefix == resulting_prefix
@@ -269,11 +261,6 @@ class TestS3Output(BaseOutputTestCase):
     def test_store_failed_counts_failed_events(self):
         self.object._write_backlog = mock.MagicMock()
         super().test_store_failed_counts_failed_events()
-
-    @staticmethod
-    def _wait_for_writing_thread(s3_output):
-        if s3_output._writing_thread is not None:
-            s3_output._writing_thread.join()
 
     @staticmethod
     def _calculate_backlog_size(s3_output):

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -433,7 +433,7 @@ class TestPipeline(ConfigurationForTests):
 
     def test_setup_adds_versions_information_to_input_connector_config(self, mock_create):
         self.pipeline._setup()
-        called_input_config = mock_create.call_args_list[1][0][0]["dummy"]
+        called_input_config = mock_create.call_args_list[0][0][0]["dummy"]
         assert "version_information" in called_input_config, "ensure version_information is added"
         assert "logprep" in called_input_config.get("version_information"), "ensure logprep key"
         assert "configuration" in called_input_config.get("version_information"), "ensure config"
@@ -446,7 +446,17 @@ class TestPipeline(ConfigurationForTests):
 
     def test_setup_connects_input_with_output(self, _):
         self.pipeline._setup()
-        assert self.pipeline._input.output_connector == self.pipeline._output["dummy"]
+        assert self.pipeline._input.output_connectors == [self.pipeline._output["dummy"]]
+
+    def test_setup_connects_input_with_multiple_outputs(self, _):
+        self.pipeline._logprep_config.update(
+            {"output": {"dummy": {"type": "dummy_output"}, "dummy2": {"type": "dummy_output"}}}
+        )
+        self.pipeline._setup()
+        assert self.pipeline._input.output_connectors == [
+            self.pipeline._output["dummy"],
+            self.pipeline._output["dummy2"],
+        ]
 
     def test_pipeline_does_not_call_batch_finished_callback_if_output_store_does_not_return_true(
         self, _


### PR DESCRIPTION
* remove `call_input_callback` parameter from s3 output connector
* do not call `batch_finished_callback` for extra data in s3, elasticsearch and opensearch output to prevent updating offsets for not fully processed events
* do not call `batch_finished_callback` on `revoke_callback` in confluent kafka input to prevent possible data loss for not fully processed events
* allow multiple default output connectors per input and ensure that the offset is only set for events that all outputs have written 