### PR TITLE
add dynamic scaling of time representations

### DIFF
--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -134,7 +134,7 @@ class TimeParser:
             The parsed timestamp as datetime object.
         """
         if source_format == "UNIX":
-            parsed_datetime = int(timestamp) if len(timestamp) <= 10 else int(timestamp) / 1000
+            parsed_datetime = int(timestamp) if len(timestamp) <= 10 else int(timestamp) / 10 ** (len(timestamp) - 10)
             parsed_datetime = cls.from_timestamp(parsed_datetime)
         elif source_format == "ISO8601":
             parsed_datetime = cls.from_string(timestamp, set_missing_utc=False)

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -134,7 +134,11 @@ class TimeParser:
             The parsed timestamp as datetime object.
         """
         if source_format == "UNIX":
-            parsed_datetime = int(timestamp) if len(timestamp) <= 10 else int(timestamp) / 10 ** (len(timestamp) - 10)
+            parsed_datetime = (
+                int(timestamp)
+                if len(timestamp) <= 10
+                else int(timestamp) / 10 ** (len(timestamp) - 10)
+            )
             parsed_datetime = cls.from_timestamp(parsed_datetime)
         elif source_format == "ISO8601":
             parsed_datetime = cls.from_string(timestamp, set_missing_utc=False)

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -168,3 +168,29 @@ class TestTimeParser:
         assert timestamp.tzinfo.tzname(timestamp) == expected_timezone_name
         for attribute, value in expected.items():
             assert getattr(timestamp, attribute) == value
+            
+    @pytest.mark.parametrize(
+        "timestamp, expected_timezone_name, expected",
+        [
+            (
+                "1615634593", 
+                "UTC",
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "1615634593000",  
+                "UTC",
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+            (
+                "1615634593000000",  
+                "UTC",
+                {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
+            ),
+        ],
+    )
+    def test_parse_unix_timestamp(self, timestamp, expected_timezone_name, expected):
+        parsed_timestamp = TimeParser.parse_datetime(timestamp, "UNIX", ZoneInfo("UTC"))
+        assert parsed_timestamp.tzinfo.tzname(parsed_timestamp) == expected_timezone_name
+        for attribute, value in expected.items():
+            assert getattr(parsed_timestamp, attribute) == value

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -168,22 +168,22 @@ class TestTimeParser:
         assert timestamp.tzinfo.tzname(timestamp) == expected_timezone_name
         for attribute, value in expected.items():
             assert getattr(timestamp, attribute) == value
-            
+
     @pytest.mark.parametrize(
         "timestamp, expected_timezone_name, expected",
         [
             (
-                "1615634593", 
+                "1615634593",
                 "UTC",
                 {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),
             (
-                "1615634593000",  
+                "1615634593000",
                 "UTC",
                 {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),
             (
-                "1615634593000000",  
+                "1615634593000000",
                 "UTC",
                 {"year": 2021, "month": 3, "day": 13, "hour": 11, "minute": 23, "second": 13},
             ),


### PR DESCRIPTION
The solution adjusts the timestamp to the actual length so that the timestamp is processed correctly regardless of its precision (milliseconds, microseconds, nanoseconds). It dynamically takes into account how many additional digits are present and scales accordingly to obtain a correct time representation in seconds.Tests are also added. fixed issue 687