### PR TITLE
fix broken gracefull shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Bugfix
 
-* fix a bug in http connector leading to only first process working
+* fixes a bug in http connector leading to only first process working
+* fixes the broken gracefull shutdown behaviour
 
 ## 11.0.1
 ### Bugfix

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -370,6 +370,8 @@ class HttpConnector(Input):
         self.port = self._config.uvicorn_config["port"]
         self.host = self._config.uvicorn_config["host"]
         self.target = f"http://{self.host}:{self.port}"
+        if self.messages is None:  # this is only for testing. Is set by pipeline_manager
+            self.messages = mp.Queue(maxsize=self._config.message_backlog_size)
 
     def setup(self):
         """setup starts the actual functionality of this connector.
@@ -382,6 +384,7 @@ class HttpConnector(Input):
             raise FatalInputError(
                 self, "Necessary instance attribute `pipeline_index` could not be found."
             )
+
         self._logger.debug(
             f"HttpInput Connector started on target {self.target} and "
             f"queue {id(self.messages)} "

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -364,7 +364,7 @@ class HttpConnector(Input):
         internal_uvicorn_config = {
             "lifespan": "off",
             "loop": "asyncio",
-            "timeout_graceful_shutdown": 0,
+            "timeout_graceful_shutdown": 5,
         }
         self._config.uvicorn_config.update(internal_uvicorn_config)
         self.port = self._config.uvicorn_config["port"]
@@ -385,7 +385,7 @@ class HttpConnector(Input):
         self._logger.debug(
             f"HttpInput Connector started on target {self.target} and "
             f"queue {id(self.messages)} "
-            f"with queue_size: {self.messages._maxsize}"
+            f"with queue_size: {self.messages._maxsize}"  # pylint: disable=protected-access
         )
         # Start HTTP Input only when in first process
         if self.pipeline_index != 1:
@@ -426,4 +426,6 @@ class HttpConnector(Input):
 
     def shut_down(self):
         """Raises Uvicorn HTTP Server internal stop flag and waits to join"""
+        if not hasattr(self, "http_server"):
+            return
         self.http_server.shut_down()

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -370,8 +370,6 @@ class HttpConnector(Input):
         self.port = self._config.uvicorn_config["port"]
         self.host = self._config.uvicorn_config["host"]
         self.target = f"http://{self.host}:{self.port}"
-        if self.messages is None:  # this is only for testing. Is set by pipeline_manager
-            self.messages = mp.Queue(maxsize=self._config.message_backlog_size)
 
     def setup(self):
         """setup starts the actual functionality of this connector.

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -4,9 +4,7 @@ import logging
 import os
 import signal
 import sys
-import tempfile
 import warnings
-from pathlib import Path
 
 import click
 from colorama import Fore
@@ -14,12 +12,12 @@ from colorama import Fore
 from logprep.event_generator.http.controller import Controller
 from logprep.event_generator.kafka.run_load_tester import LoadTester
 from logprep.runner import Runner
+from logprep.util import defaults
 from logprep.util.auto_rule_tester.auto_rule_corpus_tester import RuleCorpusTester
 from logprep.util.auto_rule_tester.auto_rule_tester import AutoRuleTester
 from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.helper import get_versions_string, print_fcolor
 from logprep.util.rule_dry_runner import DryRunner
-from logprep.util import defaults
 
 warnings.simplefilter("always", DeprecationWarning)
 logging.captureWarnings(True)
@@ -60,6 +58,9 @@ def cli() -> None:
     Logprep allows to collect, process and forward log messages from various data sources.
     Log messages are being read and written by so-called connectors.
     """
+    if "pytest" not in sys.modules:  # needed for not blocking tests
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
 
 
 @cli.command(short_help="Run logprep to process log messages", epilog=EPILOG_STR)
@@ -323,6 +324,4 @@ def signal_handler(__: int, _) -> None:
 
 
 if __name__ == "__main__":
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
     cli()


### PR DESCRIPTION
testing this is hard. too hard for me and so I decided to not add a tests for this.

test the fix explorative with:

```bash
logprep  run ./quickstart/exampledata/config/http_pipeline.yml
```

then press `CRTL + C`

you should get this:

```
^C2024-04-19 15:41:18,980 Logprep Runner INFO    : Shutting down
2024-04-19 15:41:18,980 Logprep Runner INFO    : Initiated shutdown
2024-04-19 15:41:18,980 Logprep Pipeline 2 DEBUG   : Stopping pipeline (MainProcess)
2024-04-19 15:41:18,980 Logprep Pipeline 2 DEBUG   : Stopping pipeline (MainProcess)
2024-04-19 15:41:20,659 Logprep Pipeline 1 DEBUG   : Stopping pipeline (MainProcess)
2024-04-19 15:41:20,659 Logprep Pipeline 1 DEBUG   : Stopping pipeline (MainProcess)
2024-04-19 15:41:25,673 Logprep HTTPServer INFO    : Shutting down
2024-04-19 15:41:25,778 Logprep HTTPServer ERROR   : Cancel 0 running task(s), timeout graceful shutdown exceeded
2024-04-19 15:41:25,779 Logprep HTTPServer INFO    : Finished server process [229968]
2024-04-19 15:41:25,788 Prometheus Exporter INFO    : Cleaned up /tmp/logprep1
2024-04-19 15:41:25,791 Logprep Runner INFO    : Shutdown complete
```


