### PR TITLE
fix http connector only first process working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bugfix
 
+* fix a bug in http connector leading to only first process working
+
 ## 11.0.1
 ### Bugfix
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -119,7 +119,7 @@ class HttpEndpoint(ABC):
 
     Parameters
     ----------
-    messages: queue.Queue
+    messages: mp.Queue
         Input Events are put here
     collect_meta: bool
         Collects Metadata on True (default)
@@ -127,7 +127,7 @@ class HttpEndpoint(ABC):
         Defines key name for metadata
     """
 
-    def __init__(self, messages: queue.Queue, collect_meta: bool, metafield_name: str) -> None:
+    def __init__(self, messages: mp.Queue, collect_meta: bool, metafield_name: str) -> None:
         self.messages = messages
         self.collect_meta = collect_meta
         self.metafield_name = metafield_name
@@ -370,8 +370,7 @@ class HttpConnector(Input):
         self.logger = logger
         self.port = self._config.uvicorn_config["port"]
         self.host = self._config.uvicorn_config["host"]
-        self.target = "http://" + self.host + ":" + str(self.port)
-        self.messages.maxsize = self._config.message_backlog_size
+        self.target = f"http://{self.host}:{self.port}"
 
     def setup(self):
         """setup starts the actual functionality of this connector.

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -11,7 +11,7 @@ import logging.handlers
 import multiprocessing
 
 # pylint: disable=logging-fstring-interpolation
-import queue
+import multiprocessing.queues
 import warnings
 from ctypes import c_bool
 from functools import cached_property, partial
@@ -307,7 +307,7 @@ class Pipeline:
     def _drain_input_queues(self) -> None:
         if not hasattr(self._input, "messages"):
             return
-        if isinstance(self._input.messages, queue.Queue):
+        if isinstance(self._input.messages, multiprocessing.queues.Queue):
             while self._input.messages.qsize():
                 self.process_pipeline()
 

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -77,11 +77,13 @@ class PipelineManager:
             self.prometheus_exporter = PrometheusExporter(prometheus_config)
         else:
             self.prometheus_exporter = None
-        if configuration.input.get("type") == "http_input":
+        input_config = next(iter(configuration.input.values()))
+        if input_config.get("type") == "http_input":
             # this workaround has to be done because the queue size is not configurable
             # after initialization and the queue has to be shared between the multiple processes
