### PR TITLE
Add multiple auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create SHA_SHORT Env
+        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
       - name: Build images
         uses: docker/build-push-action@v3
         with:
@@ -184,3 +187,4 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${SHORT_SHA}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set outputs
-        id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: Build images
         uses: docker/build-push-action@v3
         with:
@@ -188,4 +184,3 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create SHA_SHORT Env
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+#      - name: Create SHA_SHORT Env
+#        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
 
       - name: Build images
         uses: docker/build-push-action@v3
@@ -187,4 +187,4 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ SHORT_SHA }}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ GITHUB_SHA::8 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,4 +187,4 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${SHORT_SHA}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ SHORT_SHA }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Create SHA_SHORT Env
-#        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build images
         uses: docker/build-push-action@v3
@@ -187,4 +188,4 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ github.sha::8 }}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,4 +187,4 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ GITHUB_SHA::8 }}
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}-${{ github.sha::8 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * add possibility to define multiple oauth tokens by just appending an index to the env like
 `LOGPREP_CONFIG_AUTH_TOKEN_0`, `LOGPREP_CONFIG_AUTH_TOKEN_1`. The index has to be strictly
 monotonously rising.
-* add `SHORT_SHA` to logprep container images in CI-Pipeline
 
 ### Bugfix
 * fix loading of configuration inside the `AutoRuleCorpusTester` for `logprep test integration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Features
 
 ### Improvements
+* add possibility to define multiple oauth tokens by just appending an index to the env like
+`LOGPREP_CONFIG_AUTH_TOKEN_0`, `LOGPREP_CONFIG_AUTH_TOKEN_1`. The index has to be strictly
+monotonously rising.
 
 ### Bugfix
 * fix loading of configuration inside the `AutoRuleCorpusTester` for `logprep test integration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * add possibility to define multiple oauth tokens by just appending an index to the env like
 `LOGPREP_CONFIG_AUTH_TOKEN_0`, `LOGPREP_CONFIG_AUTH_TOKEN_1`. The index has to be strictly
 monotonously rising.
+* add `SHORT_SHA` to logprep container images in CI-Pipeline
 
 ### Bugfix
 * fix loading of configuration inside the `AutoRuleCorpusTester` for `logprep test integration`

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -108,8 +108,8 @@ class HttpGetter(Getter):
         * :code:`LOGPREP_CONFIG_AUTH_METHOD=oauth`
 
     If you want to load multiple resources from different sources you can set multiple auth tokens
-    by appending a strictly monotonously rising index to the variable. For example by using
-    :code:`LOGPREP_CONFIG_AUTH_TOKEN_0`, :code:`LOGPREP_CONFIG_AUTH_TOKEN_1`,
+    by appending a strictly monotonously rising index to the variable, starting with zero. For
+    example by using :code:`LOGPREP_CONFIG_AUTH_TOKEN_0`, :code:`LOGPREP_CONFIG_AUTH_TOKEN_1`,
     :code:`LOGPREP_CONFIG_AUTH_TOKEN_2`, etc. Logprep always tries to use all token until one is
     successful.
     """

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -143,7 +143,8 @@ class HttpGetter(Getter):
             if token := os.environ.get("LOGPREP_CONFIG_AUTH_TOKEN"):
                 self._tokens.append(token)
             for token_index in count(start=0, step=1):
-                if token := os.environ.get(f"LOGPREP_CONFIG_AUTH_TOKEN_{token_index}"):
+                token = os.environ.get(f"LOGPREP_CONFIG_AUTH_TOKEN_{token_index}")
+                if token is not None:
                     self._tokens.append(token)
                     continue
                 break

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -168,7 +168,7 @@ class HttpGetter(Getter):
         resp = None
         while resp is None:
             try:
-                if not self._found_valid_token:
+                if not self._found_valid_token and self._tokens:
                     resp = self._search_for_valid_token(session, url)
                 else:
                     resp = self._execute_request(session, url)

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -182,10 +182,13 @@ class HttpGetter(Getter):
     def _search_for_valid_token(self, session: Session, url: str) -> [Response, None]:
         for token in self._tokens:
             self._headers.update({"Authorization": f"Bearer {token}"})
-            resp = self._execute_request(session, url)
-            if resp is not None and resp.status_code == 200:
-                self._found_valid_token = True
-                return resp
+            try:
+                resp = self._execute_request(session, url)
+                resp.raise_for_status()
+            except requests.HTTPError:
+                continue
+            self._found_valid_token = True
+            return resp
         return None
 
     def _execute_request(self, session: Session, url: str) -> [Response, None]:

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -90,23 +90,28 @@ class FileGetter(Getter):
 
 @define(kw_only=True)
 class HttpGetter(Getter):
-    """get files from an api or simple web server.
+    """Get files from an api or simple web server.
 
     Matching string examples:
 
     * Simple http target: :code:`http://your.target/file.yml`
     * Simple https target: :code:`https://your.target/file.json`
 
-    if you want to use basic auth, then you have to set the environment variables
+    If you want to use basic auth, then you have to set the environment variables:
 
         * :code:`LOGPREP_CONFIG_AUTH_USERNAME=<your_username>`
         * :code:`LOGPREP_CONFIG_AUTH_PASSWORD=<your_password>`
 
-    if you want to use oauth, then you have to set the environment variables
+    If you want to use oauth, then you have to set the environment variables:
 
         * :code:`LOGPREP_CONFIG_AUTH_TOKEN=<your_token>`
         * :code:`LOGPREP_CONFIG_AUTH_METHOD=oauth`
 
+    If you want to load multiple resources from different sources you can set multiple auth tokens
+    by appending a strictly monotonously rising index to the variable. For example by using
+    :code:`LOGPREP_CONFIG_AUTH_TOKEN_0`, :code:`LOGPREP_CONFIG_AUTH_TOKEN_1`,
+    :code:`LOGPREP_CONFIG_AUTH_TOKEN_2`, etc. Logprep always tries to use all token until one is
+    successful.
     """
 
     _sessions: dict = {}

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -171,12 +171,7 @@ class HttpGetter(Getter):
                 if not self._found_valid_token:
                     resp = self._search_for_valid_token(session, url)
                 else:
-                    resp = session.get(
-                        url=url,
-                        timeout=5,
-                        allow_redirects=True,
-                        headers=self._headers,
-                    )
+                    resp = self._execute_request(session, url)
             except requests.exceptions.RequestException as error:
                 retries -= 1
                 if retries == 0:
@@ -187,13 +182,11 @@ class HttpGetter(Getter):
     def _search_for_valid_token(self, session: Session, url: str) -> [Response, None]:
         for token in self._tokens:
             self._headers.update({"Authorization": f"Bearer {token}"})
-            resp = session.get(
-                url=url,
-                timeout=5,
-                allow_redirects=True,
-                headers=self._headers,
-            )
+            resp = self._execute_request(session, url)
             if resp is not None and resp.status_code == 200:
                 self._found_valid_token = True
                 return resp
         return None
+
+    def _execute_request(self, session: Session, url: str) -> [Response, None]:
+        return session.get(url=url, timeout=5, allow_redirects=True, headers=self._headers)

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -413,7 +413,7 @@ class TestHttpGetter:
         responses.assert_call_count("https://does-not-matter", 3)
 
     @responses.activate
-    def test_get_finds_correct_auth_token_if_multiple_are_given(self):
+    def test_get_finds_correct_auth_token_if_multiple_were_given(self):
         mock_env = {
             "LOGPREP_CONFIG_AUTH_METHOD": "oauth",
             "LOGPREP_CONFIG_AUTH_TOKEN_0": "ajhsdfpoweiurjdfs239487_01",

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -9,8 +9,8 @@ from unittest import mock
 
 import pytest
 import responses
+from requests import Timeout
 from requests.auth import HTTPBasicAuth
-from requests.exceptions import Timeout
 from responses import matchers
 from ruamel.yaml import YAML
 
@@ -430,26 +430,26 @@ class TestHttpGetter:
             "Authorization": "Bearer ajhsdfpoweiurjdfs239487_01",
         }
         responses.get(
-            url="https://the.target.url/targetfile",
+            url="https://test.url/targetfile",
             match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status unauthorized",
             status=401,
         )
         header.update({"Authorization": "Bearer ajhsdfpoweiurjdfs239487_02"})
         responses.get(
-            url="https://the.target.url/targetfile",
+            url="https://test.url/targetfile",
             match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status unauthorized",
             status=401,
         )
         header.update({"Authorization": "Bearer ajhsdfpoweiurjdfs239487_03"})
         responses.get(
-            url="https://the.target.url/targetfile",
+            url="https://test.url/targetfile",
             match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status success",
             status=200,
         )
         with mock.patch.dict("os.environ", mock_env):
-            http_getter = GetterFactory.from_string("https://the.target.url/targetfile")
+            http_getter = GetterFactory.from_string("https://test.url/targetfile")
             file_content = http_getter.get()
         assert file_content == "status success"

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -422,54 +422,30 @@ class TestHttpGetter:
         }
 
         logprep_version = get_versions().get("version")
+        header = {
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+            "User-Agent": f"Logprep version {logprep_version}",
+            "Authorization": "Bearer ajhsdfpoweiurjdfs239487_01",
+        }
         responses.get(
             url="https://the.target.url/targetfile",
-            match=[
-                matchers.header_matcher(
-                    {
-                        "Accept": "*/*",
-                        "Accept-Encoding": "gzip, deflate",
-                        "Connection": "keep-alive",
-                        "User-Agent": f"Logprep version {logprep_version}",
-                        "Authorization": "Bearer ajhsdfpoweiurjdfs239487_01",
-                    },
-                    strict_match=True,
-                )
-            ],
+            match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status unauthorized",
             status=401,
         )
+        header.update({"Authorization": "Bearer ajhsdfpoweiurjdfs239487_02"})
         responses.get(
             url="https://the.target.url/targetfile",
-            match=[
-                matchers.header_matcher(
-                    {
-                        "Accept": "*/*",
-                        "Accept-Encoding": "gzip, deflate",
-                        "Connection": "keep-alive",
-                        "User-Agent": f"Logprep version {logprep_version}",
-                        "Authorization": "Bearer ajhsdfpoweiurjdfs239487_02",
-                    },
-                    strict_match=True,
-                )
-            ],
+            match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status unauthorized",
             status=401,
         )
+        header.update({"Authorization": "Bearer ajhsdfpoweiurjdfs239487_03"})
         responses.get(
             url="https://the.target.url/targetfile",
-            match=[
-                matchers.header_matcher(
-                    {
-                        "Accept": "*/*",
-                        "Accept-Encoding": "gzip, deflate",
-                        "Connection": "keep-alive",
-                        "User-Agent": f"Logprep version {logprep_version}",
-                        "Authorization": "Bearer ajhsdfpoweiurjdfs239487_03",
-                    },
-                    strict_match=True,
-                )
-            ],
+            match=[matchers.header_matcher(header.copy(), strict_match=True)],
             body="status success",
             status=200,
         )


### PR DESCRIPTION
Adds the option to use multiple auth token when using the `oauth` authentication method. Additionally, this pull request adds a short SHA to the container images.

## ToDos:
- [x] implement search for correct token
- [x] add test for getter
- [x] fix test pollution in `test_getter.py`
- [x] ~add SHA to CI Pipeline~ (removed short sha from tag again, as it spams the registry)