### PR TITLE
remove logger from Factory

### DIFF
--- a/doc/source/development/notebooks/processor_examples/calculator.ipynb
+++ b/doc/source/development/notebooks/processor_examples/calculator.ipynb
@@ -157,8 +157,7 @@
     "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "calculator = Factory.create(processor_config, mock_logger)\n",
+    "calculator = Factory.create(processor_config)\n",
     "calculator"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/concatenator.ipynb
+++ b/doc/source/development/notebooks/processor_examples/concatenator.ipynb
@@ -169,8 +169,7 @@
     "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "concatenator = Factory.create(processor_config, mock_logger)\n",
+    "concatenator = Factory.create(processor_config)\n",
     "concatenator"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/dissector.ipynb
+++ b/doc/source/development/notebooks/processor_examples/dissector.ipynb
@@ -168,8 +168,7 @@
     "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "dissector = Factory.create(processor_config, mock_logger)\n",
+    "dissector = Factory.create(processor_config)\n",
     "dissector"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/field_manager.ipynb
+++ b/doc/source/development/notebooks/processor_examples/field_manager.ipynb
@@ -145,9 +145,8 @@
     "from logging import getLogger\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "logger = getLogger()\n",
     "\n",
-    "processor = Factory.create(processor_config, logger)\n",
+    "processor = Factory.create(processor_config)\n",
     "processor\n"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/geo_ip_enricher_custom_outputfields.ipynb
+++ b/doc/source/development/notebooks/processor_examples/geo_ip_enricher_custom_outputfields.ipynb
@@ -202,8 +202,7 @@
     "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "geoip_enricher = Factory.create(processor_config, mock_logger)\n",
+    "geoip_enricher = Factory.create(processor_config)\n",
     "geoip_enricher\n"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/grokker.ipynb
+++ b/doc/source/development/notebooks/processor_examples/grokker.ipynb
@@ -144,8 +144,7 @@
     "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "grokker = Factory.create(processor_config, mock_logger)\n",
+    "grokker = Factory.create(processor_config)\n",
     "grokker.setup()"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/ip_informer.ipynb
+++ b/doc/source/development/notebooks/processor_examples/ip_informer.ipynb
@@ -225,11 +225,9 @@
     }
    ],
    "source": [
-    "from logging import getLogger\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "logger = getLogger()\n",
-    "ip_informer = Factory.create(processor_config, logger)\n",
+    "ip_informer = Factory.create(processor_config)\n",
     "ip_informer"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/key_checker.ipynb
+++ b/doc/source/development/notebooks/processor_examples/key_checker.ipynb
@@ -239,12 +239,9 @@
     }
    ],
    "source": [
-    "from unittest import mock\n",
-    "import sys\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "keychecker = Factory.create(processor_config, mock_logger)\n",
+    "keychecker = Factory.create(processor_config)\n",
     "keychecker\n"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/requester.ipynb
+++ b/doc/source/development/notebooks/processor_examples/requester.ipynb
@@ -164,11 +164,9 @@
     }
    ],
    "source": [
-    "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "requester = Factory.create(processor_config, mock_logger)\n",
+    "requester = Factory.create(processor_config)\n",
     "requester"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/string_splitter.ipynb
+++ b/doc/source/development/notebooks/processor_examples/string_splitter.ipynb
@@ -133,12 +133,10 @@
     }
    ],
    "source": [
-    "from logging import getLogger\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "logger = getLogger()\n",
     "\n",
-    "processor = Factory.create(processor_config, logger)\n",
+    "processor = Factory.create(processor_config)\n",
     "processor\n"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/timestamp_differ.ipynb
+++ b/doc/source/development/notebooks/processor_examples/timestamp_differ.ipynb
@@ -138,11 +138,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "processor = Factory.create(processor_config, mock_logger)\n",
+    "processor = Factory.create(processor_config)\n",
     "processor"
    ]
   },

--- a/doc/source/development/notebooks/processor_examples/timestamper.ipynb
+++ b/doc/source/development/notebooks/processor_examples/timestamper.ipynb
@@ -142,11 +142,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from unittest import mock\n",
     "from logprep.factory import Factory\n",
     "\n",
-    "mock_logger = mock.MagicMock()\n",
-    "processor = Factory.create(processor_config, mock_logger)\n",
+    "processor = Factory.create(processor_config)\n",
     "processor"
    ]
   },

--- a/logprep/factory.py
+++ b/logprep/factory.py
@@ -1,5 +1,6 @@
 """This module contains a factory to create connectors and processors."""
 import copy
+import logging
 from typing import TYPE_CHECKING
 
 from logprep.abc.component import Component
@@ -17,7 +18,7 @@ class Factory:
     """Create components for logprep."""
 
     @classmethod
-    def create(cls, configuration: dict, logger: "Logger") -> Component:
+    def create(cls, configuration: dict) -> Component:
         """Create component."""
         if configuration == {} or configuration is None:
             raise InvalidConfigurationError("The component definition is empty.")
@@ -43,4 +44,4 @@ class Factory:
                 component_name, component_configuration_dict
             )
             component_configuration.metric_labels = copy.deepcopy(metric_labels)
-            return component(component_name, component_configuration, logger)
+            return component(component_name, component_configuration, logging.getLogger())

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -167,7 +167,7 @@ class Pipeline:
         outputs = {}
         for output_name in output_names:
             output_config = output_configs.get(output_name)
-            outputs |= {output_name: Factory.create({output_name: output_config}, self.logger)}
+            outputs |= {output_name: Factory.create({output_name: output_config})}
         return outputs
 
     @cached_property
@@ -179,7 +179,7 @@ class Pipeline:
         input_connector_config[connector_name].update(
             {"version_information": self._event_version_information}
         )
-        return Factory.create(input_connector_config, self.logger)
+        return Factory.create(input_connector_config)
 
     @_handle_pipeline_error
     def _setup(self):
@@ -207,7 +207,7 @@ class Pipeline:
         self.logger.info("Finished building pipeline")
 
     def _create_processor(self, entry: dict) -> "Processor":
-        processor = Factory.create(entry, self.logger)
+        processor = Factory.create(entry)
         processor.setup()
         self.logger.debug(f"Created '{processor}' processor")
         return processor

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -172,7 +172,7 @@ def _load_configuration(args):
 
 def _validate_rules(args, config: Configuration, logger: logging.Logger):
     try:
-        config.verify_pipeline_only(logger)
+        config.verify_pipeline_only()
     except InvalidConfigurationError as error:
         logger.critical(error)
         sys.exit(1)
@@ -219,7 +219,7 @@ def main():
         dry_runner.run()
     elif args.verify_config:
         try:
-            config.verify(logger)
+            config.verify()
         except InvalidConfigurationError as error:
             logger.critical(error)
             sys.exit(1)

--- a/logprep/runner.py
+++ b/logprep/runner.py
@@ -164,7 +164,7 @@ class Runner:
             raise MustNotConfigureTwiceError
 
         configuration = Configuration.create_from_yaml(yaml_file)
