### PR TITLE
Fix exporter restart 

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -62,7 +62,13 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: sh -c "((sleep 15 && echo 'kafka up' && kafka-topics.sh --create --if-not-exists --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 4 --topic consumer)&) && /opt/bitnami/scripts/kafka/run.sh"
+    command: |
+      sh -c 
+      "((sleep 15 && echo 'kafka up' && 
+      kafka-topics.sh --create --if-not-exists --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 4 --topic consumer && 
+      kafka-topics.sh --create --if-not-exists --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 4 --topic errors && 
+      kafka-topics.sh --create --if-not-exists --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 4 --topic producer)&) && 
+      /opt/bitnami/scripts/kafka/run.sh"
     healthcheck:
       test:
         [

--- a/examples/exampledata/config/http_pipeline.yml
+++ b/examples/exampledata/config/http_pipeline.yml
@@ -1,7 +1,8 @@
 version: 2
-process_count: 8
-config_refresh_interval: 300
+process_count: 4
+config_refresh_interval: 5
 profile_pipelines: false
+restart_count: 3
 logger:
   level: INFO
   loggers:
@@ -47,6 +48,7 @@ input:
       /json: json
       /lab/123/(ABC|DEF)/pl.*: plaintext
       /lab/123/ABC/auditlog: jsonl
+
 output:
   kafka:
     type: confluentkafka_output

--- a/examples/exampledata/config/pipeline.yml
+++ b/examples/exampledata/config/pipeline.yml
@@ -2,6 +2,7 @@ version: 1
 process_count: 2
 timeout: 0.1
 restart_count: 2
+config_refresh_interval: 5
 logger:
   level: INFO
   format: "%(asctime)-15s %(hostname)-5s %(name)-10s %(levelname)-8s: %(message)s"

--- a/logprep/connector/jsonl/output.py
+++ b/logprep/connector/jsonl/output.py
@@ -52,7 +52,7 @@ class JsonlOutput(Output):
     failed_events: list
 
     __slots__ = [
-        "ast_timeout",
+        "last_timeout",
         "events",
         "failed_events",
     ]

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -53,7 +53,7 @@ class PrometheusExporter:
         self.healthcheck_functions = None
         self._multiprocessing_prepared = False
 
-    def _prepare_multiprocessing(self):
+    def prepare_multiprocessing(self):
         """
         Sets up the proper metric registry for multiprocessing and handles the necessary
         temporary multiprocessing directory that the prometheus client expects.
@@ -93,7 +93,7 @@ class PrometheusExporter:
             return
         port = self.configuration.port
         self.init_server(daemon=daemon)
-        self._prepare_multiprocessing()
+        self.prepare_multiprocessing()
         self.server.start()
         logger.info("Prometheus Exporter started on port %s", port)
 
@@ -116,6 +116,7 @@ class PrometheusExporter:
     def update_healthchecks(self, healthcheck_functions: Iterable[Callable], daemon=True) -> None:
         """Updates the healthcheck functions"""
         self.healthcheck_functions = healthcheck_functions
-        self.server.shut_down()
+        if self.server and self.server.thread and self.server.thread.is_alive():
+            self.server.shut_down()
         self.init_server(daemon=daemon)
         self.run()

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -82,6 +82,9 @@ def run(configs: tuple[str], version=None) -> None:
         runner = Runner.get_runner(configuration)
         logger.debug("Configuration loaded")
         runner.start()
+    except SystemExit as error:
+        logger.error(f"Error during setup: error code {error.code}")
+        sys.exit(error.code)
     # pylint: disable=broad-except
     except Exception as error:
         if os.environ.get("DEBUG", False):

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -1,5 +1,6 @@
 """logprep http utils"""
 
+import atexit
 import inspect
 import json
 import logging
@@ -52,7 +53,7 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
         logger_name: str
             Name of the logger instance
         """
-
+        atexit.register(self.shut_down, wait=0.1)
         if (
             hasattr(self, "thread")
             and self.thread is not None

--- a/logprep/util/logging.py
+++ b/logprep/util/logging.py
@@ -47,5 +47,6 @@ class LogprepMPQueueListener(QueueListener):
 
     def stop(self):
         self.enqueue_sentinel()
-        self._process.join()
+        if self._process and hasattr(self._process, "join"):
+            self._process.join()
         self._process = None

--- a/tests/acceptance/test_config_refresh.py
+++ b/tests/acceptance/test_config_refresh.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring
+import tempfile
 from pathlib import Path
 
+import pytest
 from ruamel.yaml import YAML
 
 from logprep.util.configuration import Configuration
@@ -9,17 +11,46 @@ from tests.acceptance.util import start_logprep, stop_logprep, wait_for_output
 yaml = YAML(typ="safe", pure=True)
 
 
+@pytest.fixture(name="config")
+def get_config():
+    input_file = tempfile.mkstemp(suffix=".input.log")[1]
+
+    config_dict = {
+        "version": "1",
+        "process_count": 1,
+        "timeout": 0.1,
+        "profile_pipelines": False,
+        "config_refresh_interval": 5,
+        "metrics": {"enabled": False},
+        "pipeline": [],
+        "input": {
+            "file_input": {
+                "type": "file_input",
+                "logfile_path": input_file,
+                "start": "begin",
+                "interval": 1,
+                "watch_file": True,
+            }
+        },
+        "output": {
+            "jsonl_output": {
+                "type": "dummy_output",
+            }
+        },
+    }
+
+    return Configuration(**config_dict)
+
+
 def teardown_function():
     Path("generated_config.yml").unlink(missing_ok=True)
     stop_logprep()
 
 
-def test_two_times_config_refresh_after_5_seconds(tmp_path):
-    config = Configuration.from_sources(["tests/testdata/config/config.yml"])
-    config.config_refresh_interval = 5
-    config.metrics = {"enabled": False}
+def test_two_times_config_refresh_after_5_seconds(tmp_path, config):
     config_path = tmp_path / "generated_config.yml"
     config_path.write_text(config.as_json())
+    config = Configuration.from_sources([str(config_path)])
     proc = start_logprep(config_path)
     wait_for_output(proc, "Config refresh interval is set to: 5 seconds", test_timeout=5)
     config.version = "2"
@@ -27,11 +58,10 @@ def test_two_times_config_refresh_after_5_seconds(tmp_path):
     wait_for_output(proc, "Successfully reloaded configuration", test_timeout=12)
     config.version = "other version"
     config_path.write_text(config.as_json())
-    wait_for_output(proc, "Successfully reloaded configuration", test_timeout=12)
+    wait_for_output(proc, "Successfully reloaded configuration", test_timeout=20)
 
 
-def test_no_config_refresh_after_5_seconds(tmp_path):
-    config = Configuration.from_sources(["tests/testdata/config/config.yml"])
+def test_no_config_refresh_after_5_seconds(tmp_path, config):
     config.config_refresh_interval = 5
     config.metrics = {"enabled": False}
     config_path = tmp_path / "generated_config.yml"

--- a/tests/acceptance/test_full_configuration.py
+++ b/tests/acceptance/test_full_configuration.py
@@ -166,6 +166,7 @@ def test_logprep_exposes_prometheus_metrics(tmp_path):
         assert "error" not in output.lower(), "error message"
         assert "critical" not in output.lower(), "error message"
         assert "exception" not in output.lower(), "error message"
+        assert not re.search("Shutting down", output)
         if "Startup complete" in output:
             break
     time.sleep(2)

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -141,9 +141,9 @@ def get_runner_outputs(patched_runner: Runner) -> list:
 
     try:
         patched_runner.start()
+        patched_runner.stop_and_exit()
     except SystemExit as error:
         assert not error.code, f"Runner exited with code {error.code}"
-
     for index, output_path in enumerate(output_paths):
         parsed_outputs[index] = parse_jsonl(output_path)
         remove_file_if_exists(output_path)

--- a/tests/unit/metrics/test_exporter.py
+++ b/tests/unit/metrics/test_exporter.py
@@ -15,7 +15,7 @@ from logprep.util.configuration import MetricsConfig
 
 
 @mock.patch(
-    "logprep.metrics.exporter.PrometheusExporter._prepare_multiprocessing",
+    "logprep.metrics.exporter.PrometheusExporter.prepare_multiprocessing",
     new=lambda *args, **kwargs: None,
 )
 class TestPrometheusExporter:
@@ -107,7 +107,7 @@ class TestPrometheusExporter:
 
 
 @mock.patch(
-    "logprep.metrics.exporter.PrometheusExporter._prepare_multiprocessing",
+    "logprep.metrics.exporter.PrometheusExporter.prepare_multiprocessing",
     new=lambda *args, **kwargs: None,
 )
 class TestHealthEndpoint:


### PR DESCRIPTION
This fixes an error from previous health check implementation causing the exporter restarting on first start of logprep.

it was extracted from #668 to reduce amount of changes