### PR TITLE
set upper python version limit to <3.12.4 and revise github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,38 +8,8 @@ on:
     types: [opened, synchronize]
 
 jobs:
-
   test:
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip wheel
-          pip install .[dev]
-
-      - name: Perform unit tests
-        env:
-          PYTEST_ADDOPTS: "--color=yes"
-        run: |
-          pytest  -vv tests/unit
-      
-      - name: Perform acceptance tests
-        env:
-          PYTEST_ADDOPTS: "--color=yes"
-        run: |
-          pytest  -vv tests/acceptance
+    uses: ./.github/workflows/testing.yml
 
   build-docs:
     runs-on: ubuntu-22.04
@@ -117,7 +87,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12.3"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,38 +6,8 @@ on:
     branches: [main]
 
 jobs:
-
   test:
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip wheel
-          pip install .[dev]
-
-      - name: Perform unit tests
-        env:
-          PYTEST_ADDOPTS: "--color=yes"
-        run: |
-          pytest  -vv tests/unit
-
-      - name: Perform acceptance tests
-        env:
-          PYTEST_ADDOPTS: "--color=yes"
-        run: |
-          pytest  -vv tests/acceptance
+    uses: ./.github/workflows/testing.yml
 
   code-quality:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-latest-dev-release-to-pypi.yml
+++ b/.github/workflows/publish-latest-dev-release-to-pypi.yml
@@ -39,7 +39,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12.3"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           name: logprep-build
           path: dist
-    
+
   publish-latest-release-to-pypi:
     runs-on: ubuntu-latest
     name: Publish release to PyPi
@@ -52,7 +52,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12.3"]
 
     runs-on: ubuntu-latest
     needs: publish-latest-release-to-pypi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,28 @@
+name: Testing
+
+on:
+  workflow_call:
+
+jobs:
+  python:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12.3"]
+        test-type: ["unit", "acceptance"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip wheel
+          pip install .[dev]
+      - name: Perform ${{ matrix.test-type }} test
+        env:
+          PYTEST_ADDOPTS: "--color=yes"
+        run: |
+          pytest -vv -s tests/${{ matrix.test-type }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           PYTEST_ADDOPTS: "--color=yes"
         run: |
-          pytest -vv -s tests/${{ matrix.test-type }}
+          pytest -vv tests/${{ matrix.test-type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 
 ## next release
 
+This release limits the maximum python version to `3.12.3` because of the issue
+[#612](https://github.com/fkie-cad/Logprep/issues/612).
+
 ### Breaking
 ### Features
 ### Improvements
+* a result object was added which is returned by every processor
+  * includes generated extra_data, warnings and errors
+
 ### Bugfix
 
 ## 12.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ fallback_version = "unset"
 [project]
 name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12.4"
 readme = "README.md"
 dynamic = ["version"]
 license = { file = "LICENSE" }


### PR DESCRIPTION
includes following changes:
- update CHANGELOG.md to include python version limitation
- build containers for 3.12.3
- split test workflow (unit,acceptance)
- increase wait time for http_input acceptance test and split test workflow (unit,acceptance)

These changes were done because of #612 