### PR TITLE
make `terminationGracePeriodSeconds` configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@
 * adds `desired_cluster_status` option to opensearch output to signal healthy cluster status
 * initially run health checks on setup for every configured component
 * make `imagePullPolicy` configurable for helm chart deployments
+* make `terminationGracePeriodSeconds` configurable in helm chart values
 
 
 ### Improvements
 
 * remove AutoRuleCorpusTester
 * adds support for rust extension development
-* adds prebuild wheels for architectures `x86_64` on `manylinux` and `musllinux` based linux platforms to releases
+* adds prebuilt wheels for architectures `x86_64` on `manylinux` and `musllinux` based linux platforms to releases
 * add manual how to use local images with minikube example setup to documentation
 * move `Configuration` to top level of documentation
 * add `CONTRIBUTING` file

--- a/charts/logprep/Chart.yaml
+++ b/charts/logprep/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "13.3.0"
+version: "13.4.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/logprep/templates/deployment.yaml
+++ b/charts/logprep/templates/deployment.yaml
@@ -129,6 +129,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
           {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
         - name: logprep-temp
           emptyDir:

--- a/charts/logprep/values.yaml
+++ b/charts/logprep/values.yaml
@@ -160,3 +160,7 @@ configurations:
 #       admin
 #       admin2
 artifacts: []
+
+# The termination grace period for the pod
+# Defaults to 300 seconds to ensure that queues are drained before the pod is terminated
+terminationGracePeriodSeconds: 300


### PR DESCRIPTION
this adds the possibility to set the  terminationGracePeriodSeconds in helm chart values. this is needed to ensure by time to drain all queues and message backlogs and close the connections on shutdown (pod deletion)

default is set to 300 seconds which means that the kubernetes scheduler will wait at maximum 300 seconds after sending SIGTERM before sending a SIGKILL signal.