### PR TITLE
fix logprep quickstart profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bugfix
 
 * fixes exposing OpenSearch/ElasticSearch stacktraces in log when errors happen by making loglevel configurable for loggers `opensearch` and `elasticsearch`
+* fixes the logprep quickstart profile
 
 ## 11.2.1
 

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -78,6 +78,9 @@ services:
   logprep:
     build:
       context: ..
+      args:
+        LOGPREP_VERSION: dev
+        PYTHON_VERSION: "3.11"
     image: logprep
     container_name: logprep
     profiles:
@@ -90,8 +93,11 @@ services:
       - opensearch
     volumes:
       - ../quickstart/:/home/logprep/quickstart/
+    tmpfs:
+      - /tmp/logprep/prometheus_multiproc 
     entrypoint:
       - logprep
+      - run
       - /home/logprep/quickstart/exampledata/config/pipeline.yml
   grafana:
     image: bitnami/grafana:latest


### PR DESCRIPTION
* fixes logprep quickstart profile
* test with:

```bash
docker compose -f ./quickstart/docker-compose.yml --profile logprep up -d --build
docker logs logprep -f
```