### PR TITLE
Remove broken kafka implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 ### Bugfix
 
 * ensure `logprep.abc.Component.Config` is immutable and can be applied multiple times
+* remove lost callback reassign behavior from `kafka_input` connector
+* remove manual commit option from `kafka_input` connector
 
 ## 13.1.2
 ### Bugfix

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -256,6 +256,20 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         mock_consumer.assert_called_with(injected_config)
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
+    def test_auto_offset_store_and_auto_commit_are_managed_by_connector(self, mock_consumer):
+        config = deepcopy(self.CONFIG)
+        config["kafka_config"] |= {
+            "enable.auto.offset.store": "true",
+            "enable.auto.commit": "false",
+        }
+        kafka_input = Factory.create({"test": config})
+        _ = kafka_input._consumer
+        mock_consumer.assert_called()
+        injected_config = mock_consumer.call_args[0][0]
+        assert injected_config.get("enable.auto.offset.store") == "false"
+        assert injected_config.get("enable.auto.commit") == "true"
+
+    @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_client_id_can_be_overwritten(self, mock_consumer):
         input_config = deepcopy(self.CONFIG)
         input_config["kafka_config"]["client.id"] = "thisclientid"


### PR DESCRIPTION
This removes the reassign behavior addressed in #673 and the buggy manual commit feature addressed in #653

closes #673 
closes #653


