### PR TITLE
629 no support for the mysql connector python library in version 900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * ensure `logprep.abc.Component.Config` is immutable and can be applied multiple times
 * remove lost callback reassign behavior from `kafka_input` connector
 * remove manual commit option from `kafka_input` connector
+* pin `mysql-connector-python` to >=9.1.0 to accommodate for CVE-2024-21272 and update `MySQLConnector` to work with the new version
 
 ## 13.1.2
 ### Bugfix

--- a/logprep/processor/generic_adder/mysql_connector.py
+++ b/logprep/processor/generic_adder/mysql_connector.py
@@ -33,7 +33,7 @@ class MySQLConnector:
     _last_table_checksum: Optional[int]
     """Checksum of the database table that was obtained on the last update check"""
 
-    _cursor: mysql.connector.connection.CursorBase
+    _cursor: mysql.connector.connection.MySQLCursor
 
     def __init__(self, sql_config: dict):
         """Initialize the MySQLConnector.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
   "jsonref",
   "luqum",
   "more-itertools==8.10.0",
-  "mysql-connector-python",
+  "mysql-connector-python>=9.1.0",  #  CVE-2024-21272
   "numpy>=1.26.0",
   "opensearch-py",
   "prometheus_client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
   "jsonref",
   "luqum",
   "more-itertools==8.10.0",
-  "mysql-connector-python<9",
+  "mysql-connector-python",
   "numpy>=1.26.0",
   "opensearch-py",
   "prometheus_client",


### PR DESCRIPTION
Update import for new mysql-connector-python version and unpin the version.
The mysql connector will be eventually removed, but this is required now, since trivy finds a vulnerability in the old version, which was pinned before this pull request.