-        configuration.verify(self._logger)
+        configuration.verify()
 
         self._yaml_path = yaml_file
         self._configuration = configuration
@@ -252,7 +252,7 @@ class Runner:
                 )
                 return
         try:
-            new_configuration.verify(self._logger)
+            new_configuration.verify()
 
             # Only reached when configuration is verified successfully
             self._configuration = new_configuration

--- a/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_corpus_tester.py
@@ -96,7 +96,7 @@ from pathlib import Path
 from pprint import pprint
 from typing import List
 
-from attr import define, validators, field, Factory
+from attr import Factory, define, field, validators
 from colorama import Fore, Style
 from deepdiff import DeepDiff, grep
 
@@ -193,7 +193,7 @@ class RuleCorpusTester:
             self._original_config_path, self._tmp_dir, str(merged_input_file_path)
         )
         config = Configuration.create_from_yaml(path_to_patched_config)
-        config.verify_pipeline_without_processor_outputs(getLogger("logprep"))
+        config.verify_pipeline_without_processor_outputs()
         del config["output"]
         pipeline = Pipeline(config=config)
         pipeline.logger = self._logprep_logger

--- a/logprep/util/auto_rule_tester/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_tester.py
@@ -177,9 +177,6 @@ class AutoRuleTester:
         self._custom_tests = []
         self._missing_custom_tests = []
 
-        self._logger = getLogger()
-        self._logger.disabled = True
-
     def run(self):
         """Perform auto-tests."""
         rules_dirs = self._get_rule_dirs_by_processor_name()
@@ -245,7 +242,7 @@ class AutoRuleTester:
         processors_without_custom_test = OrderedDict()
         for processor_in_pipeline in self._config_yml["pipeline"]:
             name, processor_cfg = next(iter(processor_in_pipeline.items()))
-            processor = self._get_processor_instance(name, processor_cfg, self._logger)
+            processor = self._get_processor_instance(name, processor_cfg)
             if processor.has_custom_tests:
                 processors_with_custom_test[processor] = name
             else:
@@ -256,7 +253,7 @@ class AutoRuleTester:
         processor_uses_own_tests = {}
         for processor_in_pipeline in self._config_yml["pipeline"]:
             name, processor_cfg = next(iter(processor_in_pipeline.items()))
-            processor = self._get_processor_instance(name, processor_cfg, self._logger)
+            processor = self._get_processor_instance(name, processor_cfg)
             processor_uses_own_tests[processor_cfg["type"]] = processor.has_custom_tests
         return processor_uses_own_tests
 
@@ -464,9 +461,9 @@ class AutoRuleTester:
         return rule_test_coverage
 
     @staticmethod
-    def _get_processor_instance(name, processor_cfg, logger_):
+    def _get_processor_instance(name, processor_cfg):
         cfg = {name: processor_cfg}
-        processor = Factory.create(cfg, logger_)
+        processor = Factory.create(cfg)
         return processor
 
     @staticmethod

--- a/logprep/util/pre_detector_rule_matching_tester.py
+++ b/logprep/util/pre_detector_rule_matching_tester.py
@@ -134,7 +134,7 @@ class RuleMatchingTester:
         }
         logger = logging.getLogger()
         logger.disabled = True
-        processor = Factory.create(processor_cfg, logger)
+        processor = Factory.create(processor_cfg)
         return processor
 
     def _print_results(self):

--- a/logprep/util/rule_dry_runner.py
+++ b/logprep/util/rule_dry_runner.py
@@ -50,7 +50,9 @@ from colorama import Back, Fore
 from ruamel.yaml import YAML
 
 from logprep.framework.pipeline import Pipeline
-from logprep.util.auto_rule_tester.auto_rule_corpus_tester import align_extra_output_formats
+from logprep.util.auto_rule_tester.auto_rule_corpus_tester import (
+    align_extra_output_formats,
+)
 from logprep.util.configuration import Configuration
 from logprep.util.getter import GetterFactory
 from logprep.util.helper import color_print_line, color_print_title, recursive_compare
@@ -73,7 +75,7 @@ class DryRunner:
             input_file_path=self._input_file_path,
         )
         config = Configuration.create_from_yaml(patched_config_path)
-        config.verify_pipeline_without_processor_outputs(self._logger)
+        config.verify_pipeline_without_processor_outputs()
         del config["output"]
         return Pipeline(config=config)
 

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -1,0 +1,43 @@
+version: 1
+process_count: 2
+timeout: 0.1
+logger:
+  level: INFO
+
+metrics:
+  enabled: true
+  port: 8000
+
+pipeline: []
+
+input:
+  httpinput:
+      type: http_input
+      uvicorn_config:
+          host: 0.0.0.0
+          port: 9000
+      endpoints:
+          /sap/123/ABC/auditlog: jsonl
+          /sap/123/ABC/auditlog-definition: jsonl
+          /sap/123/ABC/custom-alerts: jsonl
+          /sap/123/ABC/heartbeat: jsonl
+          /sap/123/ABC/profile-parameter-changes: jsonl
+          /sap/123/ABC/profile-parameters: jsonl
+          /sap/123/ABC/sap-kernel: jsonl
+          /sap/123/ABC/security-notes: jsonl
+          /sap/123/ABC/software-components: jsonl
+          /sap/123/ABC/software-updates: jsonl
+          /sap/123/ABC/syslog: jsonl
+          /sap/123/ABC/syslog-definition: jsonl
+
+output:
+  kafka:
+    type: confluentkafka_output
+    topic: consumer
+    error_topic: errors
+    flush_timeout: 0.2
+    send_timeout: 0
+    kafka_config:
+      bootstrap.servers: 127.0.0.1:9092
+      compression.type: gzip
+      statistics.interval.ms: "60000"

--- a/tests/unit/component/base.py
+++ b/tests/unit/component/base.py
@@ -31,7 +31,7 @@ class BaseComponentTestCase(ABC):
 
     def setup_method(self) -> None:
         config = {"Test Instance Name": self.CONFIG}
-        self.object = Factory.create(configuration=config, logger=self.logger)
+        self.object = Factory.create(configuration=config)
         assert "metrics" not in self.object.__dict__, "metrics should be a cached_property"
         self.metric_attributes = asdict(
             self.object.metrics,

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -58,7 +58,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         assert connector._add_hmac is True
 
     def test_add_hmac_to_adds_hmac(self):
@@ -74,7 +74,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         processed_event, non_critical_error_msg = connector._add_hmac_to(
             {"message": "test message"}, b"test message"
         )
@@ -101,7 +101,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         processed_event, non_critical_error_msg = connector._add_hmac_to(
             {"message": "test message"}, None
         )
@@ -129,7 +129,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"message": "with_content"}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
@@ -164,7 +164,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"message": {"with_subfield": "content"}}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
@@ -200,7 +200,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"message": {"with_subfield": "content"}}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
@@ -234,7 +234,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"message": "with_content"}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
@@ -275,7 +275,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"message": {"with_subfield": "content"}}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
@@ -291,7 +291,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector_config = deepcopy(self.CONFIG)
         assert not connector_config.get("preprocessing", {}).get("hmac")
         test_event = {"message": "with_content"}
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
             return_value=(test_event.copy(), raw_encoded_test_event)
