### PR TITLE
export metrics via uvicorn asgi app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Features
 
+* expose metrics via uvicorn webserver
+  * makes all uvicorn configuration options possible
+  * add security best practices to server configuration
+
 ### Improvements
 
 ### Bugfix

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -412,5 +412,6 @@ class HttpConnector(Input):
 
     def shut_down(self):
         """Raises Uvicorn HTTP Server internal stop flag and waits to join"""
-        if hasattr(self, "http_server") and self.http_server is not None:
-            self.http_server.shut_down()
+        if self.http_server is None:
+            return
+        self.http_server.shut_down()

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -284,6 +284,27 @@ class HttpConnector(Input):
 
         """Configure uvicorn server. For possible settings see
         `uvicorn settings page <https://www.uvicorn.org/settings>`_.
+
+        .. security-best-practice::
+           :title: Uvicorn Webserver Configuration
+           :location: uvicorn_config
+           :suggested-value: below
+           
+           Additionaly to the below it is recommended to configure `ssl on the metrics server endpoint
+           <https://www.uvicorn.org/settings/#https>`_
+
+           .. code-block:: yaml
+               :caption: Recommended uvicorn configuration for connector endpoint
+
+                metrics:
+                    enabled: true
+                    port: 9000
+                    uvicorn_config:
+                        access_log: true
+                        server_header: false
+                        date_header: false
+                        workers: 2
+
         """
         endpoints: Mapping[str, str] = field(
             validator=[

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -88,7 +88,6 @@ from typing import Callable, Mapping, Tuple, Union
 
 import falcon.asgi
 import msgspec
-import uvicorn
 from attrs import define, field, validators
 from falcon import (  # pylint: disable=no-name-in-module
     HTTP_200,
@@ -100,11 +99,6 @@ from falcon import (  # pylint: disable=no-name-in-module
 from logprep.abc.input import FatalInputError, Input
 from logprep.util import http
 from logprep.util.credentials import CredentialsFactory
-
-uvicorn_parameter_keys = inspect.signature(uvicorn.Config).parameters.keys()
-UVICORN_CONFIG_KEYS = [
-    parameter for parameter in uvicorn_parameter_keys if parameter not in ["app", "log_level"]
-]
 
 
 def decorator_basic_auth(func: Callable):
@@ -281,7 +275,7 @@ class HttpConnector(Input):
             validator=[
                 validators.instance_of(dict),
                 validators.deep_mapping(
-                    key_validator=validators.in_(UVICORN_CONFIG_KEYS),
+                    key_validator=validators.in_(http.UVICORN_CONFIG_KEYS),
                     # lamba xyz tuple necessary because of input structure
                     value_validator=lambda x, y, z: True,
                 ),

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -293,7 +293,6 @@ class HttpConnector(Input):
            <https://www.uvicorn.org/settings/#https>`_
 
            .. code-block:: yaml
-               :caption: Recommended uvicorn configuration for connector endpoint
 
                 uvicorn_config:
                     access_log: true

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -295,14 +295,11 @@ class HttpConnector(Input):
            .. code-block:: yaml
                :caption: Recommended uvicorn configuration for connector endpoint
 
-                metrics:
-                    enabled: true
-                    port: 9000
-                    uvicorn_config:
-                        access_log: true
-                        server_header: false
-                        date_header: false
-                        workers: 2
+                uvicorn_config:
+                    access_log: true
+                    server_header: false
+                    date_header: false
+                    workers: 2
 
         """
         endpoints: Mapping[str, str] = field(

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -77,7 +77,6 @@ Behaviour of HTTP Requests
     * Responds with 405
 """
 
-import inspect
 import multiprocessing as mp
 import queue
 import re
@@ -276,7 +275,7 @@ class HttpConnector(Input):
                 validators.instance_of(dict),
                 validators.deep_mapping(
                     key_validator=validators.in_(http.UVICORN_CONFIG_KEYS),
-                    # lamba xyz tuple necessary because of input structure
+                    # lambda xyz tuple necessary because of input structure
                     value_validator=lambda x, y, z: True,
                 ),
             ]

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -410,8 +410,8 @@ class HttpConnector(Input):
 
     @staticmethod
     def _get_asgi_app(endpoints_config: dict) -> falcon.asgi.App:
-        "Init falcon application server and setting endpoint routes"
-        app = falcon.asgi.App()  # pylint: disable=attribute-defined-outside-init
+        """Init falcon application server and setting endpoint routes"""
+        app = falcon.asgi.App()
         for endpoint_path, endpoint in endpoints_config.items():
             app.add_sink(endpoint, prefix=route_compile_helper(endpoint_path))
         return app

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -361,7 +361,11 @@ class HttpConnector(Input):
         super().__init__(name, configuration, logger)
         port = self._config.uvicorn_config["port"]
         host = self._config.uvicorn_config["host"]
-        self.target = f"http://{host}:{port}"
+        ssl_options = any(
+            setting for setting in self._config.uvicorn_config if setting.startswith("ssl")
+        )
+        schema = "https" if ssl_options else "http"
+        self.target = f"{schema}://{host}:{port}"
         self.http_server = None
 
     def setup(self):

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -287,7 +287,7 @@ class HttpConnector(Input):
         .. security-best-practice::
            :title: Uvicorn Webserver Configuration
            :location: uvicorn_config
-           :suggested-value: below
+           :suggested-value: uvicorn_config.access_log: true, uvicorn_config.server_header: false, uvicorn_config.data_header: false
            
            Additionaly to the below it is recommended to configure `ssl on the metrics server endpoint
            <https://www.uvicorn.org/settings/#https>`_

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -9,7 +9,7 @@ from logging import getLogger
 import uvicorn
 from prometheus_client import REGISTRY, make_asgi_app, multiprocess
 
-from logprep.util import defaults
+from logprep.util import defaults, http
 from logprep.util.configuration import MetricsConfig
 
 
@@ -18,11 +18,18 @@ class PrometheusExporter:
 
     def __init__(self, configuration: MetricsConfig):
         self.is_running = False
-        self._logger = getLogger("Prometheus Exporter")
+        logger_name = "Prometheus Exporter"
+        self._logger = getLogger(logger_name)
         self._logger.debug("Initializing Prometheus Exporter")
         self.configuration = configuration
         self._port = configuration.port
         self._app = make_asgi_app(REGISTRY)
+        self._server = http.ThreadingHTTPServer(
+            configuration.uvicorn_config | {"port": self._port},
+            self._app,
+            daemon=True,
+            logger_name=logger_name,
+        )
 
     def _prepare_multiprocessing(self):
         """
@@ -55,45 +62,9 @@ class PrometheusExporter:
         """
         multiprocess.mark_process_dead(pid)
 
-    def _init_log_config(self) -> dict:
-        """Use for Uvicorn same log formatter like for Logprep"""
-        log_config = uvicorn.config.LOGGING_CONFIG
-        log_config["formatters"]["default"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
-        log_config["formatters"]["access"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
-        log_config["handlers"]["default"]["stream"] = "ext://sys.stdout"
-        return log_config
-
-    def _override_runtime_logging(self):
-        """Uvicorn doesn't provide API to change name and handler beforehand
-        needs to be done during runtime"""
-        http_server_name = self._logger.name
-        for logger_name in ["uvicorn", "uvicorn.access"]:
-            logging.getLogger(logger_name).removeHandler(logging.getLogger(logger_name).handlers[0])
-            logging.getLogger(logger_name).addHandler(
-                logging.getLogger("Logprep").parent.handlers[0]
-            )
-        logging.getLogger("uvicorn.access").name = http_server_name
-        logging.getLogger("uvicorn.error").name = http_server_name
-
     def run(self):
         """Starts the default prometheus http endpoint"""
         self._prepare_multiprocessing()
-
-        self.uvicorn_config = self.configuration.uvicorn_config
-        log_config = self._init_log_config()
-        self.compiled_config = uvicorn.Config(
-            **self.uvicorn_config,
-            port=self._port,
-            app=self._app,
-            log_level="info",
-            log_config=log_config,
-        )
-        self.server = uvicorn.Server(self.compiled_config)
-        self._override_runtime_logging()
-        self.thread = threading.Thread(daemon=True, target=self.server.run)
-        self.thread.start()
-        while not self.server.started:
-            continue
-
+        self._server.start()
         self._logger.info(f"Prometheus Exporter started on port {self._port}")
         self.is_running = True

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -1,23 +1,28 @@
 """This module contains functionality to start a prometheus exporter and expose metrics with it"""
 
+import logging
 import os
 import shutil
+import threading
 from logging import getLogger
 
-from prometheus_client import REGISTRY, multiprocess, start_http_server
+import uvicorn
+from prometheus_client import REGISTRY, make_asgi_app, multiprocess
 
+from logprep.util import defaults
 from logprep.util.configuration import MetricsConfig
 
 
 class PrometheusExporter:
     """Used to control the prometheus exporter and to manage the metrics"""
 
-    def __init__(self, status_logger_config: MetricsConfig):
+    def __init__(self, configuration: MetricsConfig):
         self.is_running = False
         self._logger = getLogger("Prometheus Exporter")
         self._logger.debug("Initializing Prometheus Exporter")
-        self.configuration = status_logger_config
-        self._port = status_logger_config.port
+        self.configuration = configuration
+        self._port = configuration.port
+        self._app = make_asgi_app(REGISTRY)
 
     def _prepare_multiprocessing(self):
         """
@@ -50,9 +55,45 @@ class PrometheusExporter:
         """
         multiprocess.mark_process_dead(pid)
 
+    def _init_log_config(self) -> dict:
+        """Use for Uvicorn same log formatter like for Logprep"""
+        log_config = uvicorn.config.LOGGING_CONFIG
+        log_config["formatters"]["default"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
+        log_config["formatters"]["access"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
+        log_config["handlers"]["default"]["stream"] = "ext://sys.stdout"
+        return log_config
+
+    def _override_runtime_logging(self):
+        """Uvicorn doesn't provide API to change name and handler beforehand
+        needs to be done during runtime"""
+        http_server_name = self._logger.name
+        for logger_name in ["uvicorn", "uvicorn.access"]:
+            logging.getLogger(logger_name).removeHandler(logging.getLogger(logger_name).handlers[0])
+            logging.getLogger(logger_name).addHandler(
+                logging.getLogger("Logprep").parent.handlers[0]
+            )
+        logging.getLogger("uvicorn.access").name = http_server_name
+        logging.getLogger("uvicorn.error").name = http_server_name
+
     def run(self):
         """Starts the default prometheus http endpoint"""
         self._prepare_multiprocessing()
-        start_http_server(self._port)
+
+        self.uvicorn_config = self.configuration.uvicorn_config
+        log_config = self._init_log_config()
+        self.compiled_config = uvicorn.Config(
+            **self.uvicorn_config,
+            port=self._port,
+            app=self._app,
+            log_level="info",
+            log_config=log_config,
+        )
+        self.server = uvicorn.Server(self.compiled_config)
+        self._override_runtime_logging()
+        self.thread = threading.Thread(daemon=True, target=self.server.run)
+        self.thread.start()
+        while not self.server.started:
+            continue
+
         self._logger.info(f"Prometheus Exporter started on port {self._port}")
         self.is_running = True

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -63,5 +63,5 @@ class PrometheusExporter:
         """Starts the default prometheus http endpoint"""
         self._prepare_multiprocessing()
         self._server.start()
-        self._logger.info(f"Prometheus Exporter started on port {self._port}")
+        self._logger.info("Prometheus Exporter started on port %s" % self._port)
         self.is_running = True

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -1,15 +1,12 @@
 """This module contains functionality to start a prometheus exporter and expose metrics with it"""
 
-import logging
 import os
 import shutil
-import threading
 from logging import getLogger
 
-import uvicorn
 from prometheus_client import REGISTRY, make_asgi_app, multiprocess
 
-from logprep.util import defaults, http
+from logprep.util import http
 from logprep.util.configuration import MetricsConfig
 
 

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -45,7 +45,7 @@ class PrometheusExporter:
                 os.remove(os.path.join(root, file))
             for directory in dirs:
                 shutil.rmtree(os.path.join(root, directory), ignore_errors=True)
-        self._logger.info("Cleaned up %s" % multiprocess_dir)
+        self._logger.info("Cleaned up %s", multiprocess_dir)
 
     def mark_process_dead(self, pid):
         """
@@ -63,5 +63,5 @@ class PrometheusExporter:
         """Starts the default prometheus http endpoint"""
         self._prepare_multiprocessing()
         self._server.start()
-        self._logger.info("Prometheus Exporter started on port %s" % self._port)
+        self._logger.info("Prometheus Exporter started on port %s", self._port)
         self.is_running = True

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -306,6 +306,7 @@ class MetricsConfig:
 
     enabled: bool = field(validator=validators.instance_of(bool), default=False)
     port: int = field(validator=validators.instance_of(int), default=8000)
+    uvicorn_config: dict = field(validator=validators.instance_of(dict), factory=dict)
 
 
 @define(kw_only=True)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -311,7 +311,7 @@ class MetricsConfig:
             validators.instance_of(dict),
             validators.deep_mapping(
                 key_validator=validators.in_(http.UVICORN_CONFIG_KEYS),
-                # lamba xyz tuple necessary because of input structure
+                # lambda xyz tuple necessary because of input structure
                 value_validator=lambda x, y, z: True,
             ),
         ],
@@ -429,10 +429,10 @@ class Configuration:
             enabled: true
             port: 9000
             uvicorn_config:
-                access_log: true
-                server_header: false
-                date_header: false
-                workers: 1
+              access_log: true
+              server_header: false
+              date_header: false
+              workers: 1
 
     """
     profile_pipelines: bool = field(default=False, eq=False)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -408,7 +408,33 @@ class Configuration:
         converter=lambda x: MetricsConfig(**x) if isinstance(x, dict) else x,
         eq=False,
     )
-    """Metrics configuration. Defaults to :code:`{"enabled": False, "port": 8000}`."""
+    """Metrics configuration. Defaults to 
+    :code:`{"enabled": False, "port": 8000, "uvicorn_config": {}}`.
+    
+    The key :code:`uvicorn_config` can be configured with any uvicorn config parameters.
+    For further information see the `uvicorn documentation <https://www.uvicorn.org/settings/>`_.
+
+    .. security-best-practice::
+       :title: Metrics Configuration
+       :location: config.metrics.uvicorn_config
+       :suggested-value: below
+
+       Additionaly to the below it is recommended to configure `ssl on the metrics server endpoint
+       <https://www.uvicorn.org/settings/#https>`_
+
+       .. code-block:: yaml
+          :caption: Recommended uvicorn configuration for metrics
+
+          metrics:
+            enabled: true
+            port: 9000
+            uvicorn_config:
+                access_log: true
+                server_header: false
+                date_header: false
+                workers: 1
+
+    """
     profile_pipelines: bool = field(default=False, eq=False)
     """Start the profiler to profile the pipeline. Defaults to :code:`False`."""
     print_auto_test_stack_trace: bool = field(default=False, eq=False)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -423,7 +423,6 @@ class Configuration:
        <https://www.uvicorn.org/settings/#https>`_
 
        .. code-block:: yaml
-          :caption: Recommended uvicorn configuration for metrics
 
           metrics:
             enabled: true

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -417,7 +417,7 @@ class Configuration:
     .. security-best-practice::
        :title: Metrics Configuration
        :location: config.metrics.uvicorn_config
-       :suggested-value: below
+       :suggested-value: metrics.uvicorn_config.access_log: true, metrics.uvicorn_config.server_header: false, metrics.uvicorn_config.data_header: false
 
        Additionaly to the below it is recommended to configure `ssl on the metrics server endpoint
        <https://www.uvicorn.org/settings/#https>`_

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -218,7 +218,7 @@ from logprep.abc.processor import Processor
 from logprep.factory import Factory
 from logprep.factory_error import FactoryError, InvalidConfigurationError
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
-from logprep.util import getter
+from logprep.util import getter, http
 from logprep.util.credentials import CredentialsEnvNotFoundError, CredentialsFactory
 from logprep.util.defaults import (
     DEFAULT_CONFIG_LOCATION,
@@ -306,7 +306,17 @@ class MetricsConfig:
 
     enabled: bool = field(validator=validators.instance_of(bool), default=False)
     port: int = field(validator=validators.instance_of(int), default=8000)
-    uvicorn_config: dict = field(validator=validators.instance_of(dict), factory=dict)
+    uvicorn_config: dict = field(
+        validator=[
+            validators.instance_of(dict),
+            validators.deep_mapping(
+                key_validator=validators.in_(http.UVICORN_CONFIG_KEYS),
+                # lamba xyz tuple necessary because of input structure
+                value_validator=lambda x, y, z: True,
+            ),
+        ],
+        factory=dict,
+    )
 
 
 @define(kw_only=True)

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -59,9 +59,11 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
             Name of the logger instance
         """
 
-        if hasattr(self, "thread"):
-            if self.thread.is_alive():  # pylint: disable=access-member-before-definition
-                self._stop()
+        if (
+            hasattr(self, "thread")
+            and self.thread.is_alive()  # pylint: disable=access-member-before-definition
+        ):
+            self.shut_down()
         internal_uvicorn_config = {
             "lifespan": "off",
             "loop": "asyncio",

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -34,10 +34,9 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
         return log_config
 
     def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            with cls._lock:
-                if not cls._instance:
-                    cls._instance = super(ThreadingHTTPServer, cls).__new__(cls)
+        with cls._lock:
+            if not cls._instance:
+                cls._instance = super(ThreadingHTTPServer, cls).__new__(cls)
         return cls._instance
 
     def __init__(

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -1,3 +1,5 @@
+"""logprep http utils"""
+
 import logging
 import threading
 
@@ -52,6 +54,12 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
         if hasattr(self, "thread"):
             if self.thread.is_alive():  # pylint: disable=access-member-before-definition
                 self._stop()
+        internal_uvicorn_config = {
+            "lifespan": "off",
+            "loop": "asyncio",
+            "timeout_graceful_shutdown": 5,
+        }
+        uvicorn_config = {**internal_uvicorn_config, **uvicorn_config}
         self._logger_name = logger_name
         uvicorn_config = uvicorn.Config(**uvicorn_config, app=app, log_config=self._log_config)
         self.server = uvicorn.Server(uvicorn_config)

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -19,16 +19,6 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
     lifecycle of Uvicorn HTTP Server. During Runtime this singleton object
     is stateful and therefore we need to check for some attributes during
     __init__ when multiple consecutive reconfigurations are happening.
-
-    Parameters
-    ----------
-    connector_config: Input.Config
-        Holds full connector config for config change checks
-    endpoints_config: dict
-        Endpoint paths as key and initiated endpoint objects as
-        value
-    log_level: str
-        Log level to be set for uvicorn server
     """
 
     _instance = None

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -43,9 +43,22 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self, uvicorn_config: dict, app, daemon=True, logger_name="Logprep HTTPServer"
     ) -> None:
-        """Creates object attributes with necessary configuration.
+        """
+        Creates object attributes with necessary configuration.
         As this class creates a singleton object, the existing server
-        will be stopped and restarted on consecutively creations"""
+        will be stopped and restarted on consecutively creations
+
+        Parameters
+        ----------
+        uvicorn_config: dict
+            Holds server config for config change checks
+        app:
+            The app instance that the server should provide
+        daemon: bool
+            Whether the server is in daemon mode or not
+        logger_name: str
+            Name of the logger instance
+        """
 
         if hasattr(self, "thread"):
             if self.thread.is_alive():  # pylint: disable=access-member-before-definition

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -1,0 +1,92 @@
+import logging
+import threading
+
+import uvicorn
+
+from logprep.util import defaults
+
+
+class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
+    """Singleton Wrapper Class around Uvicorn Thread that controls
+    lifecycle of Uvicorn HTTP Server. During Runtime this singleton object
+    is stateful and therefore we need to check for some attributes during
+    __init__ when multiple consecutive reconfigurations are happening.
+
+    Parameters
+    ----------
+    connector_config: Input.Config
+        Holds full connector config for config change checks
+    endpoints_config: dict
+        Endpoint paths as key and initiated endpoint objects as
+        value
+    log_level: str
+        Log level to be set for uvicorn server
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    @property
+    def _log_config(self) -> dict:
+        """Use for Uvicorn same log formatter like for Logprep"""
+        log_config = uvicorn.config.LOGGING_CONFIG
+        log_config["formatters"]["default"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
+        log_config["formatters"]["access"]["fmt"] = defaults.DEFAULT_LOG_FORMAT
+        log_config["handlers"]["default"]["stream"] = "ext://sys.stdout"
+        return log_config
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            with cls._lock:
+                if not cls._instance:
+                    cls._instance = super(ThreadingHTTPServer, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(
+        self, uvicorn_config: dict, app, daemon=True, logger_name="Logprep HTTPServer"
+    ) -> None:
+        """Creates object attributes with necessary configuration.
+        As this class creates a singleton object, the existing server
+        will be stopped and restarted on consecutively creations"""
+
+        if hasattr(self, "thread"):
+            if self.thread.is_alive():  # pylint: disable=access-member-before-definition
+                self._stop()
+        self._logger_name = logger_name
+        uvicorn_config = uvicorn.Config(**uvicorn_config, app=app, log_config=self._log_config)
+        self.server = uvicorn.Server(uvicorn_config)
+        self._override_runtime_logging()
+        self.thread = threading.Thread(daemon=daemon, target=self.server.run)
+
+    def start(self):
+        """Collect all configs, initiate application server and webserver
+        and run thread with uvicorn+falcon http server and wait
+        until it is up (started)"""
+
+        self.thread.start()
+        while not self.server.started:
+            continue
+
+    def _stop(self):
+        """Stop thread with uvicorn+falcon http server, wait for uvicorn
+        to exit gracefully and join the thread"""
+        if self.thread.is_alive():
+            self.server.should_exit = True
+            while self.thread.is_alive():
+                continue
+        self.thread.join()
+
+    def _override_runtime_logging(self):
+        """Uvicorn doesn't provide API to change name and handler beforehand
+        needs to be done during runtime"""
+        for logger_name in ["uvicorn", "uvicorn.access"]:
+            logging.getLogger(logger_name).removeHandler(logging.getLogger(logger_name).handlers[0])
+            logging.getLogger(logger_name).addHandler(
+                logging.getLogger("Logprep").parent.handlers[0]
+            )
+        logging.getLogger("uvicorn.access").name = self._logger_name
+        logging.getLogger("uvicorn.error").name = self._logger_name
+
+    def shut_down(self):
+        """Shutdown method to trigger http server shutdown externally"""
+        self._stop()

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -7,6 +7,8 @@ logger:
 metrics:
   enabled: true
   port: 8003
+  uvicorn_config:
+    access_log: false
 input:
   httpinput:
       type: http_input

--- a/quickstart/exampledata/config/http_pipeline.yml
+++ b/quickstart/exampledata/config/http_pipeline.yml
@@ -8,7 +8,11 @@ metrics:
   enabled: true
   port: 8003
   uvicorn_config:
-    access_log: false
+    host: 0.0.0.0
+    access_log: true
+    server_header: false
+    date_header: false
+    workers: 1
 input:
   httpinput:
       type: http_input
@@ -18,6 +22,10 @@ input:
       uvicorn_config:
           host: 0.0.0.0
           port: 9000
+          workers: 2
+          access_log: true
+          server_header: false
+          date_header: false
       endpoints:
           /auth-json: json
           /json: json

--- a/tests/acceptance/test_full_configuration.py
+++ b/tests/acceptance/test_full_configuration.py
@@ -2,6 +2,7 @@
 import os
 import re
 import tempfile
+import time
 from pathlib import Path
 
 import requests
@@ -162,9 +163,10 @@ def test_logprep_exposes_prometheus_metrics(tmp_path):
         assert "error" not in output.lower(), "error message"
         assert "critical" not in output.lower(), "error message"
         assert "exception" not in output.lower(), "error message"
-        if "Prometheus Exporter started on port 8003" in output:
+        if "Startup complete" in output:
             break
-    response = requests.get("http://127.0.0.1:8003", timeout=5)
+    time.sleep(2)
+    response = requests.get("http://127.0.0.1:8003", timeout=7)
     response.raise_for_status()
     metrics = response.text
     expected_metrics = [

--- a/tests/acceptance/test_full_configuration.py
+++ b/tests/acceptance/test_full_configuration.py
@@ -162,7 +162,7 @@ def test_logprep_exposes_prometheus_metrics(tmp_path):
         assert "error" not in output.lower(), "error message"
         assert "critical" not in output.lower(), "error message"
         assert "exception" not in output.lower(), "error message"
-        if "Finished building pipeline" in output:
+        if "Prometheus Exporter started on port 8003" in output:
             break
     response = requests.get("http://127.0.0.1:8003", timeout=5)
     response.raise_for_status()

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -3,7 +3,6 @@
 # pylint: disable=attribute-defined-outside-init
 import multiprocessing
 import re
-import socket
 from copy import deepcopy
 from unittest import mock
 

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -357,3 +357,14 @@ class TestHttpConnector(BaseInputTestCase):
         """
         requests.post(url=f"{self.target}/jsonl", data=data, timeout=0.5)
         assert self.object.messages.qsize() == 5
+
+    def test_sets_target_to_https_schema_if_ssl_options(self):
+        connector_config = deepcopy(self.CONFIG)
+        connector_config["uvicorn_config"]["ssl_keyfile"] = "path/to/keyfile"
+        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        assert connector.target.startswith("https://")
+
+    def test_sets_target_to_http_schema_if_no_ssl_options(self):
+        connector_config = deepcopy(self.CONFIG)
+        connector = Factory.create({"test connector": connector_config}, logger=self.logger)
+        assert connector.target.startswith("http://")

--- a/tests/unit/metrics/test_exporter.py
+++ b/tests/unit/metrics/test_exporter.py
@@ -30,13 +30,13 @@ class TestPrometheusExporter:
         exporter = PrometheusExporter(metrics_config)
         assert exporter._port == 8000
 
-    @mock.patch("logprep.metrics.exporter.start_http_server")
-    def test_run_starts_http_server(self, mock_http_server, caplog):
+    @mock.patch("logprep.util.http.ThreadingHTTPServer.start")
+    def test_run_starts_http_server(self, mock_http_server_start, caplog):
         with caplog.at_level(logging.INFO):
             exporter = PrometheusExporter(self.metrics_config)
             exporter.run()
 
-        mock_http_server.assert_has_calls([mock.call(exporter._port)])
+        mock_http_server_start.assert_called()
         assert f"Prometheus Exporter started on port {exporter._port}" in caplog.text
 
     def test_cleanup_prometheus_multiprocess_dir_deletes_temp_dir_contents_but_not_the_dir_itself(

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -81,13 +81,13 @@ class TestConfiguration:
             ("logger", {"level": "INFO"}, {"level": "DEBUG"}),
             (
                 "metrics",
-                {"enabled": False, "port": 8000},
-                {"enabled": True, "port": 9000},
+                {"enabled": False, "port": 8000, "uvicorn_config": {"log_level": "INFO"}},
+                {"enabled": True, "port": 9000, "uvicorn_config": {"log_level": "DEBUG"}},
             ),
             (
                 "metrics",
                 {"enabled": False, "port": 8000},
-                {"enabled": True, "port": 9000},
+                {"enabled": True, "port": 9000, "uvicorn_config": {}},
             ),
         ],
     )

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -81,8 +81,8 @@ class TestConfiguration:
             ("logger", {"level": "INFO"}, {"level": "DEBUG"}),
             (
                 "metrics",
-                {"enabled": False, "port": 8000, "uvicorn_config": {"log_level": "INFO"}},
-                {"enabled": True, "port": 9000, "uvicorn_config": {"log_level": "DEBUG"}},
+                {"enabled": False, "port": 8000, "uvicorn_config": {"access_log": True}},
+                {"enabled": True, "port": 9000, "uvicorn_config": {"access_log": False}},
             ),
             (
                 "metrics",


### PR DESCRIPTION
this change adds the uvicorn webserver to the metrics endpoint to be able to disable server side headers, and to enable an access log. Beside this, you are now able to configure ssl transport security for the metrics endpoint. 

closes #575