### PR TITLE
Scan images using Trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12.3"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
     steps:
@@ -139,8 +139,14 @@ jobs:
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
 
   trivy-scan:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        
     runs-on: ubuntu-latest
+    
     needs: containerbuild
+    
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,18 +150,18 @@ jobs:
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
           format: sarif
           output: trivy-results.sarif
-          
-      # Trivy-db uses `0600` permissions.
-      # But `action/cache` use `runner` user by default
-      # So we need to change the permissions before caching the database.
-      - name: Change permissions for trivy.db
-        run: chmod 0644 ./cache/db/trivy.db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
           category: trivy-image
+
+      # Trivy-db uses `0600` permissions.
+      # But `action/cache` use `runner` user by default
+      # So we need to change the permissions before caching the database.
+      - name: Change permissions for trivy.db
+        run: sudo chmod 0644 ./cache/db/trivy.db
   
       # This step will build the image again, but every layer will already be cached, so it is nearly instantaneous.
       - name: Push image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,9 @@ jobs:
       
       - name: Scan image using Trivy
         uses: aquasecurity/trivy-action@0.24.0
+        env:
+          TRIVY_CACHE_DIR: ./cache
         with:
-          cache-dir: ./cache
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
           trivy-config: trivy.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,33 +138,6 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-
-  trivy-scan:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        
-    runs-on: ubuntu-latest
-
-    # Execute after containerbuild, but allow the containerbuild jobs to have failed.
-    # That way we do not skip scanning, when a single containerbuild job failed.
-    needs: containerbuild
-    if: ${{ always() }}
-    
-    steps:
-      - name: Ensure containerbuild succeeded
-        if: needs.containerbuild.result != 'success'
-        run: |
-          echo "containerbuild for python-${{ matrix.python-version }} failed or was cancelled"
-          exit 1
-          
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
   
       # To avoid the trivy-db becoming outdated, we save the cache for one day
       - name: Get date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,18 @@ jobs:
       - name: Ensure logprep is available in image
         run: |
           docker run --rm ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }} --version
+  
+      # This step will build the image again, but every layer will already be cached, so it is nearly instantaneous.
+      - name: Push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: |
+            LOGPREP_VERSION=dev
+            PYTHON_VERSION=${{ matrix.python-version }}
+          tags: |
+            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
 
       # To avoid the trivy-db becoming outdated, we save the cache for one day
       - name: Get date
@@ -141,36 +153,17 @@ jobs:
       
       - name: Scan image using Trivy
         uses: aquasecurity/trivy-action@0.24.0
-        env:
-          # cache-dir input is ignored due to a bug when using the sarif output
-          TRIVY_CACHE_DIR: ./cache
         with:
           cache-dir: ./cache
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-          format: sarif
-          output: trivy-results.sarif
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-image
+          format: tablei
+          exit-code: 1
+          ignore-unfixed: true
+          severity: CRITICAL
 
       # Trivy-db uses `0600` permissions.
       # But `action/cache` use `runner` user by default
       # So we need to change the permissions before caching the database.
       - name: Change permissions for trivy.db
         run: sudo chmod 0644 ./cache/db/trivy.db
-  
-      # This step will build the image again, but every layer will already be cached, so it is nearly instantaneous.
-      - name: Push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          build-args: |
-            LOGPREP_VERSION=dev
-            PYTHON_VERSION=${{ matrix.python-version }}
-          tags: |
-            ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,17 @@ jobs:
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
 
+  trivy-scan:
+    runs-on: ubuntu-latest
+    needs: containerbuild
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  
       # To avoid the trivy-db becoming outdated, we save the cache for one day
       - name: Get date
         id: date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,12 @@ jobs:
       # But `action/cache` use `runner` user by default
       # So we need to change the permissions before caching the database.
       - name: Change permissions for trivy.db
+        if: always()
         run: chmod 0644 ./cache/db/trivy.db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
+        if: always()
         with:
           sarif_file: trivy-results.sarif
           catogory: trivy-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and export to Docker
+      - name: Build image and export to Docker
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -122,15 +122,53 @@ jobs:
           tags: |
             ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
 
-      - name: Test
+      - name: Ensure logprep is available in image
         run: |
           docker run --rm ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }} --version
 