@@ -309,7 +309,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -325,7 +325,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "version_info": "something random"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -339,7 +339,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "version_info": "something random"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -370,7 +370,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         connector._get_event = mock.MagicMock(return_value=({"any": "content"}, None))
         result, _ = connector.get_next(0.01)
         target_field = preprocessing_config.get("preprocessing", {}).get(
@@ -390,7 +390,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "arrival_time": "does not matter"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -408,7 +408,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "@timestamp": "1999-09-09T09:09:09.448319+02:00"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -434,7 +434,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -449,7 +449,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -468,7 +468,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result, _ = connector.get_next(0.01)
@@ -484,7 +484,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         os.environ["TEST_ENV_VARIABLE"] = "test_value"
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
@@ -502,7 +502,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
         os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
         os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"

--- a/tests/unit/connector/test_confluent_kafka_common.py
+++ b/tests/unit/connector/test_confluent_kafka_common.py
@@ -26,7 +26,7 @@ class CommonConfluentKafkaTestCase:
         kafka_config = deepcopy(self.CONFIG)
         kafka_config.update({"unknown_option": "bad value"})
         with pytest.raises(TypeError, match=r"unexpected keyword argument"):
-            _ = Factory.create({"test connector": kafka_config}, logger=self.logger)
+            _ = Factory.create({"test connector": kafka_config})
 
     def test_error_callback_logs_error(self):
         self.object.metrics.number_of_errors = 0

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -105,7 +105,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_batch_finished_callback_calls_offsets_handler_for_setting(self, _, settings, handlers):
         input_config = deepcopy(self.CONFIG)
-        kafka_input = Factory.create({"test": input_config}, logger=self.logger)
+        kafka_input = Factory.create({"test": input_config})
         kafka_input._config.kafka_config.update(settings)
         kafka_consumer = kafka_input._consumer
         message = "test message"
@@ -131,7 +131,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self, _, settings, handler
     ):
         input_config = deepcopy(self.CONFIG)
-        kafka_input = Factory.create({"test": input_config}, logger=self.logger)
+        kafka_input = Factory.create({"test": input_config})
         kafka_input._config.kafka_config.update(settings)
         kafka_consumer = kafka_input._consumer
         return_sequence = [KafkaException("test error"), None]
@@ -248,7 +248,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_client_id_can_be_overwritten(self, mock_consumer):
         input_config = deepcopy(self.CONFIG)
-        kafka_input = Factory.create({"test": input_config}, logger=self.logger)
+        kafka_input = Factory.create({"test": input_config})
         kafka_input._config.kafka_config["client.id"] = "thisclientid"
         kafka_input.setup()
         mock_consumer.assert_called()
@@ -257,7 +257,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_statistics_interval_can_be_overwritten(self, mock_consumer):
-        kafka_input = Factory.create({"test": self.CONFIG}, logger=self.logger)
+        kafka_input = Factory.create({"test": self.CONFIG})
         kafka_input._config.kafka_config["statistics.interval.ms"] = "999999999"
         kafka_input.setup()
         mock_consumer.assert_called()
@@ -275,7 +275,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         config.get("kafka_config").pop("group.id")
         expected_error_message = r"keys are missing: {'(bootstrap.servers|group.id)', '(bootstrap.servers|group.id)'}"  # pylint: disable=line-too-long
         with pytest.raises(InvalidConfigurationError, match=expected_error_message):
-            Factory.create({"test": config}, logger=self.logger)
+            Factory.create({"test": config})
 
     @pytest.mark.parametrize(
         "metric_name",

--- a/tests/unit/connector/test_confluent_kafka_output.py
+++ b/tests/unit/connector/test_confluent_kafka_output.py
@@ -54,7 +54,7 @@ class TestConfluentKafkaOutput(BaseOutputTestCase, CommonConfluentKafkaTestCase)
 
     @mock.patch("logprep.connector.confluent_kafka.output.Producer", return_value="The Producer")
     def test_producer_property_instanciates_kafka_producer(self, _):
-        kafka_output = Factory.create({"test connector": self.CONFIG}, logger=self.logger)
+        kafka_output = Factory.create({"test connector": self.CONFIG})
         assert kafka_output._producer == "The Producer"
 
     @mock.patch("logprep.connector.confluent_kafka.output.Producer")
@@ -158,4 +158,4 @@ class TestConfluentKafkaOutput(BaseOutputTestCase, CommonConfluentKafkaTestCase)
         config.get("kafka_config").pop("bootstrap.servers")
         expected_error_message = r"keys are missing: {'bootstrap.servers'}"
         with pytest.raises(InvalidConfigurationError, match=expected_error_message):
-            Factory.create({"test": config}, logger=self.logger)
+            Factory.create({"test": config})

--- a/tests/unit/connector/test_dummy_input.py
+++ b/tests/unit/connector/test_dummy_input.py
@@ -46,7 +46,7 @@ class TestDummyInput(BaseInputTestCase):
     def test_repeat_documents_repeats_documents(self):
         config = copy.deepcopy(self.CONFIG)
         config["repeat_documents"] = True
-        connector = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+        connector = Factory.create(configuration={"Test Instance Name": config})
         connector._config.documents = [{"order": 0}, {"order": 1}, {"order": 2}]
 
         for order in range(0, 9):

--- a/tests/unit/connector/test_dummy_output.py
+++ b/tests/unit/connector/test_dummy_output.py
@@ -2,7 +2,7 @@
 # pylint: disable=no-self-use
 from copy import deepcopy
 
-from pytest import raises, fail
+from pytest import fail, raises
 
 from logprep.abc.output import FatalOutputError
 from logprep.factory import Factory
@@ -48,7 +48,7 @@ class TestDummyOutput(BaseOutputTestCase):
     def test_raises_exception_on_call_to_store(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        dummy_output = Factory.create({"test connector": config}, logger=self.logger)
+        dummy_output = Factory.create({"test connector": config})
 
         with raises(BaseException, match="FatalOutputError"):
             dummy_output.store({"order": 0})
@@ -56,7 +56,7 @@ class TestDummyOutput(BaseOutputTestCase):
     def test_raises_exception_on_call_to_store_custom(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        dummy_output = Factory.create({"test connector": config}, logger=self.logger)
+        dummy_output = Factory.create({"test connector": config})
 
         with raises(Exception, match="FatalOutputError"):
             dummy_output.store_custom({"order": 0}, target="whatever")
@@ -64,7 +64,7 @@ class TestDummyOutput(BaseOutputTestCase):
     def test_raises_exception_only_once(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        dummy_output = Factory.create({"test connector": config}, logger=self.logger)
+        dummy_output = Factory.create({"test connector": config})
 
         with raises(Exception, match="FatalOutputError"):
             dummy_output.store({"order": 0})
@@ -76,7 +76,7 @@ class TestDummyOutput(BaseOutputTestCase):
     def test_raises_exception_only_when_not_none(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": [None, "FatalOutputError", None]})
-        dummy_output = Factory.create({"test connector": config}, logger=self.logger)
+        dummy_output = Factory.create({"test connector": config})
 
         dummy_output.store({"order": 0})
         with raises(Exception, match="FatalOutputError"):

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -1,13 +1,14 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
-from copy import deepcopy
 import json
+from copy import deepcopy
 
 import requests
 import uvicorn
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
 from logprep.connector.http.input import HttpConnector
 from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
@@ -134,7 +135,7 @@ class TestHttpConnector(BaseInputTestCase):
                 }
             }
         )
-        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        connector = Factory.create({"test connector": connector_config})
         connector.setup()
         test_event = "the content"
         with connector.server.run_in_thread():

--- a/tests/unit/connector/test_json_input.py
+++ b/tests/unit/connector/test_json_input.py
@@ -62,7 +62,7 @@ class TestJsonInput(BaseInputTestCase):
         config = copy.deepcopy(self.CONFIG)
         config["repeat_documents"] = True
         mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
-        object = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+        object = Factory.create(configuration={"Test Instance Name": config})
 
         for order in range(0, 9):
             event, _ = object.get_next(self.timeout)

--- a/tests/unit/connector/test_jsonl_input.py
+++ b/tests/unit/connector/test_jsonl_input.py
@@ -56,7 +56,7 @@ class TestJsonlInput(BaseInputTestCase):
         config = copy.deepcopy(self.CONFIG)
         config["repeat_documents"] = True
         mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
-        object = Factory.create(configuration={"Test Instance Name": config}, logger=self.logger)
+        object = Factory.create(configuration={"Test Instance Name": config})
 
         for order in range(0, 9):
             event, _ = object.get_next(self.timeout)

--- a/tests/unit/connector/test_real_kafka.py
+++ b/tests/unit/connector/test_real_kafka.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=subprocess-run-check
 # pylint: disable=protected-access
-import logging
 import os
 import re
 import subprocess
@@ -64,9 +63,7 @@ class TestKafkaConnection:
                 "bootstrap.servers": "localhost:9092",
             },
         }
