### PR TITLE
Fix docker image and avoid implicit setuptools runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,20 @@ ARG no_proxy
 
 ADD . /logprep
 WORKDIR /logprep
+
+# Install the Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN python -m venv --without-pip /opt/venv
-# Make sure we use the virtualenv:
+
+# Use a python virtual environment
+RUN python -m venv --upgrade-deps /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
+
 
 RUN if [ "$LOGPREP_VERSION" = "dev" ]; then pip install .;\
     elif [ "$LOGPREP_VERSION" = "latest" ]; then pip install git+https://github.com/fkie-cad/Logprep.git@latest; \
     else pip install "logprep==$LOGPREP_VERSION"; fi; \
-    logprep --version
+    /opt/venv/bin/logprep --version
 
 # geoip2 4.8.0 lists a vulnerable setuptools version as a dependency. setuptools is unneeded at runtime, so it is uninstalled.
 # More recent (currently unreleased) versions of geoip2 removed setuptools from dependencies.

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from re import error
 
 import numpy as np
-import pkg_resources
+from importlib import resources
 from attrs import define, field, validators
 
 from logprep.util.decorators import timeout
@@ -42,8 +42,8 @@ if sys.version_info.minor < 11:
     # added to re module in python 3.11
     import regex as re  # pylint: disable=shadowed-import
 
-DEFAULT_PATTERNS_DIRS = [pkg_resources.resource_filename(__name__, "patterns/ecs-v1")]
 
+DEFAULT_PATTERNS_DIRS = [str(resources.files(__package__) / "patterns/ecs-v1")]
 LOGSTASH_NOTATION = r"(([^\[\]\{\}\.:]*)?(\[[^\[\]\{\}\.:]*\])*)"
 GROK = r"%\{" + rf"([A-Z0-9_]*)(:({LOGSTASH_NOTATION}))?(:(int|float))?" + r"\}"
 ONIGURUMA = r"\(\?<([^()]*)>\(?(([^()]*|\(([^()]*|\([^()]*\))*\))*)\)?\)"


### PR DESCRIPTION
https://github.com/fkie-cad/Logprep/pull/682 introduced a regression, where the logprep binary is not available in the final image. This is because it is installed with the system-wide pip, which installs the binary to`/opt/bitnami/python/bin/` instead of `/opt/venv/bin/`. pip was removed from the venv, because it is unneeded at runtime. The `logprep --version` check, which ensures that logprep is properly installed still passed, because `/opt/bitnami/python/bin/` is also in `PATH`. To avoid such issues in the future, I changed the command to explicitly use `/opt/venv/bin/logprep`.

To install logprep into the venv, it is required to install pip into the virtual environment and use the pip version from the venv instead of the system-wide installation from bitnami. Therefore the `--without-pip` flag has been removed. The `--upgrade-deps` flag was added to ensure a recent non-vulnerable version of pip is installed.
We no longer remove pip from the runtime image, because if it is not installed in the venv, a (possibly outdated and vulnerable) version from the bitnami image is used.

Once the proper venv was used, I experienced the following error:
```
Traceback (most recent call last):
  File "/opt/venv/bin/logprep", line 5, in <module>
    from logprep.run_logprep import cli
  File "/opt/venv/lib/python3.10/site-packages/logprep/run_logprep.py", line 13, in <module>
    from logprep.generator.http.controller import Controller
  File "/opt/venv/lib/python3.10/site-packages/logprep/generator/http/controller.py", line 12, in <module>
    from logprep.factory import Factory
  File "/opt/venv/lib/python3.10/site-packages/logprep/factory.py", line 6, in <module>
    from logprep.configuration import Configuration
  File "/opt/venv/lib/python3.10/site-packages/logprep/configuration.py", line 6, in <module>
    from logprep.registry import Registry
  File "/opt/venv/lib/python3.10/site-packages/logprep/registry.py", line 33, in <module>
    from logprep.processor.grokker.processor import Grokker
  File "/opt/venv/lib/python3.10/site-packages/logprep/processor/grokker/processor.py", line 47, in <module>
    from logprep.processor.grokker.rule import GrokkerRule
  File "/opt/venv/lib/python3.10/site-packages/logprep/processor/grokker/rule.py", line 55, in <module>
    from logprep.util.grok.grok import GROK, ONIGURUMA, Grok
  File "/opt/venv/lib/python3.10/site-packages/logprep/util/grok/grok.py", line 35, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

It turns out Logprep has an implicit runtime dependency on setuptools by importing from pkg_resources. This is bad practice because of issues like the above. [The pkg_resources package got deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and Python 3.7 ships `importlib.resources` as an alternative. Because Logprep requires Python version 3.10 or newer, we can safely replace pkg_resources which allows running Logprep without having setuptools installed at runtime.
