### PR TITLE
change base image to bitnami/python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * move `Configuration` to top level of documentation
 * add `CONTRIBUTING` file
 * sets the default for `flush_timeout` and `send_timeout` in `kafka_output` connector to `0` seconds
+* changed python base image for logprep to `bitnami/python` in cause of better CVE governance
 
 ### Bugfix
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.10
 
-FROM python:${PYTHON_VERSION}-bullseye as build
+FROM bitnami/python:${PYTHON_VERSION} as build
 ARG LOGPREP_VERSION=latest
 ARG http_proxy
 ARG https_proxy
@@ -21,7 +21,7 @@ RUN if [ "$LOGPREP_VERSION" = "dev" ]; then pip install .;\
     logprep --version
 
 
-FROM python:${PYTHON_VERSION}-slim as prod
+FROM bitnami/python:${PYTHON_VERSION} as prod
 ARG http_proxy
 ARG https_proxy
 COPY --from=build /opt/venv /opt/venv


### PR DESCRIPTION
As stated in the title this changes the base image to bitnami/python in cause of a better cve governance.