-      - name: Build images
+      # To avoid the trivy-db becoming outdated, we save the cache for one day
+      - name: Get date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Restore trivy cache
+        uses: actions/cache@v4
+        with:
+          path: cache/db
+          key: trivy-cache-${{ steps.date.outputs.date }}
+          restore-keys:
+            trivy-cache-
+      
+      - name: Scan image using Trivy
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          cache-dir: ./cache
+          scan-type: image
+          image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: 1
+          ignore-unfixed: true
+          severity: CRITICAL
+          
+      # Trivy-db uses `0600` permissions.
+      # But `action/cache` use `runner` user by default
+      # So we need to change the permissions before caching the database.
+      - name: Change permissions for trivy.db
+        run: chmod 0644 ./cache/db/trivy.db
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          catogory: trivy-image
+  
+      # This step will build the image again, but every layer will already be cached, so it is nearly instantaneous.
+      - name: Push image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true # Will only build if this is not here
+          push: true
           build-args: |
             LOGPREP_VERSION=dev
             PYTHON_VERSION=${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
       
       - name: Scan image using Trivy
         uses: aquasecurity/trivy-action@0.24.0
+        env:
+          # cache-dir input is ignored due to a bug when using the sarif output
+          TRIVY_CACHE_DIR: ./cache
         with:
           cache-dir: ./cache
           scan-type: image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,19 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
         
     runs-on: ubuntu-latest
-    
+
+    # Execute after containerbuild, but allow the containerbuild jobs to have failed.
+    # That way we do not skip scanning, when a single containerbuild job failed.
     needs: containerbuild
+    if: ${{ always() }}
     
     steps:
+      - name: Ensure containerbuild succeeded
+        if: needs.containerbuild.result != 'success'
+        run: |
+          echo "containerbuild for python-${{ matrix.python-version }} failed or was cancelled"
+          exit 1
+          
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,7 @@ jobs:
           cache-dir: ./cache
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-          format: table
-          timeout: 10m
-          exit-code: 1
-          ignore-unfixed: true
-          severity: HIGH,CRITICAL
+          trivy-config: trivy.yaml
 
       # Trivy-db uses `0600` permissions.
       # But `action/cache` use `runner` user by default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,10 @@ jobs:
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
           format: table
+          timeout: 10m
           exit-code: 1
           ignore-unfixed: true
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
 
       # Trivy-db uses `0600` permissions.
       # But `action/cache` use `runner` user by default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
 
   containerbuild:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 
@@ -140,6 +141,7 @@ jobs:
 
   trivy-scan:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
-          catogory: trivy-image
+          category: trivy-image
   
       # This step will build the image again, but every layer will already be cached, so it is nearly instantaneous.
       - name: Push image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           cache-dir: ./cache
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
-          format: tablei
+          format: table
           exit-code: 1
           ignore-unfixed: true
           severity: CRITICAL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,20 +147,15 @@ jobs:
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
           format: sarif
           output: trivy-results.sarif
-          exit-code: 1
-          ignore-unfixed: true
-          severity: CRITICAL
           
       # Trivy-db uses `0600` permissions.
       # But `action/cache` use `runner` user by default
       # So we need to change the permissions before caching the database.
       - name: Change permissions for trivy.db
-        if: always()
         run: chmod 0644 ./cache/db/trivy.db
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
         with:
           sarif_file: trivy-results.sarif
           catogory: trivy-image

--- a/.github/workflows/publish-latest-dev-release-to-pypi.yml
+++ b/.github/workflows/publish-latest-dev-release-to-pypi.yml
@@ -49,7 +49,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12.3"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -62,7 +62,7 @@ jobs:
   containerbuild:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12.3"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
     needs: publish-latest-release-to-pypi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12.3"]
+        python-version: ["3.10", "3.11", "3.12"]
         test-type: ["unit", "acceptance"]
     steps:
       - uses: actions/checkout@v4

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore Python 3.10 CVE that is only fixed in Python 3.11 as long as we still support Python 3.10.
+CVE-2023-36632

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.10
 
-FROM python:${PYTHON_VERSION} as build
+FROM bitnami/python:${PYTHON_VERSION} as build
 ARG LOGPREP_VERSION=latest
 ARG http_proxy
 ARG https_proxy
@@ -28,7 +28,7 @@ RUN if [ "$LOGPREP_VERSION" = "dev" ]; then pip install .;\
 RUN pip uninstall -y setuptools
 
 
-FROM python:${PYTHON_VERSION} as prod
+FROM bitnami/python:${PYTHON_VERSION} as prod
 ARG http_proxy
 ARG https_proxy
 COPY --from=build /opt/venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.10
 
-FROM bitnami/python:${PYTHON_VERSION} as build
+FROM python:${PYTHON_VERSION} as build
 ARG LOGPREP_VERSION=latest
 ARG http_proxy
 ARG https_proxy
@@ -28,7 +28,7 @@ RUN if [ "$LOGPREP_VERSION" = "dev" ]; then pip install .;\
 RUN pip uninstall -y setuptools
 
 
-FROM bitnami/python:${PYTHON_VERSION} as prod
+FROM python:${PYTHON_VERSION} as prod
 ARG http_proxy
 ARG https_proxy
 COPY --from=build /opt/venv /opt/venv

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,15 @@
+# https://aquasecurity.github.io/trivy/v0.56/docs/references/configuration/config-file/
+format: table
+report: all
+ignorefile: .trivyignore
+exit-code: 1
+severity:
+  - HIGH
+  - CRITICAL
+timeout: 10m
+scan:
+  scanners:
+    - vuln
+    - secret
+vulnerability:
+  ignore-unfixed: true


### PR DESCRIPTION
This PR sets up container image scanning using Trivy from Aquasecurity.

- Images will be scanned in the CI workflow.
- Scanning is performed in the containerbuild job after pushing the image to the registry.
- Scan results are available in the workflow log (the comment from github-advanced-security originated from a test to store SARIF outputs in the GitHub security tab and can be ignored).
- When an unfixed critical CVE is found, the pipeline exits with status code 1. Images are already pushed to the registry at this point and can be pulled for further debugging.
- fail-fast was disabled, so that if one containerbuild job from the matrix fails, the other jobs are still executed.

This PR also changes the Python base image version back from 3.12.3 to 3.12. It was pinned to version 3.12.3, because 3.12.4 did not work. The most recent 3.12 version should work again.

Sample workflow log: https://github.com/fkie-cad/Logprep/actions/runs/11236005155/job/31235173514?pr=685

 I recommend squashing all commits when merging, because the history is quite messy due to experimenting with the pipeline.