-            message_backlog_size = configuration.input.get("message_backlog_size", 15000)
-            HttpConnector.messages = multiprocessing.Queue(maxsize=message_backlog_size)
+            if HttpConnector.messages is None:
+                message_backlog_size = input_config.get("message_backlog_size", 15000)
+                HttpConnector.messages = multiprocessing.Queue(maxsize=message_backlog_size)
 
     def get_count(self) -> int:
         """Get the pipeline count.

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -1,6 +1,9 @@
 version: 1
 process_count: 2
 
+logger:
+  level: DEBUG
+
 metrics:
   enabled: true
   port: 8003

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -7,7 +7,7 @@ metrics:
 input:
   httpinput:
       type: http_input
-      message_backlog_size: 1500000
+      message_backlog_size: 1500
       collect_meta: True
       metafield_name: "@metadata"
       uvicorn_config:

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
 import multiprocessing
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 
 import falcon
@@ -18,12 +17,12 @@ from tests.unit.connector.base import BaseInputTestCase
 class TestHttpConnector(BaseInputTestCase):
 
     def setup_method(self):
+        HttpConnector.messages = multiprocessing.Queue(
+            maxsize=self.CONFIG.get("message_backlog_size")
+        )
         super().setup_method()
         self.object.pipeline_index = 1
         self.object.setup()
-        # we have to empty the queue for testing
-        while not self.object.messages.empty():
-            self.object.messages.get(timeout=0.001)
         self.target = self.object.target
 
     CONFIG: dict = {
@@ -43,6 +42,8 @@ class TestHttpConnector(BaseInputTestCase):
     }
 
     def teardown_method(self):
+        while not self.object.messages.empty():
+            self.object.messages.get(timeout=0.001)
         self.object.shut_down()
 
     def test_create_connector(self):
@@ -74,18 +75,11 @@ class TestHttpConnector(BaseInputTestCase):
     def test_get_error_code_too_many_requests(self):
         data = {"message": "my log message"}
         session = requests.Session()
-        session.mount(
-            "http://",
-            requests.adapters.HTTPAdapter(pool_maxsize=20, max_retries=3, pool_block=True),
-        )
-
-        def get_url(url):
-            for _ in range(100):
-                _ = session.post(url, json=data)
-
-        with ThreadPoolExecutor(max_workers=100) as executor:
-            executor.submit(get_url, f"{self.target}/json")
+        for i in range(100):
+            resp = session.post(url=f"{self.target}/json", json=data, timeout=0.5)
+        assert self.object.messages.qsize() == 100
         resp = requests.post(url=f"{self.target}/json", json=data, timeout=0.5)
+        assert self.object.messages._maxsize == 100
         assert resp.status_code == 429
 
     def test_json_endpoint_accepts_post_request(self):
@@ -288,3 +282,18 @@ class TestHttpConnector(BaseInputTestCase):
 
     def test_messages_is_multiprocessing_queue(self):
         assert isinstance(self.object.messages, multiprocessing.queues.Queue)
+
+    def test_all_endpoints_share_the_same_queue(self):
+        data = {"message": "my log message"}
+        requests.post(url=f"{self.target}/json", json=data, timeout=0.5)
+        assert self.object.messages.qsize() == 1
+        data = "my log message"
+        requests.post(url=f"{self.target}/plaintext", json=data, timeout=0.5)
+        assert self.object.messages.qsize() == 2
+        data = """
+        {"message": "my first log message"}
+        {"message": "my second log message"}
+        {"message": "my third log message"}
+        """
+        requests.post(url=f"{self.target}/jsonl", data=data, timeout=0.5)
+        assert self.object.messages.qsize() == 5

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -1,14 +1,17 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
-from copy import deepcopy
+import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+
+import falcon
 import requests
 import uvicorn
-import falcon
+
+from logprep.abc.input import FatalInputError
 from logprep.connector.http.input import HttpConnector
 from logprep.factory import Factory
-from logprep.abc.input import FatalInputError
 from tests.unit.connector.base import BaseInputTestCase
 
 
@@ -278,3 +281,10 @@ class TestHttpConnector(BaseInputTestCase):
         }
         connector_next_msg, _ = connector.get_next(1)
         assert connector_next_msg == expected_event, "Output event with hmac is not as expected"
+
+    def test_two_connector_instances_share_the_same_queue(self):
+        new_connector = Factory.create({"test connector": self.CONFIG}, logger=self.logger)
+        assert self.object.messages is new_connector.messages
+
+    def test_messages_is_multiprocessing_queue(self):
+        assert isinstance(self.object.messages, multiprocessing.queues.Queue)

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from logging import Logger
 from unittest import mock
 
+from logprep.connector.http.input import HttpConnector
 from logprep.framework.pipeline_manager import PipelineManager
 from logprep.metrics.exporter import PrometheusExporter
 from logprep.util.configuration import Configuration, MetricsConfig
@@ -197,3 +198,17 @@ class TestPipelineManager:
         with mock.patch.object(pipeline_manager, "_create_pipeline") as mock_create_pipeline:
             pipeline_manager.restart_failed_pipeline()
             mock_create_pipeline.assert_called_once_with(1)
+
+    def test_pipeline_manager_sets_queue_size_for_http_input(self):
+        config = deepcopy(self.config)
+        config.input = {
+            "type": "http_input",
+            "message_backlog_size": 100,
+            "collect_meta": False,
+            "uvicorn_config": {"port": 9000, "host": "127.0.0.1"},
+            "endpoints": {
+                "/json": "json",
+            },
+        }
+        PipelineManager(config)
+        assert HttpConnector.messages._maxsize == 100

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -6,6 +6,7 @@ from logging import Logger
 from unittest import mock
 
 from logprep.connector.http.input import HttpConnector
+from logprep.factory import Factory
 from logprep.framework.pipeline_manager import PipelineManager
 from logprep.metrics.exporter import PrometheusExporter
 from logprep.util.configuration import Configuration, MetricsConfig
@@ -202,13 +203,17 @@ class TestPipelineManager:
     def test_pipeline_manager_sets_queue_size_for_http_input(self):
         config = deepcopy(self.config)
         config.input = {
-            "type": "http_input",
-            "message_backlog_size": 100,
-            "collect_meta": False,
-            "uvicorn_config": {"port": 9000, "host": "127.0.0.1"},
-            "endpoints": {
-                "/json": "json",
-            },
+            "http": {
+                "type": "http_input",
+                "message_backlog_size": 100,
+                "collect_meta": False,
+                "uvicorn_config": {"port": 9000, "host": "127.0.0.1"},
+                "endpoints": {
+                    "/json": "json",
+                },
+            }
         }
         PipelineManager(config)
         assert HttpConnector.messages._maxsize == 100
+        http_input = Factory.create(config.input, mock.MagicMock())
+        assert http_input.messages._maxsize == 100


### PR DESCRIPTION
this fixes an issue for not using multiprocessing on http_input connector:

to reproduce run on main:
* set logging to DEBUG in `quickstart/exampledata/config/http_pipeline.yml` 

```yaml
logger:
  level: DEBUG
```

* then start logprep with `logprep run ./quickstart/exampledata/config/http_pipeline.yml`
* then start loadtest with `logprep generate http --input-dir ./quickstart/exampledata/input_logdata/ --target-url http://localhost:9000 --user "" --password "" --events 100000000 --batch-size 10000 --thread_count 2`
* the output shows, that only one process in storing output in kafka:

```
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,607 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,607 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,609 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,609 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,608 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,609 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,609 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,610 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:00:32,609 Logprep Pipeline 1 DEBUG   : Stored output in kafka
```

then checkout this branch and reproduce these steps and you will see, that the second pipeline stores output in kafka:

```
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,172 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,170 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,170 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,170 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,170 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 1 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,171 Logprep Pipeline 2 DEBUG   : Stored output in kafka
2024-04-17 15:07:29,172 Logprep Pipeline 2 DEBUG   : Stored output in kafka
```



