### PR TITLE
Add Basic Auth to HTTP Connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ sql_db_table.json
 build/
 dist/
 error_file
+experiments
+**/_static/*.xlsx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 ## Upcoming Changes
 
 ## next release
+
 ### Breaking
+
+### Features
+
+### Improvements
+
+### Bugfix
+
+## 11.1.0
 
 ### Features
 
   * new documentation part with security best practices which compiles to `user_manual/security/best_practices.html`
     * also comes with excel export functionality of given best practices  
-
-### Improvements
+  * add basic auth to http_input
 
 ### Bugfix
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -118,7 +118,7 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 #
 html_theme_options = {
-    "navigation_depth": 5,
+    "navigation_depth": 4,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -35,16 +35,27 @@ add basic authentication for a specific endpoint. The format of this file would 
 Endpoint Credentials Config Example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ..  code-block:: yaml
+    :caption: Example for credentials file 
     :linenos:
 
     input:
-    endpoints:
-      /firstendpoint:
-        username: user
-        password_file: quickstart/exampledata/config/user_password.txt
-      /second*:
-        username: user
-        password: secret_password
+        endpoints:
+        /firstendpoint:
+            username: user
+            password_file: quickstart/exampledata/config/user_password.txt
+        /second*:
+            username: user
+            password: secret_password
+                /seccondendpoint: plaintext
+                /thirdendpoint: jsonl
+
+.. security-best-practice::
+   :title: Http Input Connector - Authentication
+
+    When using basic auth with the http input connector the following points should 
+    be taken into account:
+        - basic auth must only be used with strong passwords
+        - basic auth must only be used with TLS encryption
 """
 
 import inspect

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -4,10 +4,10 @@ HTTPInput
 
 A http input connector that spawns an uvicorn server and accepts http requests, parses them,
 puts them to an internal queue and pops them via :code:`get_next` method.
-By providing 
+An example config file would look like:
 
-Example
-^^^^^^^
+HTTP Connector Config Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ..  code-block:: yaml
     :linenos:
 
@@ -22,8 +22,29 @@ Example
             port: 9000
         endpoints:
             /firstendpoint: json 
-            /seccondendpoint: plaintext
-            /thirdendpoint: jsonl
+            /second*: plaintext
+            /(third|fourth)/endpoint: jsonl
+            
+The endpoint config supports regex and wildcard patterns:
+  * :code:`/second*`: matches everything after asterisk
+  * :code:`/(third|fourth)/endpoint` matches either third or forth in the first part
+
+By providing a credentials file in environment variable :code:`LOGPREP_CREDENTIALS_FILE` you can
+add basic authentication for a specific endpoint. The format of this file would look like:
+
+Endpoint Credentials Config Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+..  code-block:: yaml
+    :linenos:
+
+    input:
+    endpoints:
+      /firstendpoint:
+        username: user
+        password_file: quickstart/exampledata/config/user_password.txt
+      /second*:
+        username: user
+        password: secret_password
 """
 
 import inspect
@@ -350,8 +371,10 @@ class HttpConnector(Input):
             ]
         )
         """Configure endpoint routes with a Mapping of a path to an endpoint. Possible endpoints
-        are: :code:`json`, :code:`jsonl`, :code:`plaintext`.
-
+        are: :code:`json`, :code:`jsonl`, :code:`plaintext`. It's possible to use wildcards and
+        regexes for pattern matching.
+        
+        
         .. autoclass:: logprep.connector.http.input.PlaintextHttpEndpoint
             :noindex:
         .. autoclass:: logprep.connector.http.input.JSONLHttpEndpoint

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -20,7 +20,12 @@ Example
             host: 0.0.0.0
             port: 9000
         endpoints:
-            /firstendpoint: json
+            linux_logs: 
+              path: /firstendpoint 
+              type: json
+              auth: true
+              user: test
+              password: secret:alksdfjsadkl
             /seccondendpoint: plaintext
             /thirdendpoint: jsonl
 """

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -52,8 +52,7 @@ Endpoint Credentials Config Example
 .. security-best-practice::
    :title: Http Input Connector - Authentication
 
-    When using basic auth with the http input connector the following points should 
-    be taken into account:
+    When using basic auth with the http input connector the following points should be taken into account:
         - basic auth must only be used with strong passwords
         - basic auth must only be used with TLS encryption
 """

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -4,10 +4,12 @@ HTTPInput
 
 A http input connector that spawns an uvicorn server and accepts http requests, parses them,
 puts them to an internal queue and pops them via :code:`get_next` method.
-An example config file would look like:
+
 
 HTTP Connector Config Example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+An example config file would look like:
+
 ..  code-block:: yaml
     :linenos:
 
@@ -18,55 +20,60 @@ HTTP Connector Config Example
         collect_meta: False
         metafield_name: "@metadata"
         uvicorn_config:
-            host: 0.0.0.0
-            port: 9000
+          host: 0.0.0.0
+          port: 9000
         endpoints:
-            /firstendpoint: json 
-            /second*: plaintext
-            /(third|fourth)/endpoint: jsonl
+          /firstendpoint: json 
+          /second*: plaintext
+          /(third|fourth)/endpoint: jsonl
             
 The endpoint config supports regex and wildcard patterns:
   * :code:`/second*`: matches everything after asterisk
   * :code:`/(third|fourth)/endpoint` matches either third or forth in the first part
 
-By providing a credentials file in environment variable :code:`LOGPREP_CREDENTIALS_FILE` you can
-add basic authentication for a specific endpoint. The format of this file would look like:
 
 Endpoint Credentials Config Example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By providing a credentials file in environment variable :code:`LOGPREP_CREDENTIALS_FILE` you can
+add basic authentication for a specific endpoint. The format of this file would look like:
+
 ..  code-block:: yaml
     :caption: Example for credentials file 
     :linenos:
 
     input:
-        endpoints:
+      endpoints:
         /firstendpoint:
-            username: user
-            password_file: quickstart/exampledata/config/user_password.txt
+          username: user
+          password_file: quickstart/exampledata/config/user_password.txt
         /second*:
-            username: user
-            password: secret_password
-                /seccondendpoint: plaintext
-                /thirdendpoint: jsonl
+          username: user
+          password: secret_password
+          
+You can choose between a plain secret with the key :code:`password` or a filebased secret
+with the key :code:`password_file`.
 
 .. security-best-practice::
    :title: Http Input Connector - Authentication
 
-    When using basic auth with the http input connector the following points 
-    should be taken into account:
+    When using basic auth with the http input connector the following points should be taken into account:
         - basic auth must only be used with strong passwords
         - basic auth must only be used with TLS encryption
+        - avoid to reveal your plaintext secrets in public repositories
         
 Behaviour of HTTP Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  * :code:`GET`: 
+  * :code:`GET`:
+   
     * Responds always with 200 (ignores configured Basic Auth)
     * When Messages Queue is full, it responds with 429
   * :code:`POST`:
+  
     * Responds with 200 on non-Basic Auth Endpoints
     * Responds with 401 on Basic Auth Endpoints (and 200 with appropriate credentials)
     * When Messages Queue is full, it responds wiht 429
   * :code:`ALL OTHER`:
+  
     * Responds with 405
 """
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -93,10 +93,10 @@ import msgspec
 import uvicorn
 from attrs import define, field, validators
 from falcon import (  # pylint: disable=no-name-in-module
+    HTTP_200,
     HTTPMethodNotAllowed,
     HTTPTooManyRequests,
     HTTPUnauthorized,
-    HTTP_200,
 )
 
 from logprep.abc.input import FatalInputError, Input

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -89,11 +89,8 @@ def decorator_basic_auth(func: Callable):
             auth_request_header = req.get_header("Authorization")
             if not auth_request_header:
                 raise HTTPUnauthorized
-            auth_creds = b64encode(
-                f"{endpoint.credentials.username}:{endpoint.credentials.password}".encode("utf-8")
-            ).decode("utf-8")
             basic_string = req.auth
-            if auth_creds not in basic_string:
+            if endpoint.basicauth_b64 not in basic_string:
                 raise HTTPUnauthorized
         func_wrapper = await func(*args, **kwargs)
         return func_wrapper
@@ -178,6 +175,10 @@ class HttpEndpoint(ABC):
         self.collect_meta = collect_meta
         self.metafield_name = metafield_name
         self.credentials = credentials
+        if self.credentials:
+            self.basicauth_b64 = b64encode(
+                f"{self.credentials.username}:{self.credentials.password}".encode("utf-8")
+            ).decode("utf-8")
 
 
 class JSONHttpEndpoint(HttpEndpoint):

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -8,60 +8,73 @@ This file should provide the credentials that are needed and can either be
 in yaml or in json format.
 To use the authentication, the given credentials file has to be
 filled with the correct values that correspond to the method you want to use.
+It is important not to forget the getter keyword when filling the credentials file.
 
 .. code-block:: yaml
-    :caption: Example for credentials file
-
-    "http://target.url":
-        # example for token given directly via file
-        token_file: <path/to/token/file> # won't be refreshed if expired
-    "http://target.url":
-        # example for token given directly inline
-        token: <token> # won't be refreshed if expired
-    "http://target.url":
-        # example for OAuth2 Client Credentials Grant
-        endpoint: <endpoint>
-        client_id: <id>
-        client_secret_file: <path/to/secret/file>
-    "http://target.url":
-        # example for OAuth2 Client Credentials Grant with inline secret
-        endpoint: <endpoint>
-        client_id: <id>
-        client_secret: <secret>
-    "http://target.url":
-        # example for OAuth2 Resource Owner Password Credentials Grant with authentication for a confidential client
-        endpoint: <endpoint>
-        username: <username>
-        password_file: <path/to/password/file>
-        client_id: <client_id> # optional if required
-        client_secret_file: <path/to/secret/file> # optional if required
-    "http://target.url":
-        # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client
-        endpoint: <endpoint>
-        username: <username>
-        password_file: <path/to/password/file>
-    "http://target.url":
-        # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client with inline password
-        endpoint: <endpoint>
-        username: <username>
-        password: <password>
-    "http://target.url":
-        # example for Basic Authentication
-        username: <username>
-        password_file: <path/to/password/file>
-    "http://target.url":
-        # example for Basic Authentication with inline password
-        username: <username>
-        password: <plaintext password> # will be overwritten if 'password_file' is given
-    "http://target.url":
-        # example for mTLS authentication
-        client_key: <path/to/client/key/file>
-        cert: <path/to/certificate/file>
-    "http://target.url":
-        # example for mTLS authentication with ca cert given
-        client_key: <path/to/client/key/file>
-        cert: <path/to/certificate/file>
-        ca_cert: <path/to/ca/cert>
+    :caption: Example for credentials file 
+    
+    getter:
+        "http://target.url":
+            # example for token given directly via file
+            token_file: <path/to/token/file> # won't be refreshed if expired
+    getter:
+        "http://target.url":
+            # example for token given directly inline
+            token: <token> # won't be refreshed if expired
+    getter:
+        "http://target.url":
+            # example for OAuth2 Client Credentials Grant
+            endpoint: <endpoint>
+            client_id: <id>
+            client_secret_file: <path/to/secret/file>
+    getter:
+        "http://target.url":
+            # example for OAuth2 Client Credentials Grant with inline secret
+            endpoint: <endpoint>
+            client_id: <id>
+            client_secret: <secret>
+    getter:
+        "http://target.url":
+            # example for OAuth2 Resource Owner Password Credentials Grant with authentication for a confidential client
+            endpoint: <endpoint>
+            username: <username>
+            password_file: <path/to/password/file>
+            client_id: <client_id> # optional if required
+            client_secret_file: <path/to/secret/file> # optional if required
+    getter:
+        "http://target.url":
+            # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client
+            endpoint: <endpoint>
+            username: <username>
+            password_file: <path/to/password/file>
+    getter:
+        "http://target.url":
+            # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client with inline password
+            endpoint: <endpoint>
+            username: <username>
+            password: <password>
+    getter:
+        "http://target.url":
+            # example for Basic Authentication
+            username: <username>
+            password_file: <path/to/password/file>
+    getter:
+        "http://target.url":
+            # example for Basic Authentication with inline password
+            username: <username>
+            password: <plaintext password> # will be overwritten if 'password_file' is given
+    getter:
+        "http://target.url":
+            # example for mTLS authentication
+            client_key: <path/to/client/key/file>
+            cert: <path/to/certificate/file>
+    getter:
+        "http://target.url":
+            # example for mTLS authentication with ca cert given
+            client_key: <path/to/client/key/file>
+            cert: <path/to/certificate/file>
+            ca_cert: <path/to/ca/cert>
+   
 
 Options for the credentials file are:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -144,7 +144,35 @@ class CredentialsFactory:
         raw_content: dict = cls._get_content(Path(credentials_file_path))
         domain = urlparse(target_url).netloc
         scheme = urlparse(target_url).scheme
-        credential_mapping = raw_content.get(f"{scheme}://{domain}")
+        getter_credentials = raw_content.get("getter")
+        credential_mapping = getter_credentials.get(f"{scheme}://{domain}")
+        credentials = cls.from_dict(credential_mapping)
+        return credentials
+
+    @classmethod
+    def from_endpoint(cls, target_endpoint: str) -> "Credentials":
+        """Factory method to create a credentials object based on the credentials stored in the
+        environment variable :code:`LOGPREP_CREDENTIALS_FILE`.
+        Based on these credentials the expected authentication method is chosen and represented
+        by the corresponding credentials object.
+
+        Parameters
+        ----------
+        target_endpoint : str
+           get authentication parameters for given target_endpoint
+
+        Returns
+        -------
+        credentials: Credentials
+            Credentials object representing the correct authorization method
+
+        """
+        credentials_file_path = os.environ.get("LOGPREP_CREDENTIALS_FILE")
+        if credentials_file_path is None:
+            return None
+        raw_content: dict = cls._get_content(Path(credentials_file_path))
+        endpoint_credentials = raw_content.get("input").get("endpoints")
+        credential_mapping = endpoint_credentials.get(target_endpoint)
         credentials = cls.from_dict(credential_mapping)
         return credentials
 

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -8,7 +8,6 @@ This file should provide the credentials that are needed and can either be
 in yaml or in json format.
 To use the authentication, the given credentials file has to be
 filled with the correct values that correspond to the method you want to use.
-It is important not to forget the getter keyword when filling the credentials file.
 
 .. code-block:: yaml
     :caption: Example for credentials file 
@@ -17,58 +16,48 @@ It is important not to forget the getter keyword when filling the credentials fi
         "http://target.url":
             # example for token given directly via file
             token_file: <path/to/token/file> # won't be refreshed if expired
-    getter:
         "http://target.url":
             # example for token given directly inline
             token: <token> # won't be refreshed if expired
-    getter:
         "http://target.url":
             # example for OAuth2 Client Credentials Grant
             endpoint: <endpoint>
             client_id: <id>
             client_secret_file: <path/to/secret/file>
-    getter:
         "http://target.url":
             # example for OAuth2 Client Credentials Grant with inline secret
             endpoint: <endpoint>
             client_id: <id>
             client_secret: <secret>
-    getter:
         "http://target.url":
             # example for OAuth2 Resource Owner Password Credentials Grant with authentication for a confidential client
             endpoint: <endpoint>
             username: <username>
             password_file: <path/to/password/file>
             client_id: <client_id> # optional if required
-            client_secret_file: <path/to/secret/file> # optional if required
-    getter:
+            client_secret_file: <path/to/secret/file> # optional if require
         "http://target.url":
             # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client
             endpoint: <endpoint>
             username: <username>
             password_file: <path/to/password/file>
-    getter:
         "http://target.url":
             # example for OAuth2 Resource Owner Password Credentials Grant for a public unconfidential client with inline password
             endpoint: <endpoint>
             username: <username>
             password: <password>
-    getter:
         "http://target.url":
             # example for Basic Authentication
             username: <username>
             password_file: <path/to/password/file>
-    getter:
         "http://target.url":
             # example for Basic Authentication with inline password
             username: <username>
             password: <plaintext password> # will be overwritten if 'password_file' is given
-    getter:
         "http://target.url":
             # example for mTLS authentication
             client_key: <path/to/client/key/file>
             cert: <path/to/certificate/file>
-    getter:
         "http://target.url":
             # example for mTLS authentication with ca cert given
             client_key: <path/to/client/key/file>

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -63,6 +63,14 @@ filled with the correct values that correspond to the method you want to use.
             client_key: <path/to/client/key/file>
             cert: <path/to/certificate/file>
             ca_cert: <path/to/ca/cert>
+    input:
+      endpoints:
+        /firstendpoint:
+          username: <username>
+          password_file: <path/to/password/file>
+        /second*:
+          username: <username>
+          password: <password>
    
 
 Options for the credentials file are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dependencies = [
   "pandas",
   "tabulate",
   "falcon==3.1.3",
+  "falcon-auth==1.1.0"
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
   "pandas",
   "tabulate",
   "falcon==3.1.3",
-  "falcon-auth==1.1.0"
+  "falcon-auth2==0.1.0",
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ dependencies = [
   "pandas",
   "tabulate",
   "falcon==3.1.3",
-  "falcon-auth2==0.1.0",
-
 ]
 
 [project.optional-dependencies]

--- a/quickstart/exampledata/config/credentials.yml
+++ b/quickstart/exampledata/config/credentials.yml
@@ -17,3 +17,6 @@ input:
     /auth-json:
       username: user
       password_file: quickstart/exampledata/config/user_password.txt
+    /lab/123/ABC/auditlog:
+      username: user
+      password_file: quickstart/exampledata/config/user_password.txt

--- a/quickstart/exampledata/config/credentials.yml
+++ b/quickstart/exampledata/config/credentials.yml
@@ -1,13 +1,19 @@
-"http://localhost:8002":
-  endpoint: http://localhost:8080/realms/logprep/protocol/openid-connect/token
-  username: logprep
-  password: logprep
-  client_id: fda
-  client_secret: tYfkKygb1g2Hf6fmAInoq3XPK1OILbSp
-"http://localhost:8081":
-  username: user
-  password: password
-"https://localhost:8082":
-  client_key: quickstart/exampledata/config/nginx/mtls.conf.d/client.key
-  cert: quickstart/exampledata/config/nginx/mtls.conf.d/client.crt
-  ca_cert: quickstart/exampledata/config/nginx/mtls.conf.d/ca.crt
+getter:
+  "http://localhost:8002":
+    endpoint: http://localhost:8080/realms/logprep/protocol/openid-connect/token
+    username: logprep
+    password: logprep
+    client_id: fda
+    client_secret: tYfkKygb1g2Hf6fmAInoq3XPK1OILbSp
+  "http://localhost:8081":
+    username: user
+    password: password
+  "https://localhost:8082":
+    client_key: quickstart/exampledata/config/nginx/mtls.conf.d/client.key
+    cert: quickstart/exampledata/config/nginx/mtls.conf.d/client.crt
+    ca_cert: quickstart/exampledata/config/nginx/mtls.conf.d/ca.crt
+input:
+  endpoints:
+    /auth-json:
+      username: user
+      password_file: quickstart/exampledata/config/user_password.txt

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -2,7 +2,7 @@ version: 1
 process_count: 2
 
 logger:
-  level: DEBUG
+  level: INFO
 
 metrics:
   enabled: true

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -17,21 +17,10 @@ input:
           host: 0.0.0.0
           port: 9000
       endpoints:
-          auth-linux-logs:
-            path: /auth-json
-            type: json
-            auth: True
-            username: blah
-            password_file: /home/logprep/auth/basic-auth-linux-logs
-          linux-logs:
-            path: /json 
-            type: json
-          plaintext-logs:
-            path: /lab/123/(ABC|DEF)/pl.*
-            type: plaintext
-          jsonl-logs:
-            path: /lab/123/ABC/auditlog
-            type: jsonl
+          /auth-json: json
+          /json: json
+          /lab/123/(ABC|DEF)/pl.*: plaintext
+          /lab/123/ABC/auditlog: jsonl
 output:
   kafka:
     type: confluentkafka_output

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -17,10 +17,21 @@ input:
           host: 0.0.0.0
           port: 9000
       endpoints:
-          /json: json
-          /lab/123/(first|second|third)/js.*: jsonl
-          /lab/123/(ABC|DEF)/pl.*: plaintext
-          /lab/123/ABC/auditlog: jsonl
+          auth-linux-logs:
+            path: /auth-json
+            type: json
+            auth: True
+            username: blah
+            password_file: /home/logprep/auth/basic-auth-linux-logs
+          linux-logs:
+            path: /json 
+            type: json
+          plaintext-logs:
+            path: /lab/123/(ABC|DEF)/pl.*
+            type: plaintext
+          jsonl-logs:
+            path: /lab/123/ABC/auditlog
+            type: jsonl
 output:
   kafka:
     type: confluentkafka_output

--- a/quickstart/exampledata/config/user_password.txt
+++ b/quickstart/exampledata/config/user_password.txt
@@ -1,0 +1,1 @@
+secret_password

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -98,17 +98,26 @@ class TestHttpConnector(BaseInputTestCase):
 
     def test_get_error_code_on_get(self):
         resp = requests.get(url=f"{self.target}/json", timeout=0.5)
-        assert resp.status_code == 405
+        assert resp.status_code == 200
+        
+    def test_get_error_code_on_get_with_basic_auth_endpoint(self):
+        resp = requests.get(url=f"{self.target}/auth-json-secret", timeout=0.5)
+        assert resp.status_code == 200
 
     def test_get_error_code_too_many_requests(self):
         data = {"message": "my log message"}
         session = requests.Session()
-        for _ in range(100):
+        for _ in range(200):
             resp = session.post(url=f"{self.target}/json", json=data, timeout=0.5)
         assert self.object.messages.qsize() == 100
         resp = requests.post(url=f"{self.target}/json", json=data, timeout=0.5)
         assert self.object.messages._maxsize == 100
         assert resp.status_code == 429
+        for _ in range(200):
+            resp = session.post(url=f"{self.target}/json", json=data, timeout=0.5)
+        resp = requests.get(url=f"{self.target}/json", json=data, timeout=0.5)
+        assert resp.status_code == 429
+
 
     def test_json_endpoint_accepts_post_request(self):
         data = {"message": "my log message"}

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -325,6 +325,9 @@ class TestHttpConnector(BaseInputTestCase):
             new_connector.setup()
             resp = requests.post(url=f"{self.target}/auth-json-file", timeout=0.5)
             assert resp.status_code == 401
+            basic = HTTPBasicAuth("wrong", "credentials")
+            resp = requests.post(url=f"{self.target}/auth-json-file", auth=basic, timeout=0.5)
+            assert resp.status_code == 401
             basic = HTTPBasicAuth("user", "file_password")
             resp = requests.post(url=f"{self.target}/auth-json-file", auth=basic, timeout=0.5)
             assert resp.status_code == 200

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
 import multiprocessing
-import os
 from copy import deepcopy
 from unittest import mock
 
@@ -99,7 +98,7 @@ class TestHttpConnector(BaseInputTestCase):
     def test_get_error_code_on_get(self):
         resp = requests.get(url=f"{self.target}/json", timeout=0.5)
         assert resp.status_code == 200
-        
+
     def test_get_error_code_on_get_with_basic_auth_endpoint(self):
         resp = requests.get(url=f"{self.target}/auth-json-secret", timeout=0.5)
         assert resp.status_code == 200
@@ -107,17 +106,16 @@ class TestHttpConnector(BaseInputTestCase):
     def test_get_error_code_too_many_requests(self):
         data = {"message": "my log message"}
         session = requests.Session()
-        for _ in range(200):
+        for _ in range(100):
             resp = session.post(url=f"{self.target}/json", json=data, timeout=0.5)
         assert self.object.messages.qsize() == 100
         resp = requests.post(url=f"{self.target}/json", json=data, timeout=0.5)
         assert self.object.messages._maxsize == 100
         assert resp.status_code == 429
-        for _ in range(200):
+        for _ in range(100):
             resp = session.post(url=f"{self.target}/json", json=data, timeout=0.5)
         resp = requests.get(url=f"{self.target}/json", json=data, timeout=0.5)
         assert resp.status_code == 429
-
 
     def test_json_endpoint_accepts_post_request(self):
         data = {"message": "my log message"}

--- a/tests/unit/util/test_credentials.py
+++ b/tests/unit/util/test_credentials.py
@@ -696,9 +696,10 @@ class TestCredentialsFactory:
             (
                 "Return BasicAuthCredential object",
                 """---
-"https://some.url":
-    username: test
-    password: test
+getter:
+    "https://some.url":
+        username: test
+        password: test
 """,
                 BasicAuthCredentials,
                 None,
@@ -706,10 +707,11 @@ class TestCredentialsFactory:
             (
                 "Return OAuthPasswordFlowCredential object",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    username: test
-    password: test
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        username: test
+        password: test
 """,
                 OAuth2PasswordFlowCredentials,
                 None,
@@ -717,10 +719,11 @@ class TestCredentialsFactory:
             (
                 "Return OAuthClientFlowCredential object",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    client_id: test
-    client_secret: test
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        client_id: test
+        client_secret: test
 """,
                 OAuth2ClientFlowCredentials,
                 None,
@@ -728,8 +731,9 @@ class TestCredentialsFactory:
             (
                 "Return OAuthTokenCredential object",
                 """---
-"https://some.url":
-    token: "jsoskdmoiewjdoeijkxsmoiqw8jdiowd0"
+getter:
+    "https://some.url":
+        token: "jsoskdmoiewjdoeijkxsmoiqw8jdiowd0"
 """,
                 OAuth2TokenCredentials,
                 None,
@@ -737,7 +741,8 @@ class TestCredentialsFactory:
             (
                 "Return None if credentials are missing",
                 """---
-"https://some.url":
+getter:
+    "https://some.url":
 """,
                 type(None),
                 None,
@@ -745,8 +750,9 @@ class TestCredentialsFactory:
             (
                 "Return None if wrong URL is given",
                 """---
-"https://some.other.url":
-    token: "jsoskdmoiewjdoeijkxsmoiqw8jdiowd0"
+getter:             
+    "https://some.other.url":
+        token: "jsoskdmoiewjdoeijkxsmoiqw8jdiowd0"
 """,
                 type(None),
                 None,
@@ -754,10 +760,11 @@ class TestCredentialsFactory:
             (
                 "Raises InvalidConfigurationError credentials file is invalid yml",
                 """---
-"https://some.url":
-    password no colon here
-    username: test
-    endpoint: https://endpoint.end
+getter:                
+    "https://some.url":
+        password no colon here
+        username: test
+        endpoint: https://endpoint.end
 """,
                 None,
                 InvalidConfigurationError,
@@ -766,10 +773,12 @@ class TestCredentialsFactory:
                 "Return OAuthClientFlowCredential object when credentials file is valid json",
                 """
 {
+"getter": {
     "https://some.url": {
         "endpoint": "https://endpoint.end",
         "client_id": "test",
         "client_secret": "test"
+        }
     }
 }
 """,
@@ -780,6 +789,7 @@ class TestCredentialsFactory:
                 "Raise InvalidConfigurationError when credentials file is invalid json",
                 """
 {
+"getter": {
     "https://some.url": 
         "endpoint": "https://endpoint.end",
         "client_id": "test",
@@ -791,11 +801,12 @@ class TestCredentialsFactory:
             (
                 "Return OAuth2PassowordFlowCredentials object with additional client_id in credentials file",
                 """---
-"https://some.url": 
-    endpoint: https://endpoint.end
-    client_id: test
-    username: test
-    password: test
+getter:
+    "https://some.url": 
+        endpoint: https://endpoint.end
+        client_id: test
+        username: test
+        password: test
 """,
                 OAuth2PasswordFlowCredentials,
                 None,
@@ -803,13 +814,14 @@ class TestCredentialsFactory:
             (
                 "Return OAuthTokenCredential object when other params are given",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    client_id: test
-    username: test
-    client_secret: test
-    password: test
-    token: "73475289038didjhwxnwnxwoiencn"
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        client_id: test
+        username: test
+        client_secret: test
+        password: test
+        token: "73475289038didjhwxnwnxwoiencn"
 
 """,
                 OAuth2TokenCredentials,
@@ -818,11 +830,12 @@ class TestCredentialsFactory:
             (
                 "Raise InvalidConfigurationError if credentials have wrong type",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    username: 123
-    password: test
-    client_secret: 456
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        username: 123
+        password: test
+        client_secret: 456
 
 """,
                 None,
@@ -831,12 +844,13 @@ class TestCredentialsFactory:
             (
                 "Return OAuthClientFlowCredential object when username passowrd are also given",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    client_id: test
-    username: test
-    password: test
-    client_secret: test
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        client_id: test
+        username: test
+        password: test
+        client_secret: test
 """,
                 OAuth2PasswordFlowCredentials,
                 None,
@@ -844,10 +858,11 @@ class TestCredentialsFactory:
             (
                 "Return None if no matching credentials class is found",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    username: test
-    client_secret: test
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        username: test
+        client_secret: test
 """,
                 type(None),
                 None,
@@ -855,10 +870,11 @@ class TestCredentialsFactory:
             (
                 "Error",
                 """---
-"https://some.url":
-    endpoint: https://endpoint.end
-    username: test
-    password:
+getter:
+    "https://some.url":
+        endpoint: https://endpoint.end
+        username: test
+        password:
 """,
                 type(None),
                 InvalidConfigurationError,
@@ -866,9 +882,10 @@ class TestCredentialsFactory:
             (
                 "Return MTLSCredentials object if certificate and key are given",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
-    cert: "path/to/cert"
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
+        cert: "path/to/cert"
 """,
                 MTLSCredentials,
                 None,
@@ -876,15 +893,16 @@ class TestCredentialsFactory:
             (
                 "Return MTLSCredentials object if certificate key and ca cert are given",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
-    cert: "path/to/cert"
-    ca_cert: "path/to/ca/cert"
-    endpoint: https://endpoint.end
-    client_id: test
-    username: test
-    password: test
-    client_secret: test
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
+        cert: "path/to/cert"
+        ca_cert: "path/to/ca/cert"
+        endpoint: https://endpoint.end
+        client_id: test
+        username: test
+        password: test
+        client_secret: test
 """,
                 MTLSCredentials,
                 None,
@@ -892,10 +910,11 @@ class TestCredentialsFactory:
             (
                 "Return MTLSCredentials object if certificate key and ca cert are given with extra params",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
-    cert: "path/to/cert"
-    ca_cert: "path/to/ca/cert"
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
+        cert: "path/to/cert"
+        ca_cert: "path/to/ca/cert"
 """,
                 MTLSCredentials,
                 None,
@@ -903,11 +922,12 @@ class TestCredentialsFactory:
             (
                 "Return MTLSCredentials object if certificate and key are given with extra parameters",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
-    cert: "path/to/cert"
-    endpoint: https://endpoint.end
-    username: test
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
+        cert: "path/to/cert"
+        endpoint: https://endpoint.end
+        username: test
 """,
                 MTLSCredentials,
                 None,
@@ -915,8 +935,9 @@ class TestCredentialsFactory:
             (
                 "Return None if certificate is missing",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
 """,
                 type(None),
                 None,
@@ -924,16 +945,17 @@ class TestCredentialsFactory:
             (
                 "Return InvalidConfigurationError object if certificate is empty",
                 """---
-"https://some.url":
-    client_key: "path/to/client/key"
-    cert: 
+getter:
+    "https://some.url":
+        client_key: "path/to/client/key"
+        cert: 
 """,
                 None,
                 InvalidConfigurationError,
             ),
         ],
     )
-    def test_credentials_returns_expected_credential_object(
+    def test_getter_credentials_returns_expected_credential_object(
         self, testcase, credential_file_content, instance, tmp_path, error
     ):
         credential_file_path = tmp_path / "credentials"
@@ -947,6 +969,23 @@ class TestCredentialsFactory:
                 creds = CredentialsFactory.from_target("https://some.url/configuration")
                 assert isinstance(creds, instance), testcase
 
+    def test_input_credentials_returns_expected_credentials_object(self, tmp_path):
+        credential_file_path = tmp_path / "credentials.yml"
+        credential_file_path.write_text(
+            """---
+input:
+    endpoints:
+        /some/auth/endpoint:
+            username: test_user
+            password: myverysecretpassword
+"""
+        )
+        mock_env = {"LOGPREP_CREDENTIALS_FILE": str(credential_file_path)}
+        with mock.patch.dict("os.environ", mock_env):
+            creds = CredentialsFactory.from_endpoint("/some/auth/endpoint")
+            assert isinstance(creds, BasicAuthCredentials)
+            assert "test_user" in creds.username
+
     def test_credentials_returns_none_if_env_not_set(self):
         creds = CredentialsFactory.from_target("https://some.url/configuration")
         assert creds is None
@@ -955,10 +994,11 @@ class TestCredentialsFactory:
         credential_file_path = tmp_path / "credentials.yml"
         credential_file_path.write_text(
             """---
-"http://some.url":
-    endpoint: https://endpoint.end
-    client_id: test
-    client_secret: test
+getter:
+    "http://some.url":
+        endpoint: https://endpoint.end
+        client_id: test
+        client_secret: test
 """
         )
         mock_env = {"LOGPREP_CREDENTIALS_FILE": str(credential_file_path)}
@@ -1013,11 +1053,12 @@ class TestCredentialsFactory:
         secret_file_path = tmp_path / "secret.txt"
         credential_file_path.write_text(
             f"""---
-"http://some.url":
-    {endpoint}
-    username: testuser
-    client_id: testid
-    {type_of_secret}: {secret_file_path}
+getter:
+    "http://some.url":
+        {endpoint}
+        username: testuser
+        client_id: testid
+        {type_of_secret}: {secret_file_path}
 """
         )
         secret_file_path.write_text(secret_content)
@@ -1033,12 +1074,13 @@ class TestCredentialsFactory:
 
         credential_file_path.write_text(
             f"""---
-"http://some.url":
-    endpoint: "https://endpoint.end"
-    username: testuser
-    client_id: testid
-    client_secret_file: {secret_file_path_0}
-    password_file: {secret_file_path_1}
+getter:
+    "http://some.url":
+        endpoint: "https://endpoint.end"
+        username: testuser
+        client_id: testid
+        client_secret_file: {secret_file_path_0}
+        password_file: {secret_file_path_1}
 """
         )
         secret_file_path_0.write_text("thisismysecretsecretclientsecret")

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -397,9 +397,11 @@ class TestHttpGetter:
 
     def test_credentials_returns_credentials_if_set(self, tmp_path):
         credentials_file_content = {
-            "https://does-not-matter": {
-                "username": "myuser",
-                "password": "mypassword",
+            "getter": {
+                "https://does-not-matter": {
+                    "username": "myuser",
+                    "password": "mypassword",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -427,10 +429,12 @@ class TestHttpGetter:
             match=[matchers.header_matcher({"Authorization": "Bearer toooooken"})],
         )
         credentials_file_content = {
-            f"https://{domain}": {
-                "username": "myuser",
-                "password": "mypassword",
-                "endpoint": "https://the.krass.endpoint/token",
+            "getter": {
+                f"https://{domain}": {
+                    "username": "myuser",
+                    "password": "mypassword",
+                    "endpoint": "https://the.krass.endpoint/token",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -461,10 +465,12 @@ class TestHttpGetter:
             match=[matchers.header_matcher({"Authorization": "Bearer toooooken"})],
         )
         credentials_file_content = {
-            f"https://{domain}": {
-                "username": "myuser",
-                "password": "mypassword",
-                "endpoint": "https://the.krass.endpoint/token",
+            "getter": {
+                f"https://{domain}": {
+                    "username": "myuser",
+                    "password": "mypassword",
+                    "endpoint": "https://the.krass.endpoint/token",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -496,10 +502,12 @@ class TestHttpGetter:
             match=[matchers.header_matcher({"Authorization": "Bearer toooooken"})],
         )
         credentials_file_content = {
-            f"https://{domain}": {
-                "username": "myuser",
-                "password": "mypassword",
-                "endpoint": "https://the.krass.endpoint/token",
+            "getter": {
+                f"https://{domain}": {
+                    "username": "myuser",
+                    "password": "mypassword",
+                    "endpoint": "https://the.krass.endpoint/token",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -559,9 +567,11 @@ class TestHttpGetter:
                 match=[matchers.request_kwargs_matcher(req_kwargs)],
             )
         credentials_file_content = {
-            f"https://{domain}": {
-                "client_key": "path/to/key",
-                "cert": "path/to/cert",
+            "getter": {
+                f"https://{domain}": {
+                    "client_key": "path/to/key",
+                    "cert": "path/to/cert",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -589,10 +599,12 @@ class TestHttpGetter:
             match=[matchers.request_kwargs_matcher(req_kwargs)],
         )
         credentials_file_content = {
-            f"https://{domain}": {
-                "client_key": "path/to/key",
-                "cert": "path/to/cert",
-                "ca_cert": "path/to/ca/cert",
+            "getter": {
+                f"https://{domain}": {
+                    "client_key": "path/to/key",
+                    "cert": "path/to/cert",
+                    "ca_cert": "path/to/ca/cert",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"
@@ -627,10 +639,12 @@ class TestHttpGetter:
             match=[matchers.request_kwargs_matcher(req_kwargs)],
         )
         credentials_file_content = {
-            f"https://{domain}": {
-                "client_key": "path/to/key",
-                "cert": "path/to/cert",
-                "ca_cert": "path/to/ca/cert",
+            "getter": {
+                f"https://{domain}": {
+                    "client_key": "path/to/key",
+                    "cert": "path/to/cert",
+                    "ca_cert": "path/to/ca/cert",
+                }
             }
         }
         credentials_file: Path = tmp_path / "credentials.json"


### PR DESCRIPTION
This PR will add additional Basic Authentication functionality to the HTTP Connector:

- The Basic Auth Feature is completely modular in a Decorator and could be removed completely without dependencies to the endpoint code
- Basic Auth is configured using a additional `credentials.yaml` for example in the format below. The path to the file needs to be in the environment variable `LOGPREP_CREDENTIALS_FILE` beforehand running Logprep. The keys of the endpoints need to be matching to the http connector endpoints to apply basic auth:
```yaml
input:
  endpoints:
    /firstendpoint:
      username: user
      password_file: quickstart/exampledata/config/user_password.txt
    /second*:
      username: user
      password: secret_password
```
- POST-Requests work as expected, when basic auth is configured
- To create proper Readiness Probe Endpoints, GET-Requests will ignore basic auth and will ALWAYS respond with an empty 200