-        self.kafka_output = Factory.create(
-            {"test output": ouput_config}, logger=logging.getLogger()
-        )
+        self.kafka_output = Factory.create({"test output": ouput_config})
 
         input_config = {
             "type": "confluentkafka_input",
@@ -76,7 +73,7 @@ class TestKafkaConnection:
                 "group.id": "test_consumergroup",
             },
         }
-        self.kafka_input = Factory.create({"test input": input_config}, logger=logging.getLogger())
+        self.kafka_input = Factory.create({"test input": input_config})
         self.kafka_input.output_connector = mock.MagicMock()
 
     def teardown_method(self):
@@ -111,7 +108,7 @@ class TestKafkaConnection:
                 "group.id": "test_consumergroup",
             },
         }
-        kafka_input = Factory.create({"librdkafkatest": input_config}, logger=mock.MagicMock())
+        kafka_input = Factory.create({"librdkafkatest": input_config})
         kafka_input._logger.log = mock.MagicMock()
         kafka_input.get_next(10)
         kafka_input._logger.log.assert_called()
@@ -130,8 +127,7 @@ class TestKafkaConnection:
                 "debug": "consumer,cgrp,topic,fetch",
             },
         }
-        logger = logging.getLogger()
-        kafka_input = Factory.create({"librdkafkatest": input_config}, logger=logger)
+        kafka_input = Factory.create({"librdkafkatest": input_config})
         kafka_input.get_next(10)
 
     @pytest.mark.xfail(reason="sometimes fails, if not ran isolated")

--- a/tests/unit/connector/test_s3_output.py
+++ b/tests/unit/connector/test_s3_output.py
@@ -72,7 +72,7 @@ class TestS3Output(BaseOutputTestCase):
         }
         s3_config = deepcopy(self.CONFIG)
         s3_config.update({"message_backlog_size": 2, "base_prefix": base_prefix})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
 
         s3_output.store(event)
 
@@ -94,7 +94,7 @@ class TestS3Output(BaseOutputTestCase):
         }
         s3_config = deepcopy(self.CONFIG)
         s3_config.update({"default_prefix": default_prefix, "message_backlog_size": 2})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
 
         s3_output.store(event)
 
@@ -109,7 +109,7 @@ class TestS3Output(BaseOutputTestCase):
 
         s3_config = deepcopy(self.CONFIG)
         s3_config.update({"message_backlog_size": 2})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
 
         s3_output.store_custom(event, custom_prefix)
         assert s3_output._message_backlog[custom_prefix][0] == expected
@@ -128,7 +128,7 @@ class TestS3Output(BaseOutputTestCase):
         }
         s3_config = deepcopy(self.CONFIG)
         s3_config.update({"error_prefix": error_prefix, "message_backlog_size": 2})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
 
         s3_output.store_failed(error_message, event_received, event)
 
@@ -188,7 +188,7 @@ class TestS3Output(BaseOutputTestCase):
         s3_config = deepcopy(self.CONFIG)
         message_backlog_size = 5
         s3_config.update({"message_backlog_size": message_backlog_size})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
         assert self._calculate_backlog_size(s3_output) == 0
         for idx in range(1, message_backlog_size):
             s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
@@ -198,7 +198,7 @@ class TestS3Output(BaseOutputTestCase):
         s3_config = deepcopy(self.CONFIG)
         message_backlog_size = 5
         s3_config.update({"message_backlog_size": message_backlog_size})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
 
         s3_output._write_document_batch = mock.MagicMock()
         s3_output._write_document_batch.assert_not_called()
@@ -243,7 +243,7 @@ class TestS3Output(BaseOutputTestCase):
     def test_store_does_not_call_batch_finished_callback_if_disabled(self):
         s3_config = deepcopy(self.CONFIG)
         s3_config.update({"call_input_callback": False})
-        s3_output = Factory.create({"s3": s3_config}, self.logger)
+        s3_output = Factory.create({"s3": s3_config})
         s3_output._s3_resource = mock.MagicMock()
         s3_output.input_connector = mock.MagicMock()
         s3_output.store({"message": "my event message"})

--- a/tests/unit/exceptions/test_connector_exceptions.py
+++ b/tests/unit/exceptions/test_connector_exceptions.py
@@ -32,7 +32,7 @@ class TestFatalOutputError(ExceptionBaseTest):
 
     def setup_method(self):
         self.object = Factory.create(
-            {"test connector": {"type": "dummy_output", "default": False}}, logger=getLogger()
+            {"test connector": {"type": "dummy_output", "default": False}}
         )
         self.exception_args = (self.object, "the error message")
 
