### PR TITLE
Fix http output timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Improvements
 ### Bugfix
 
+* fixes a bug in the `http_output` used by the http generator, where the timeout parameter does only set the read_timeout not the write_timeout
+
 ## 13.1.0
 ### Features
 

--- a/logprep/connector/http/output.py
+++ b/logprep/connector/http/output.py
@@ -188,7 +188,7 @@ class HttpOutput(Output):
                     headers=self._headers,
                     verify=False,
                     auth=(self.user, self.password),
-                    timeout=self.timeout,
+                    timeout=(self.timeout, self.timeout),
                     data=request_data,
                 )
                 logger.debug("Servers response code is: %i", response.status_code)


### PR DESCRIPTION
according to https://docs.python-requests.org/en/latest/user/advanced/#timeouts timeout parameter can be specified as tupe for read and write timeouts