### PR TITLE
Fix handling of `CriticalInputError` exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bugfix
 
 * make the s3 connector actually use the `max_retries` parameter
+* fixed a bug which leads to a `FatalOutputError` on handling `CriticalInputError` in pipeline
 
 ## v9.0.3
 ### Breaking

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -58,7 +58,7 @@ def _handle_pipeline_error(func):
             self.logger.error(str(error))
             self.stop()
         except CriticalInputError as error:
-            if raw_input := error.raw_input and self._output:  # pylint: disable=protected-access
+            if (raw_input := error.raw_input) and self._output:  # pylint: disable=protected-access
                 for _, output in self._output.items():  # pylint: disable=protected-access
                     if output.default:
                         output.store_failed(str(self), raw_input, {})

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -291,6 +291,9 @@ class TestPipeline(ConfigurationForTests):
             str(CriticalInputError(self.pipeline._input, "mock input error", input_event))
         )
         assert self.pipeline._output["dummy"].store_failed.call_count == 1, "one error is stored"
+        self.pipeline._output["dummy"].store_failed.assert_called_with(
+            str(self.pipeline), input_event, {}
+        )
         assert self.pipeline._output["dummy"].store.call_count == 0, "no event is stored"
 
     @mock.patch("logging.Logger.warning")


### PR DESCRIPTION
This PR fixes an error in the `_handle_pipeline_error()` function that leads to `FatalOutputError` when `CriticalInputError` exceptions are handled.