### PR TITLE
Pseudonymizer late error on non existing regexmapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release limits the maximum python version to `3.12.3` because of the issue
 
 * fixes a bug where it could happen that a config value could be overwritten by a default in a later configuration in a multi source config scenario
 * fixes a bug in the `field_manager` where extending a non list target leads to a processing failure
+* fixes a bug in `pseudonymizer` where a missing regex_mapping from an existing config_file causes logprep to crash continuously
 
 ## 12.0.0
 

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -58,6 +58,7 @@ from tldextract import TLDExtract
 from urlextract import URLExtract
 
 from logprep.abc.processor import Processor
+from logprep.factory_error import InvalidConfigurationError
 from logprep.metrics.metrics import CounterMetric, GaugeMetric
 from logprep.processor.field_manager.processor import FieldManager
 from logprep.processor.pseudonymizer.rule import PseudonymizerRule
@@ -241,6 +242,10 @@ class Pseudonymizer(FieldManager):
             for dotted_field, regex_keyword in rule.pseudonyms.items():
                 if regex_keyword in self._regex_mapping:
                     rule.pseudonyms[dotted_field] = re.compile(self._regex_mapping[regex_keyword])
+                else:
+                    raise InvalidConfigurationError(
+                        f"Regex keyword '{regex_keyword}' not found in regex_mapping '{self._config.regex_mapping}'"
+                    )
 
     def _apply_rules(self, event: dict, rule: PseudonymizerRule):
         source_dict = {}

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -242,7 +242,7 @@ class Pseudonymizer(FieldManager):
             for dotted_field, regex_keyword in rule.pseudonyms.items():
                 if regex_keyword in self._regex_mapping:
                     rule.pseudonyms[dotted_field] = re.compile(self._regex_mapping[regex_keyword])
-                else:
+                elif isinstance(regex_keyword, str):  # after the first run, the regex is compiled
                     raise InvalidConfigurationError(
                         f"Regex keyword '{regex_keyword}' not found in regex_mapping '{self._config.regex_mapping}'"
                     )


### PR DESCRIPTION
check with:

1. create `pipeline.yml`

```yaml
input:
  dummy:
    type: dummy_input
    documents: [{ "foo": "bar" }]
output:
  dummy:
    type: dummy_output
pipeline:
  - pseudonymizername:
      type: pseudonymizer
      specific_rules:
        - filter: foo
          pseudonymizer:
            mapping:
              foo: DOES_NOT_EXIST
      generic_rules: []
      outputs:
        - dummy: pseudonyms_topic
      pubkey_analyst: analyst.crt
      pubkey_depseudo: depseudo.crt
      hash_salt: secret_salt
      regex_mapping: tests/testdata/unit/pseudonymizer/pseudonymizer_regex_mapping.yml
      max_cached_pseudonyms: 1000000
```

2. create needed pseudo keys

```bash
logprep pseudo generate -f analyst 1024
logprep pseudo generate -f depseudo 2048
```

run logprep with:

```bash
logprep run ./pipeline.yml
```

you will get nice error output complaining the regex mapping is not found
