### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ADD . /logprep
 WORKDIR /logprep
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN python -m pip install --upgrade pip wheel setuptools>=72.2.0
-RUN python -m venv /opt/venv
+RUN python -m venv --without-pip /opt/venv
 # Make sure we use the virtualenv:
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN if [ "$LOGPREP_VERSION" = "dev" ]; then pip install .;\
     else pip install "logprep==$LOGPREP_VERSION"; fi; \
     logprep --version
 
+# geoip2 4.8.0 lists a vulnerable setuptools version as a dependency. setuptools is unneeded at runtime, so it is uninstalled.
+# More recent (currently unreleased) versions of geoip2 removed setuptools from dependencies.
+RUN pip uninstall -y setuptools
+
 
 FROM bitnami/python:${PYTHON_VERSION} as prod
 ARG http_proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ dependencies = [
   "urlextract",
   "urllib3>=1.26.17",         # CVE-2023-43804
   "uvicorn",
-  "wheel",
   "deepdiff",
   "msgspec",
   "boto3",


### PR DESCRIPTION
## Changes

- Remove wheel runtime dependency. It is only needed at build time.
- Dont install pip into venv. It is not needed at runtime. Fixes CVE-2023-5752.
- Remove setuptools dependency after building. Fixes CVE-2022-40897. Note that setuptools is only a build depdendency, but is still present at runtime, because the geoip2 package references a vulnerable version as a dependency.


## Trivy Image scan results

Scanned using `trivy image IMAGE --ignore-unfixed`

### Before

```
Python (python-pkg)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 2, CRITICAL: 0)

┌───────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────┐
│        Library        │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                          Title                           │
├───────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ pip (METADATA)        │ CVE-2023-5752  │ MEDIUM   │ fixed  │ 23.0.1            │ 23.3          │ pip: Mercurial configuration injectable in repo revision │
│                       │                │          │        │                   │               │ when installing via pip                                  │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5752                │
├───────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ setuptools (METADATA) │ CVE-2022-40897 │ HIGH     │        │ 65.5.0            │ 65.5.1        │ pypa-setuptools: Regular Expression Denial of Service    │
│                       │                │          │        │                   │               │ (ReDoS) in package_index.py                              │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-40897               │
│                       ├────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────┤
│                       │ CVE-2024-6345  │          │        │                   │ 70.0.0        │ pypa/setuptools: Remote code execution via download      │
│                       │                │          │        │                   │               │ functions in the package_index module in...              │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6345                │
└───────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────┘

opt/bitnami/python (bitnami)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬──────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                          Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────┤
│ python  │ CVE-2023-36632 │ HIGH     │ fixed  │ 3.10.15-4         │ 3.11.4         │ python: RecursionError: maximum recursion depth exceeded │
│         │                │          │        │                   │                │ while calling a Python object                            │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-36632               │
│         ├────────────────┼──────────┤        │                   ├────────────────┼──────────────────────────────────────────────────────────┤
│         │ CVE-2023-27043 │ MEDIUM   │        │                   │ 2.7.18, 3.11.0 │ python: Parsing errors in email/_parseaddr.py lead to    │
│         │                │          │        │                   │                │ incorrect value in email address...                      │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-27043               │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴──────────────────────────────────────────────────────────┘
```


### After

```
logprep (debian 12.7)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


opt/bitnami/python (bitnami)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬──────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                          Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────┤
│ python  │ CVE-2023-36632 │ HIGH     │ fixed  │ 3.10.15-4         │ 3.11.4         │ python: RecursionError: maximum recursion depth exceeded │
│         │                │          │        │                   │                │ while calling a Python object                            │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-36632               │
│         ├────────────────┼──────────┤        │                   ├────────────────┼──────────────────────────────────────────────────────────┤
│         │ CVE-2023-27043 │ MEDIUM   │        │                   │ 2.7.18, 3.11.0 │ python: Parsing errors in email/_parseaddr.py lead to    │
│         │                │          │        │                   │                │ incorrect value in email address...                      │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-27043               │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴──────────────────────────────────────────────────────────┘
```