@@ -47,7 +47,6 @@ class TestCriticalOutputError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_output", "default": False}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message", b"raw input")
 
@@ -62,7 +61,6 @@ class TestOutputError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_output", "default": False}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")
 
@@ -77,7 +75,6 @@ class TestOutputWarning(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_output", "default": False}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")
 
@@ -92,7 +89,6 @@ class TestInputError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")
 
@@ -107,7 +103,6 @@ class TestCriticalInputError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message", b"raw input")
 
@@ -122,7 +117,6 @@ class TestCriticalInputParsingError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message", b"raw input")
 
@@ -137,7 +131,6 @@ class TestFatalInputError(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")
 
@@ -152,7 +145,6 @@ class TestInputWarning(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")
 
@@ -167,6 +159,5 @@ class TestSourceDisconnectedWarning(ExceptionBaseTest):
     def setup_method(self):
         self.object = Factory.create(
             {"test connector": {"type": "dummy_input", "documents": []}},
-            logger=getLogger(),
         )
         self.exception_args = (self.object, "the error message")

--- a/tests/unit/framework/rule_tree/test_rule_tree.py
+++ b/tests/unit/framework/rule_tree/test_rule_tree.py
@@ -49,7 +49,6 @@ class TestRuleTree:
                     "tree_config": "tests/testdata/unit/tree_config.json",
                 }
             },
-            mock.MagicMock(),
         )
         rule_tree = RuleTree(processor_config=processor._config)
 

--- a/tests/unit/processor/base.py
+++ b/tests/unit/processor/base.py
@@ -92,7 +92,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
             self.patchers.append(patcher)
         super().setup_method()
         config = {"Test Instance Name": self.CONFIG}
-        self.object = Factory.create(configuration=config, logger=self.logger)
+        self.object = Factory.create(config)
         self.specific_rules = self.set_rules(self.specific_rules_dirs)
         self.generic_rules = self.set_rules(self.generic_rules_dirs)
 
@@ -163,7 +163,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
             {"generic_rules": ["http://does.not.matter", "https://this.is.not.existent/bla.yml"]}
         )
         with pytest.raises(TypeError, match="not .*MagicMock.*"):
