### PR TITLE
fix merge of version string for multiple configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * fix version string of release versions
 * fix version string of container builds for feature branches
+* fix merge of config versions for multiple configs
 
 
 ## v10.0.4

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -491,7 +491,7 @@ class Configuration:
             raise InvalidConfigurationErrors(errors)
 
     def _set_attributes_from_configs(self) -> None:
-        exclude_attrs = ("pipeline", "version")
+        exclude_attrs = "version"
         for attribute in filter(
             lambda x: x.repr and x.name not in exclude_attrs, self.__attrs_attrs__
         ):

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -491,10 +491,7 @@ class Configuration:
             raise InvalidConfigurationErrors(errors)
 
     def _set_attributes_from_configs(self) -> None:
-        exclude_attrs = "version"
-        for attribute in filter(
-            lambda x: x.repr and x.name not in exclude_attrs, self.__attrs_attrs__
-        ):
+        for attribute in filter(lambda x: x.repr and x.name, self.__attrs_attrs__):
             setattr(
                 self,
                 attribute.name,

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -491,12 +491,17 @@ class Configuration:
             raise InvalidConfigurationErrors(errors)
 
     def _set_attributes_from_configs(self) -> None:
-        for attribute in filter(lambda x: x.repr, self.__attrs_attrs__):
+        exclude_attrs = ("pipeline", "version")
+        for attribute in filter(
+            lambda x: x.repr and x.name not in exclude_attrs, self.__attrs_attrs__
+        ):
             setattr(
                 self,
                 attribute.name,
                 self._get_last_non_falsy_value(self._configs, attribute.name),
             )
+        versions = (config.version for config in self._configs if config.version)
+        self.version = ", ".join(versions)
 
     def _build_merged_pipeline(self):
         pipelines = (config.pipeline for config in self._configs if config.pipeline)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -491,7 +491,7 @@ class Configuration:
             raise InvalidConfigurationErrors(errors)
 
     def _set_attributes_from_configs(self) -> None:
-        for attribute in filter(lambda x: x.repr and x.name, self.__attrs_attrs__):
+        for attribute in filter(lambda x: x.repr, self.__attrs_attrs__):
             setattr(
                 self,
                 attribute.name,

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -1115,6 +1115,20 @@ output:
             ):
                 config._verify_environment()
 
+    def test_versions_are_aggregated_for_multiple_configs(self, config_path, tmp_path):
+        config1 = Configuration.from_sources([str(config_path)])
+        config1.version = "first"
+        config1_path = tmp_path / "config1.yml"
+        config1_path.write_text(config1.as_yaml())
+
+        config2 = Configuration.from_sources([str(config_path)])
+        config2.version = "second"
+        config2_path = tmp_path / "config2.yml"
+        config2_path.write_text(config2.as_yaml())
+
+        config = Configuration.from_sources([str(config1_path), str(config2_path)])
+        assert config.version == "first, second"
+
 
 class TestInvalidConfigurationErrors:
     @pytest.mark.parametrize(

--- a/tests/unit/util/test_helper.py
+++ b/tests/unit/util/test_helper.py
@@ -14,7 +14,7 @@ from logprep.util.helper import (
     snake_to_camel,
 )
 from logprep.util.json_handling import is_json
-from tests.testdata.metadata import path_to_alternative_config, path_to_config
+from tests.testdata.metadata import path_to_config
 
 
 class TestCamelToSnake:
@@ -256,7 +256,7 @@ class TestGetVersionString:
         expected_pattern = (
             r"python version:\s+3\.\d+\.\d+\n"
             r"logprep version:\s+[^\s]+\n"
-            r"configuration version:\s+1,\s+file://[^\s]+/config\.yml,\s+file://[^\s]+/config\.yml"
+            r"configuration version:\s+1,\s1,\s+file://[^\s]+/config\.yml,\s+file://[^\s]+/config\.yml"
         )
 
         result = get_versions_string(config)


### PR DESCRIPTION
This PR fixes the version generation for multiple configs.

the resulting configuration version is now concatenated in the same order as the configs were given.