### PR TITLE
Set no offsets on store custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * make the s3 connector raise `FatalOutputError` instead of warnings
 * make the s3 connector blocking by removing threading
 * revert the change from v9.0.0 to always check the existence of a field for negated key-value based lucene filter expressions
+* make store_custom in s3, opensearch and elasticsearch connector not call `batch_finished_callback` to prevent data loss that could be caused by partially processed events
 
 ### Bugfix
 

--- a/logprep/connector/elasticsearch/output.py
+++ b/logprep/connector/elasticsearch/output.py
@@ -237,6 +237,7 @@ class ElasticsearchOutput(Output):
         """
         document["_index"] = target
         self._add_dates(document)
+        self.metrics.number_of_processed_events += 1
         self._message_backlog.append(document)
 
     def store_failed(self, error_message: str, document_received: dict, document_processed: dict):

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -137,7 +137,6 @@ class S3Output(Output):
     def __init__(self, name: str, configuration: "S3Output.Config", logger: Logger):
         super().__init__(name, configuration, logger)
         self._message_backlog = defaultdict(list)
-        self._writing_thread = None
         self._base_prefix = f"{self._config.base_prefix}/" if self._config.base_prefix else ""
         self._s3_resource = None
         self._setup_s3_resource()

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -293,6 +293,7 @@ class S3Output(Output):
             Prefix for the document.
 
         """
+        self.metrics.number_of_processed_events += 1
         self._add_to_backlog(document, target)
 
     def store_failed(self, error_message: str, document_received: dict, document_processed: dict):

--- a/tests/unit/connector/test_elasticsearch_output.py
+++ b/tests/unit/connector/test_elasticsearch_output.py
@@ -138,7 +138,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     ):
         self.object._config.message_backlog_size = 1
         self.object._handle_serialization_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_serialization_error.assert_called()
 
     @mock.patch(
@@ -148,7 +149,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_connection_error_if_connection_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_connection_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_connection_error.assert_called()
 
     @mock.patch(
@@ -158,7 +160,8 @@ class TestElasticsearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_bulk_index_error_if_bulk_index_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_bulk_index_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_bulk_index_error.assert_called()
 
     @mock.patch("elasticsearch.helpers.bulk")

--- a/tests/unit/connector/test_opensearch_output.py
+++ b/tests/unit/connector/test_opensearch_output.py
@@ -152,7 +152,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     ):
         self.object._config.message_backlog_size = 1
         self.object._handle_serialization_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_serialization_error.assert_called()
 
     @mock.patch(
@@ -162,7 +163,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_connection_error_if_connection_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_connection_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_connection_error.assert_called()
 
     @mock.patch(
@@ -172,7 +174,8 @@ class TestOpenSearchOutput(BaseOutputTestCase):
     def test_write_to_search_context_calls_handle_bulk_index_error_if_bulk_index_error(self, _):
         self.object._config.message_backlog_size = 1
         self.object._handle_bulk_index_error = mock.MagicMock()
-        self.object._write_to_search_context({"dummy": "event"})
+        self.object._message_backlog.append({"dummy": "event"})
+        self.object._write_to_search_context()
         self.object._handle_bulk_index_error.assert_called()
 
     @mock.patch("opensearchpy.helpers.parallel_bulk")

--- a/tests/unit/connector/test_s3_output.py
+++ b/tests/unit/connector/test_s3_output.py
@@ -206,26 +206,22 @@ class TestS3Output(BaseOutputTestCase):
         # Backlog not full
         for idx in range(message_backlog_size - 1):
             s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-            self._wait_for_writing_thread(s3_output)
             assert self._calculate_backlog_size(s3_output) == idx + 1
         s3_output._write_document_batch.assert_not_called()
 
         # Backlog full then cleared
         s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-        self._wait_for_writing_thread(s3_output)
         s3_output._write_document_batch.assert_called_once()
         assert self._calculate_backlog_size(s3_output) == 0
 
         # Backlog not full
         for idx in range(message_backlog_size - 1):
             s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-            self._wait_for_writing_thread(s3_output)
             assert self._calculate_backlog_size(s3_output) == idx + 1
         s3_output._write_document_batch.assert_called_once()
 
         # Backlog full then cleared
         s3_output._write_to_s3_resource({"dummy": "event"}, "write_to_s3")
-        self._wait_for_writing_thread(s3_output)
         assert s3_output._write_document_batch.call_count == 2
         assert self._calculate_backlog_size(s3_output) == 0
 
@@ -237,7 +233,6 @@ class TestS3Output(BaseOutputTestCase):
         self.object._s3_resource = mock.MagicMock()
         self.object.input_connector = mock.MagicMock()
         self.object.store({"message": "my event message"})
-        self._wait_for_writing_thread(self.object)
         self.object.input_connector.batch_finished_callback.assert_called()
 
     def test_store_does_not_call_batch_finished_callback_if_disabled(self):
@@ -269,11 +264,6 @@ class TestS3Output(BaseOutputTestCase):
     def test_store_failed_counts_failed_events(self):
         self.object._write_backlog = mock.MagicMock()
         super().test_store_failed_counts_failed_events()
-
-    @staticmethod
-    def _wait_for_writing_thread(s3_output):
-        if s3_output._writing_thread is not None:
-            s3_output._writing_thread.join()
 
     @staticmethod
     def _calculate_backlog_size(s3_output):


### PR DESCRIPTION
Make `store_custom` in s3, opensearch and elasticsearch connector not call `batch_finished_callback` to prevent data loss that could be caused by partially processed events.