-            Factory.create({"http_rule_processor": myconfig}, self.logger)
+            Factory.create({"http_rule_processor": myconfig})
 
     def test_no_redundant_rules_are_added_to_rule_tree(self):
         """
@@ -222,26 +222,26 @@ class BaseProcessorTestCase(BaseComponentTestCase):
         config = deepcopy(self.CONFIG)
         config.update({rule_list: "i am not a list"})
         with pytest.raises(TypeError, match=r"must be <class 'list'>"):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     @pytest.mark.parametrize("rule_list", ["specific_rules", "generic_rules"])
     def test_validation_raises_if_elements_does_not_exist(self, rule_list):
         config = deepcopy(self.CONFIG)
         config.update({rule_list: ["/i/do/not/exist"]})
         with pytest.raises(FileNotFoundError):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     def test_validation_raises_if_tree_config_is_not_a_str(self):
         config = deepcopy(self.CONFIG)
         config.update({"tree_config": 12})
         with pytest.raises(TypeError, match=r"must be <class 'str'>"):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     def test_validation_raises_if_tree_config_is_not_exist(self):
         config = deepcopy(self.CONFIG)
         config.update({"tree_config": "/i/am/not/a/file/path"})
         with pytest.raises(FileNotFoundError):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     @responses.activate
     def test_accepts_tree_config_from_http(self):
@@ -249,7 +249,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
         config.update({"tree_config": "http://does.not.matter.bla/tree_config.yml"})
         tree_config = Path("tests/testdata/unit/tree_config.json").read_text()
         responses.add(responses.GET, "http://does.not.matter.bla/tree_config.yml", tree_config)
-        processor = Factory.create({"test instance": config}, self.logger)
+        processor = Factory.create({"test instance": config})
         assert (
             processor._specific_tree._processor_config.tree_config
             == "http://does.not.matter.bla/tree_config.yml"
@@ -263,7 +263,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
         config.update({"tree_config": "http://does.not.matter.bla/tree_config.yml"})
         responses.add(responses.GET, "http://does.not.matter.bla/tree_config.yml", status=404)
         with pytest.raises(requests.HTTPError):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     @pytest.mark.parametrize(
         "metric_name, metric_class",

--- a/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
+++ b/tests/unit/processor/domain_label_extractor/test_domain_label_extractor.py
@@ -182,7 +182,7 @@ class TestDomainLabelExtractor(BaseProcessorTestCase):
             }
         }
 
-        domain_label_extractor = Factory.create(configuration=config, logger=self.logger)
+        domain_label_extractor = Factory.create(configuration=config)
         document = {"url": {"domain": "domain.fubarbo"}}
         expected_output = {
             "url": {"domain": "domain.fubarbo"},
@@ -203,7 +203,7 @@ class TestDomainLabelExtractor(BaseProcessorTestCase):
             }
         }
 
-        domain_label_extractor = Factory.create(config, self.logger)
+        domain_label_extractor = Factory.create(config)
         document = {"url": {"domain": "domain.fubarbo"}, "special_tags": ["source"]}
         expected_output = {
             "url": {"domain": "domain.fubarbo"},

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -87,7 +87,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_domain_ip_map_greater_cache(self):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 1})
-        self.object = Factory.create({"resolver": config}, self.logger)
+        self.object = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -119,7 +119,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_url_to_ip_resolved_and_added_with_debug_cache(self, _):
         config = deepcopy(self.CONFIG)
         config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config}, self.logger)
+        self.object = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -139,7 +139,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_url_to_ip_resolved_from_cache_and_added_with_debug_cache(self, _):
         config = deepcopy(self.CONFIG)
         config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config}, self.logger)
+        self.object = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -161,7 +161,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_url_to_ip_resolved_and_added_with_cache_disabled(self, _):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
-        self.object = Factory.create({"resolver": config}, self.logger)
+        self.object = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -189,7 +189,7 @@ sth.ac.at
         responses.add(responses.GET, "http://does_not_matter", response_content)
         config = deepcopy(self.CONFIG)
         config.update({"tld_lists": ["http://does_not_matter"]})
-        domain_resolver = Factory.create({"test instance": config}, self.logger)
+        domain_resolver = Factory.create({"test instance": config})
         document = {"url": "http://www.google.ac.at/some/text"}
         expected = {"url": "http://www.google.ac.at/some/text", "resolved_ip": "1.2.3.4"}
         domain_resolver.process(document)
@@ -199,7 +199,7 @@ sth.ac.at
     def test_invalid_dots_domain_to_ip_produces_warning(self):
         config = deepcopy(self.CONFIG)
         config.update({"tld_list": TLD_LIST})
-        domain_resolver = Factory.create({"test instance": config}, self.logger)
+        domain_resolver = Factory.create({"test instance": config})
 
         assert self.object.metrics.number_of_processed_events == 0
         document = {"url": "google..invalid.de"}

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -403,7 +403,7 @@ class TestGenericAdder(BaseProcessorTestCase):
             config = deepcopy(self.CONFIG)
             config["specific_rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
-            Factory.create(configuration, self.logger)
+            Factory.create(configuration)
 
     def test_add_generic_fields_from_file_invalid(self):
         with pytest.raises(
@@ -413,7 +413,7 @@ class TestGenericAdder(BaseProcessorTestCase):
             config = deepcopy(self.CONFIG)
             config["generic_rules"] = [RULES_DIR_INVALID]
             configuration = {"test processor": config}
-            Factory.create(configuration, self.logger)
+            Factory.create(configuration)
 
 
 class BaseTestGenericAdderSQLTestCase(BaseProcessorTestCase):
@@ -760,9 +760,9 @@ class TestGenericAdderProcessorSQLWithoutAddedTargetAndTableNeverEmpty(
 
         if raised_error:
             with pytest.raises(raised_error[0], match=raised_error[1]):
-                Factory.create({"Test Instance Name": config}, self.logger)
+                Factory.create({"Test Instance Name": config})
         else:
-            Factory.create({"Test Instance Name": config}, self.logger)
+            Factory.create({"Test Instance Name": config})
 
 
 class TestGenericAdderProcessorSQLWithAddedTarget(BaseTestGenericAdderSQLTestCase):

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -451,7 +451,7 @@ class TestGrokker(BaseProcessorTestCase):
         config |= {
             "custom_patterns_dir": "",
         }
-        grokker = Factory.create({"grokker": config}, self.logger)
+        grokker = Factory.create({"grokker": config})
         assert len(grokker.rules) > 0
 
     def test_loads_custom_patterns(self):

--- a/tests/unit/processor/labeler/test_labeler.py
+++ b/tests/unit/processor/labeler/test_labeler.py
@@ -9,10 +9,10 @@ import copy
 import pytest
 from pytest import raises
 
+from logprep.factory import Factory
 from logprep.processor.base.exceptions import ValueDoesnotExistInSchemaError
 from logprep.processor.labeler.labeling_schema import LabelingSchema
 from logprep.processor.labeler.rule import LabelerRule
-from logprep.factory import Factory
 from tests.testdata.metadata import path_to_schema, path_to_schema2
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -239,7 +239,7 @@ class TestLabeler(BaseProcessorTestCase):
             TypeError,
             match="'include_parent_labels' must be <class 'bool'>",
         ):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     def test_create_fails_when_rules_do_not_conform_to_labeling_schema(self):
         config = copy.deepcopy(self.CONFIG)
@@ -247,12 +247,12 @@ class TestLabeler(BaseProcessorTestCase):
         with raises(
             ValueDoesnotExistInSchemaError, match="Invalid value 'windows' for key 'reporter'."
         ):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})
 
     def test_create_loads_the_specified_labeling_schema(self):
         config = copy.deepcopy(self.CONFIG)
         config["schema"] = path_to_schema
         expected_schema = LabelingSchema.create_from_file(path_to_schema)
-        labeler = Factory.create({"test instance": config}, self.logger)
+        labeler = Factory.create({"test instance": config})
 
         assert labeler._schema == expected_schema

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -270,7 +270,7 @@ Hans
             "generic_rules": [],
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
-        processor = Factory.create({"custom_lister": config}, self.logger)
+        processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class._create_from_dict(rule_dict)
         processor._specific_tree.add_rule(rule)
         processor.setup()

--- a/tests/unit/processor/normalizer/test_normalizer.py
+++ b/tests/unit/processor/normalizer/test_normalizer.py
@@ -1110,7 +1110,7 @@ class TestNormalizer(BaseProcessorTestCase):
             {"count_grok_pattern_matches": {"count_directory_path": temp_path, "write_period": 0}}
         )
         processor_config = {"Test Normalizer Name": config}
-        self.object = Factory.create(processor_config, self.logger)
+        self.object = Factory.create(processor_config)
 
         event = {
             "winlog": {

--- a/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
+++ b/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
@@ -747,9 +747,9 @@ class TestPseudonymizer(BaseProcessorTestCase):
         config |= config_change
         if error:
             with pytest.raises(error, match=msg):
-                Factory.create({"name": config}, self.logger)
+                Factory.create({"name": config})
         else:
-            Factory.create({"name": config}, self.logger)
+            Factory.create({"name": config})
 
     @pytest.mark.parametrize("testcase, rule, event, expected, regex_mapping", test_cases)
     def test_testcases(self, testcase, rule, event, expected, regex_mapping):
@@ -762,7 +762,7 @@ class TestPseudonymizer(BaseProcessorTestCase):
     def test_tld_extractor_uses_file(self):
         config = deepcopy(self.CONFIG)
         config["tld_lists"] = [TLD_LIST]
-        object_with_tld_list = Factory.create({"pseudonymizer": config}, self.logger)
+        object_with_tld_list = Factory.create({"pseudonymizer": config})
         assert len(object_with_tld_list._tld_extractor.suffix_list_urls) == 1
         assert object_with_tld_list._tld_extractor.suffix_list_urls[0].endswith(
             "tests/testdata/mock_external/tld_list.dat",

--- a/tests/unit/processor/template_replacer/test_template_replacer.py
+++ b/tests/unit/processor/template_replacer/test_template_replacer.py
@@ -81,7 +81,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
     def test_replace_dotted_message_via_template(self):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
-        self.object = Factory.create({"test instance": config}, self.logger)
+        self.object = Factory.create({"test instance": config})
         document = {
             "winlog": {"channel": "System", "provider_name": "Test", "event_id": 123},
             "dotted": {"message": "foo"},
@@ -96,7 +96,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
     def test_replace_non_existing_dotted_message_via_template(self):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
-        self.object = Factory.create({"test instance": config}, self.logger)
+        self.object = Factory.create({"test instance": config})
         document = {"winlog": {"channel": "System", "provider_name": "Test", "event_id": 123}}
 
         self.object.process(document)
@@ -108,7 +108,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
     def test_replace_partly_existing_dotted_message_via_template(self):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
-        self.object = Factory.create({"test instance": config}, self.logger)
+        self.object = Factory.create({"test instance": config})
         document = {
             "winlog": {"channel": "System", "provider_name": "Test", "event_id": 123},
             "dotted": {"bar": "foo"},
@@ -124,7 +124,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
     def test_replace_existing_dotted_message_dict_via_template(self):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
-        self.object = Factory.create({"test instance": config}, self.logger)
+        self.object = Factory.create({"test instance": config})
         document = {
             "winlog": {"channel": "System", "provider_name": "Test", "event_id": 123},
             "dotted": {"message": {"foo": "bar"}},
@@ -139,7 +139,7 @@ class TestTemplateReplacer(BaseProcessorTestCase):
     def test_replace_incompatible_existing_dotted_message_parent_via_template(self, caplog):
         config = deepcopy(self.CONFIG)
         config.get("pattern").update({"target_field": "dotted.message"})
-        self.object = Factory.create({"test instance": config}, self.logger)
+        self.object = Factory.create({"test instance": config})
         document = {
             "winlog": {"channel": "System", "provider_name": "Test", "event_id": 123},
             "dotted": "foo",
@@ -155,4 +155,4 @@ class TestTemplateReplacer(BaseProcessorTestCase):
             {"template": "tests/testdata/unit/template_replacer/replacer_template_invalid.yml"}
         )
         with pytest.raises(TemplateReplacerError, match="Not enough delimiters"):
-            Factory.create({"test instance": config}, self.logger)
+            Factory.create({"test instance": config})

--- a/tests/unit/processor/test_process.py
+++ b/tests/unit/processor/test_process.py
@@ -1,7 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import re
-from logging import getLogger
 from unittest import mock
 from unittest.mock import call
 
@@ -23,8 +21,7 @@ class TestSpecificGenericProcessStrategy:
                     "generic_rules": [],
                     "specific_rules": [],
                 }
-            },
-            mock.MagicMock(),
+            }
         )
         processor.process({})
         mock_process_rule_tree.assert_called()
@@ -39,8 +36,7 @@ class TestSpecificGenericProcessStrategy:
                     "generic_rules": [],
                     "specific_rules": [],
                 }
-            },
-            mock.MagicMock(),
+            }
         )
         processor.process({})
         assert mock_process_rule_tree.call_count == 2
@@ -57,7 +53,7 @@ class TestSpecificGenericProcessStrategy:
             "generic_rules": [],
             "apply_multiple_times": True,
         }
-        processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
+        processor = Factory.create({"custom_lister": config})
         rule_one_dict = {
             "filter": "message",
             "dissector": {"mapping": {"message": "%{time} [%{protocol}] %{url}"}},
@@ -84,7 +80,7 @@ class TestSpecificGenericProcessStrategy:
 
     def test_apply_processor_multiple_times_not_enabled(self):
         config = {"type": "dissector", "specific_rules": [], "generic_rules": []}
-        processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
+        processor = Factory.create({"custom_lister": config})
         rule_one_dict = {
             "filter": "message",
             "dissector": {"mapping": {"message": "%{time} [%{protocol}] %{url}"}},
@@ -110,7 +106,7 @@ class TestSpecificGenericProcessStrategy:
     @pytest.mark.parametrize("execution_number", range(5))  # repeat test to ensure determinism
     def test_strategy_applies_rules_in_deterministic_order(self, execution_number):
         config = {"type": "generic_adder", "specific_rules": [], "generic_rules": []}
-        processor = Factory.create({"custom_lister": config}, getLogger("test-logger"))
+        processor = Factory.create({"custom_lister": config})
         rule_one_dict = {"filter": "val", "generic_adder": {"add": {"some": "value"}}}
         rule_two_dict = {"filter": "NOT something", "generic_adder": {"add": {"something": "else"}}}
         rule_one = GenericAdderRule._create_from_dict(rule_one_dict)

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -54,7 +54,7 @@ logger = getLogger()
 def test_create_from_dict_validates_config(configs, error, message):
     for config in configs:
         with raises(error) as exception_info:
-            Factory.create(config, logger)
+            Factory.create(config)
         value = str(exception_info.value)
         assertion_error_message = (
             f'Error message of "{error.__name__}" did not match regex for test input '
@@ -69,7 +69,7 @@ def test_create_fails_for_unknown_type():
         "".join(sample(ascii_letters, 6)) for i in range(5)
     ]:
         with raises(UnknownComponentTypeError):
-            Factory.create({"processorname": {"type": type_name}}, logger)
+            Factory.create({"processorname": {"type": type_name}})
 
 
 def test_create_pseudonymizer_returns_pseudonymizer_processor():
@@ -87,7 +87,6 @@ def test_create_pseudonymizer_returns_pseudonymizer_processor():
                 "max_cached_pseudonyms": 1000000,
             }
         },
-        logger,
     )
 
     assert isinstance(processor, Pseudonymizer)
@@ -103,7 +102,6 @@ def test_create_clusterer_returns_clusterer_processor():
                 "generic_rules": ["tests/testdata/unit/clusterer/rules/generic"],
             }
         },
-        logger,
     )
 
     assert isinstance(processor, Clusterer)
@@ -115,7 +113,7 @@ def test_fails_when_section_contains_more_than_one_element():
         match=r"Found multiple component definitions \(first, second\), "
         r"but there must be exactly one\.",
     ):
-        Factory.create({"first": mock.MagicMock(), "second": mock.MagicMock()}, logger)
+        Factory.create({"first": mock.MagicMock(), "second": mock.MagicMock()})
 
 
 def test_create_labeler_creates_labeler_processor():
@@ -128,7 +126,6 @@ def test_create_labeler_creates_labeler_processor():
                 "specific_rules": [path_to_single_rule],
             }
         },
-        logger,
     )
 
     assert isinstance(processor, Labeler)
@@ -153,7 +150,6 @@ def test_creates_calculator_with_inline_rules():
                 ],
             }
         },
-        logger,
     )
     assert len(processor._generic_rules) == 1
     assert len(processor._specific_rules) == 1
@@ -180,7 +176,6 @@ def test_creates_calculator_with_inline_rules_and_files():
                 ],
             }
         },
-        logger,
     )
     assert len(processor._generic_rules) == 2
     assert len(processor._specific_rules) == 2
@@ -209,7 +204,6 @@ def test_creates_calculator_with_inline_rules_and_file_and_directory():
                 ],
             }
         },
-        logger,
     )
     assert len(processor._generic_rules) == 2
     assert len(processor._specific_rules) == 2
@@ -218,7 +212,6 @@ def test_creates_calculator_with_inline_rules_and_file_and_directory():
 def test_dummy_input_creates_dummy_input_connector():
     processor = Factory.create(
         {"labelername": {"type": "dummy_input", "documents": [{}, {}]}},
-        logger,
     )
 
     assert isinstance(processor, Input)

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -12,7 +12,7 @@ class TestQuickstart:
 
     def test_validity_of_quickstart_config(self):
         config = Configuration().create_from_yaml(self.QUICKSTART_CONFIG_PATH)
-        config.verify(getLogger("test-logger"))
+        config.verify()
 
     def test_quickstart_rules_are_valid(self):
         """ensures the quickstart rules are valid"""

--- a/tests/unit/util/test_auto_rule_tester.py
+++ b/tests/unit/util/test_auto_rule_tester.py
@@ -153,9 +153,7 @@ class TestAutoRuleTester:
             "max_cached_pseudonyms": 1000000,
         }
         mock_replace_regex_keywords_by_regex_expression.assert_not_called()
-        processor = auto_rule_tester._get_processor_instance(
-            "pseudonymizer", pseudonymizer_cfg, LOGGER
-        )
+        processor = auto_rule_tester._get_processor_instance("pseudonymizer", pseudonymizer_cfg)
         auto_rule_tester._reset_trees(
             processor
         )  # Called every time by auto tester before adding rules
@@ -175,9 +173,7 @@ class TestAutoRuleTester:
             "list_search_base_path": "tests/testdata/unit/list_comparison/rules",
         }
         mock_setup.assert_not_called()
-        processor = auto_rule_tester._get_processor_instance(
-            "list_comparison", list_comparison_cfg, LOGGER
-        )
+        processor = auto_rule_tester._get_processor_instance("list_comparison", list_comparison_cfg)
         auto_rule_tester._reset_trees(
             processor
         )  # Called every time by auto tester before adding rules instead

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -57,7 +57,7 @@ class TestConfiguration:
         parent[key] = value
 
         with pytest.raises(InvalidConfigurationError, match=expected_message):
-            config.verify(logger)
+            config.verify()
 
     @mock.patch("logprep.util.configuration.print_fcolor")
     def test_invalid_yml_prints_formatted_error(self, mock_print_fcolor, tmp_path):
@@ -71,13 +71,13 @@ class TestConfiguration:
 
     def test_verify_passes_for_valid_configuration(self):
         try:
-            self.config.verify(logger)
+            self.config.verify()
         except InvalidConfigurationError as error:
             pytest.fail(f"The verification should pass for a valid configuration.: {error}")
 
     def test_verify_pipeline_only_passes_for_valid_configuration(self):
         try:
-            self.config.verify_pipeline_only(logger)
+            self.config.verify_pipeline_only()
         except InvalidConfigurationError:
             pytest.fail("The verification should pass for a valid configuration.")
 
@@ -90,18 +90,18 @@ class TestConfiguration:
             del config[key]
 
             with pytest.raises(InvalidConfigurationError):
-                config.verify(logger)
+                config.verify()
 
     def test_verify_pipeline_only_fails_on_missing_pipeline_value(self):
         for key in list(key for key in self.config.keys() if key != "pipeline"):
             config = deepcopy(self.config)
             del config[key]
-            config.verify_pipeline_only(logger)
+            config.verify_pipeline_only()
 
         config = deepcopy(self.config)
         del config["pipeline"]
         with pytest.raises(InvalidConfigurationError):
-            config.verify(logger)
+            config.verify()
 
     def test_verify_fails_on_low_process_count(self):
         for i in range(0, -10, -1):
@@ -369,7 +369,7 @@ class TestConfiguration:
         config.update(config_dict)
         if raised_errors is not None:
             with pytest.raises(InvalidConfigurationErrors) as e_info:
-                config.verify(logger)
+                config.verify()
             errors_set = [(type(err), str(err)) for err in e_info.value.errors]
             assert len(raised_errors) == len(errors_set), test_case
             zipped_errors = zip(raised_errors, errors_set)
@@ -495,7 +495,7 @@ class TestConfiguration:
         config = deepcopy(self.config)
         config.update(config_dict)
         if raised_errors is not None:
-            errors = config._check_for_errors(logger)
+            errors = config._check_for_errors()
             collected_errors = []
             for error in errors:
                 collected_errors += error.errors
@@ -514,7 +514,7 @@ class TestConfiguration:
         with pytest.raises(
             RequiredConfigurationKeyMissingError, match="Required option is missing: input"
         ):
-            config._verify_input(logger)
+            config._verify_input()
 
     def test_verify_input_raises_type_error(self):
         config = deepcopy(self.config)
@@ -526,7 +526,7 @@ class TestConfiguration:
                 + "'topic'."
             ),
         ):
-            config._verify_input(logger)
+            config._verify_input()
 
     def test_verify_output_raises_missing_output_key(self):
         config = deepcopy(self.config)
@@ -534,7 +534,7 @@ class TestConfiguration:
         with pytest.raises(
             RequiredConfigurationKeyMissingError, match="Required option is missing: output"
         ):
-            config._verify_output(logger)
+            config._verify_output()
 
     def test_patch_yaml_with_json_connectors_inserts_json_input_connector(self, tmp_path):
         regular_config = GetterFactory.from_string(path_to_config).get_yaml()
@@ -659,7 +659,7 @@ output:
             "LOGPREP_INPUT"
         ] = "input:\n    kafka:\n        type: confluentkafka_input\n        topic: consumer\n        kafka_config:\n          bootstrap.servers: localhost:9092\n          group.id: testgroup\n"
         config = Configuration.create_from_yaml(str(config_path))
-        config.verify(mock.MagicMock())
+        config.verify()
 
     def test_config_gets_enriched_by_environment_with_non_existent_variable(self, tmp_path):
         config_path = tmp_path / "pipeline.yml"
@@ -715,7 +715,7 @@ output:
             InvalidConfigurationErrors,
             match=r"Environment variable\(s\) used, but not set: LOGPREP_I_DO_NOT_EXIST",
         ):
-            config.verify(mock.MagicMock())
+            config.verify()
 
     def test_verifies_processor_configs_against_defined_outputs(self):
         config = Configuration()
@@ -752,7 +752,7 @@ output:
         ]
         config.update({"pipeline": pipeline, "output": {}})
         with pytest.raises(InvalidConfigurationErrors) as raised:
-            config._verify_pipeline(logger=logger)
+            config._verify_pipeline()
         assert len(raised.value.errors) == 3
         for error in raised.value.errors:
             assert "output 'kafka' does not exist in logprep outputs" in error.args[0]
@@ -772,7 +772,7 @@ output:
         ]
         config.update({"pipeline": pipeline, "output": {}})
         try:
-            config.verify_pipeline_without_processor_outputs(logger=logger)
+            config.verify_pipeline_without_processor_outputs()
         except InvalidConfigurationErrors as error:
             assert False, f"Shouldn't raise output does not exist error: '{error}'"
 
@@ -804,7 +804,7 @@ output:
         ]
         config.update({"pipeline": pipeline, "output": {}})
         with pytest.raises(InvalidConfigurationErrors) as raised:
-            config._verify_pipeline(logger=logger)
+            config._verify_pipeline()
         assert len(raised.value.errors) == 1
         for error in raised.value.errors:
             assert "Duplicate rule id: same id" in error.args[0]
@@ -838,7 +838,7 @@ output:
         ]
         config.update({"pipeline": pipeline, "output": {}})
         with pytest.raises(InvalidConfigurationErrors) as raised:
-            config._verify_pipeline(logger=logger)
+            config._verify_pipeline()
         assert len(raised.value.errors) == 1
         for error in raised.value.errors:
             assert "Duplicate rule id: same id" in error.args[0]


### PR DESCRIPTION
this removes the logger parameter from `Factory.create` method, because it is not needed.
