### PR TITLE
refactor validation of `generic_resolver` rules to startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Breaking
 ### Features
 ### Improvements
+
+* refactor `generic_resolver` to validate rules on startup instead of application of each rule
+
 ### Bugfix
 
 ## 14.0.0
@@ -53,7 +56,7 @@
 
 * fixes a bug not increasing but decreasing timeout throttle factor of ThrottlingQueue
 * handle DecodeError and unexpected Exceptions on requests in `http_input` separately
-* fixes unbound local error in http input connector 
+* fixes unbound local error in http input connector
 
 ## 13.1.1
 ### Improvements
@@ -97,7 +100,7 @@
 
 ### Bugfix
 
-* This release limits the mysql-connector-python dependency to have version less the 9 
+* This release limits the mysql-connector-python dependency to have version less the 9
 
 ## 13.0.0
 

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -4,10 +4,7 @@
 # pylint: disable=wrong-import-position
 from collections import OrderedDict
 
-from logprep.processor.base.exceptions import (
-    FieldExistsWarning,
-    ProcessingCriticalError,
-)
+from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.processor.generic_resolver.processor import GenericResolver
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -276,40 +273,6 @@ class TestGenericResolver(BaseProcessorTestCase):
         self.object.process(document)
 
         assert document == expected
-
-    def test_resolve_dotted_field_no_conflict_match_from_file_group_mapping_does_not_exist(
-        self,
-    ):
-        rule = {
-            "filter": "to_resolve",
-            "generic_resolver": {
-                "field_mapping": {"to_resolve": "resolved"},
-                "resolve_from_file": {
-                    "path": "tests/testdata/unit/generic_resolver/resolve_mapping.yml",
-                    "pattern": r"\d*(?P<foobar>[a-z]+)\d*",
-                },
-                "resolve_list": {"FOO": "BAR"},
-            },
-        }
-        self._load_specific_rule(rule)
-        document = {"to_resolve": "ab"}
-        result = self.object.process(document)
-        assert isinstance(result.errors[0], ProcessingCriticalError)
-        assert "Mapping group is missing in mapping" in result.errors[0].args[0]
-
-    def test_resolve_generic_match_from_file_and_file_does_not_exist(self):
-        rule = {
-            "filter": "to.resolve",
-            "generic_resolver": {
-                "field_mapping": {"to.resolve": "resolved"},
-                "resolve_from_file": {"path": "foo", "pattern": "bar"},
-            },
-        }
-        self._load_specific_rule(rule)
-        document = {"to": {"resolve": "something HELLO1"}}
-        result = self.object.process(document)
-        assert isinstance(result.errors[0], ProcessingCriticalError)
-        assert "Additions file 'foo' not found" in result.errors[0].args[0]
 
     def test_resolve_dotted_field_no_conflict_no_match(self):
         rule = {


### PR DESCRIPTION
- Move validation logic to `__attrs_post_init__` in GenericResolverRule.
- Remove redundant error handling in GenericResolver processor.
- Update corresponding tests to reflect changes.