### PR TITLE
add rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,12 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
-        # env:
-        #   # configure cibuildwheel to build native archs ('auto'), and some
-        #   # emulated ones
-        #   CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+        env:
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_BUILD_LINUX: "cp310-* cp311-* cp312-*"
+          CIBW_SKIP_LINUX: "*pp* *i686*musl*"
+          CIBW_BEFORE_BUILD_LINUX: "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+          CIBW_ENVIRONMENT: "PATH=$HOME/.cargo/bin:$PATH"
 
   containerbuild:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse --platform linux --archs ${{ matrix.arch }}
 
-      - name: Upload Artifact for next job
-        uses: actions/upload-artifact@master
-        with:
-          name: logprep-build-${{ matrix.arch }}
-          path: wheelhouse
-
   containerbuild:
-    needs: build_wheels
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12.3"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,11 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ubuntu-22.04
-
+    strategy:
+      matrix:
+        python-version: ["cp310", "cp311", "cp312"]
+        arch: ["x86_64", "i686", "aarch64"]
+        flavor: ["manylinux", "musllinux"]
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +118,7 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse --only ${{ matrix.python-version }}-${{ matrix.flavor }}-${{ matrix.arch }}
 
   containerbuild:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Upload Artifact for next job
         uses: actions/upload-artifact@master
         with:
-          name: logprep-build
+          name: logprep-build-${{ matrix.arch }}
           path: wheelhouse
 
   containerbuild:
@@ -132,12 +132,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact from previous job
-        uses: actions/download-artifact@master
-        with:
-          name: logprep-build
-          path: wheelhouse
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - name: Initialize Python
+        uses: actions/setup-python@v1
         with:
           python-version: "3.11"
 
@@ -116,7 +116,19 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse --platform linux --archs ${{ matrix.arch }}
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build binary wheel and a source tarball
+        run: pipx run build --sdist
+
+      - name: copy artifacts to dist folder
+        run: cp ./wheelhouse/* ./dist/
+
+      - name: Upload Artifact for next job
+        uses: actions/upload-artifact@master
+        with:
+          name: logprep-build
+          path: dist
 
   containerbuild:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse --archs x86_64,aarch64
 
       - name: Build binary wheel and a source tarball
         run: pipx run build --sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["cp310", "cp311", "cp312"]
         arch: ["x86_64", "i686", "aarch64"]
-        flavor: ["manylinux", "musllinux"]
     steps:
       - uses: actions/checkout@v4
 
@@ -118,7 +116,7 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse --only ${{ matrix.python-version }}-${{ matrix.flavor }}-${{ matrix.arch }}
+        run: python -m cibuildwheel --output-dir wheelhouse --platform linux --archs ${{ matrix.arch }}
 
   containerbuild:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,26 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse --platform linux --archs ${{ matrix.arch }}
 
+      - name: Upload Artifact for next job
+        uses: actions/upload-artifact@master
+        with:
+          name: logprep-build
+          path: wheelhouse
+
   containerbuild:
+    needs: build_wheels
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12.3"]
 
     runs-on: ubuntu-latest
     steps:
+      - name: Download artifact from previous job
+        uses: actions/download-artifact@master
+        with:
+          name: logprep-build
+          path: wheelhouse
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,11 @@ jobs:
         with:
           platforms: all
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v1.12.0
-        env:
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_BUILD_LINUX: "cp310-* cp311-* cp312-*"
-          CIBW_SKIP_LINUX: "*pp* *i686*musl*"
-          CIBW_BEFORE_BUILD_LINUX: "curl -sSf https://sh.rustup.rs | sh -s -- -y"
-          CIBW_ENVIRONMENT: "PATH=$HOME/.cargo/bin:$PATH"
+        run: python -m cibuildwheel --output-dir wheelhouse
 
   containerbuild:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ["x86_64", "i686", "aarch64"]
+        arch: ["x86_64", "aarch64"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,40 +93,6 @@ jobs:
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v2
 
-  build_wheels:
-    name: Build wheels
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Initialize Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: "3.11"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse --archs x86_64,aarch64
-
-      - name: Build binary wheel and a source tarball
-        run: pipx run build --sdist
-
-      - name: copy artifacts to dist folder
-        run: cp ./wheelhouse/* ./dist/
-
-      - name: Upload Artifact for next job
-        uses: actions/upload-artifact@master
-        with:
-          name: logprep-build
-          path: dist
-
   containerbuild:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,30 @@ jobs:
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v2
 
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.11"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
+        # env:
+        #   # configure cibuildwheel to build native archs ('auto'), and some
+        #   # emulated ones
+        #   CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+
   containerbuild:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,6 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        arch: ["x86_64", "aarch64"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-latest-dev-release-to-pypi.yml
+++ b/.github/workflows/publish-latest-dev-release-to-pypi.yml
@@ -17,14 +17,24 @@ jobs:
       - name: Initialize Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip wheel
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse --archs x86_64,aarch64
 
       - name: Build binary wheel and a source tarball
-        run: pip wheel --no-deps --wheel-dir ./dist .
+        run: pipx run build --sdist
+
+      - name: copy artifacts to dist folder
+        run: cp ./wheelhouse/* ./dist/
 
       - uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -14,14 +14,24 @@ jobs:
       - name: Initialize Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Build binary wheel and a source tarball
-        run: pip wheel --no-deps --wheel-dir ./dist .
+        run: pipx run build --sdist
+
+      - name: copy artifacts to dist folder
+        run: cp ./wheelhouse/* ./dist/
 
       - name: Upload Artifact for next job
         uses: actions/upload-artifact@master

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse --archs x86_64,aarch64
 
       - name: Build binary wheel and a source tarball
         run: pipx run build --sdist

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,6 +4,12 @@ on:
   workflow_call:
 
 jobs:
+  rust:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Perform tests for rust modules
+        run: cargo test
   python:
     runs-on: ubuntu-22.04
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ logprep.log
 examples/k8s/charts
 *.so
 target
+wheelhouse

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ experiments
 logprep.log
 /charts/logprep/charts
 examples/k8s/charts
+*.so
+target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Improvements
 
 * remove AutoRuleCorpusTester
+* adds support for rust extension  development
+* adds prebuild wheels for architectures `x86_64 i686 aarch64` on `manylinux` and `musllinux` based linux platforms
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * remove AutoRuleCorpusTester
 * adds support for rust extension  development
-* adds prebuild wheels for architectures `x86_64 i686 aarch64` on `manylinux` and `musllinux` based linux platforms
+* adds prebuild wheels for architectures `x86_64` and `aarch64` on `manylinux` and `musllinux` based linux platforms
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Improvements
 
 * remove AutoRuleCorpusTester
-* adds support for rust extension  development
-* adds prebuild wheels for architectures `x86_64` and `aarch64` on `manylinux` and `musllinux` based linux platforms
+* adds support for rust extension development
+* adds prebuild wheels for architectures `x86_64` and `aarch64` on `manylinux` and `musllinux` based linux platforms to releases
 
 ### Bugfix
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "rust"
+path = "rust/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = "0.22.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ARG no_proxy
 
 ADD . /logprep
 WORKDIR /logprep
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN python -m pip install --upgrade pip wheel setuptools>=72.2.0
 RUN python -m venv /opt/venv
 # Make sure we use the virtualenv:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include Cargo.toml
+recursive-include rust *

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=logging-fstring-interpolation
 
-import ctypes
 import logging
 import logging.handlers
 import multiprocessing
@@ -20,8 +19,6 @@ from logprep.metrics.exporter import PrometheusExporter
 from logprep.metrics.metrics import CounterMetric
 from logprep.util.configuration import Configuration
 from logprep.util.logging import LogprepMPQueueListener, logqueue
-
-libc = ctypes.CDLL("libc.so.6")
 
 logger = logging.getLogger("Manager")
 
@@ -48,7 +45,7 @@ class ThrottlingQueue(multiprocessing.queues.Queue):
                 self.wait_time, int(self.wait_time * self.consumed_percent / batch_size)
             )
             # sleep times in microseconds
-            libc.usleep(sleep_time)
+            time.sleep(sleep_time / 1000)
 
     def put(self, obj, block=True, timeout=None, batch_size=1):
         """Put an obj into the queue."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ binding = "PyO3"    # Default value, can be omitted
 [project]
 name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
-requires-python = ">=3.10,<=3.12.3"
+requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ binding = "PyO3"    # Default value, can be omitted
 [project]
 name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
-requires-python = ">=3.10,<3.12.4"
+requires-python = ">=3.10,<=3.12.3"
 readme = "README.md"
 dynamic = ["version"]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ profile = "black"
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-*"
-skip = "*pp* *i686*musl*"
+skip = "*pp* *i686-unknown-linux-musl*"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 i686 aarch64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,24 @@
 [build-system]
-requires = ["setuptools>=68.0.0", "setuptools-scm>=8.0", "wheel"]
+requires = [
+  "setuptools>=68.0.0",
+  "setuptools-scm>=8.0",
+  "wheel",
+  "setuptools-rust",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["logprep"]
 
-
 [tool.setuptools_scm]
 fallback_version = "unset"
+
+[[tool.setuptools-rust.ext-modules]]
+# Private Rust extension module to be nested into the Python package
+target = "rust" # The last part of the name (e.g. "_lib") has to match lib.name in Cargo.toml,
+# but you can add a prefix to nest it inside of a Python package.
+path = "Cargo.toml" # Default value, can be omitted
+binding = "PyO3"    # Default value, can be omitted
 
 [project]
 name = "logprep"
@@ -98,6 +109,7 @@ dev = [
   "pytest-cov",
   "responses",
   "jinja2",
+  "maturin",
 ]
 
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-package-dir = { "" = "logprep" }
+package-dir = { "logprep" = "logprep" }
+packages = ["logprep"]
 
 [tool.setuptools_scm]
 fallback_version = "unset"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["logprep"]
+package-dir = { "" = "logprep" }
 
 [tool.setuptools_scm]
 fallback_version = "unset"
@@ -110,6 +110,7 @@ dev = [
   "responses",
   "jinja2",
   "maturin",
+  "cibuildwheel",
 ]
 
 doc = [
@@ -145,3 +146,12 @@ extend-exclude = '''
 
 [tool.isort]
 profile = "black"
+
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-*"
+skip = "*pp* *i686*musl*"
+
+[tool.cibuildwheel.linux]
+archs = "x86_64 i686 aarch64"
+before-build = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+environment = 'PATH=$HOME/.cargo/bin:$PATH'

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,72 @@
+/target
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+.pytest_cache/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+.venv/
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+include/
+man/
+venv/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+pip-selfcheck.json
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+.DS_Store
+
+# Sphinx documentation
+docs/_build/
+
+# PyCharm
+.idea/
+
+# VSCode
+.vscode/
+
+# Pyenv
+.python-version

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,0 +1,22 @@
+use pyo3::prelude::*;
+
+/// Formats the sum of two numbers as string.
+#[pyfunction]
+fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+
+/// A Python module implemented in Rust.
+#[pymodule]
+fn rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!("4", "4");
+    }
+}

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 mod tests;
 use pyo3::prelude::*;
 

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod tests;
 use pyo3::prelude::*;
 
 /// Formats the sum of two numbers as string.
@@ -11,12 +13,4 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 fn rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!("4", "4");
-    }
 }

--- a/rust/tests/mod.rs
+++ b/rust/tests/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(test)]
+#[test]
+fn it_works() {
+    assert_eq!("4", "4");
+}

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -5,7 +5,6 @@ import logging
 import multiprocessing
 from copy import deepcopy
 from logging import DEBUG
-from multiprocessing import Lock
 from unittest import mock
 
 import pytest

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -277,14 +277,14 @@ class TestThrottlingQueue:
             mock_throttle.assert_called()
 
     def test_throttle_sleeps(self):
-        with mock.patch("logprep.framework.pipeline_manager.libc.usleep") as mock_sleep:
+        with mock.patch("time.sleep") as mock_sleep:
             queue = ThrottlingQueue(multiprocessing.get_context(), 100)
             with mock.patch.object(queue, "qsize", return_value=95):
                 queue.throttle()
             mock_sleep.assert_called()
 
     def test_throttle_sleep_time_increases_with_qsize(self):
-        with mock.patch("logprep.framework.pipeline_manager.libc.usleep") as mock_sleep:
+        with mock.patch("time.sleep") as mock_sleep:
             queue = ThrottlingQueue(multiprocessing.get_context(), 100)
             with mock.patch.object(queue, "qsize", return_value=91):
                 queue.throttle()

--- a/tests/unit/rust/test_rust.py
+++ b/tests/unit/rust/test_rust.py
@@ -1,0 +1,5 @@
+import rust
+
+
+def test_example():
+    assert rust.sum_as_string(1, 2) == "3"


### PR DESCRIPTION
this adds rust toolchain with setuptools-rust and multiplatform builds with cibuildwheel.
see changelog for more.

ToDo:

- [x] add simple rust example
- [x] add basic compilation and packaging for x64 arch
- [x] add cross compilation and packaging for at minimum arm64 and x64 on manylinux and musllinux
- [x] test package publishing and installation to and from pypi
- [x] add rust library tests to unittest ci pipeline
- [x] fix 3.12 build
