### PR TITLE
standardize exception inheritance to `Exception`

### DIFF
--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -375,7 +375,7 @@ class Processor(Component):
         if missing_fields:
             if rule.ignore_missing_fields:
                 return True
-            error = BaseException(f"{self.name}: no value for fields: {missing_fields}")
+            error = Exception(f"{self.name}: no value for fields: {missing_fields}")
             self._handle_warning_error(event, rule, error)
             return True
         return False

--- a/logprep/connector/dummy/input.py
+++ b/logprep/connector/dummy/input.py
@@ -4,7 +4,7 @@ DummyInput
 
 A dummy input that returns the documents it was initialized with.
 
-If a "document" is derived from BaseException, that exception will be thrown instead of
+If a "document" is derived from Exception, that exception will be thrown instead of
 returning a document. The exception will be removed and subsequent calls may return documents or
 throw other exceptions in the given order.
 
@@ -36,7 +36,7 @@ class DummyInput(Input):
     class Config(Input.Config):
         """DummyInput specific configuration"""
 
-        documents: List[Union[dict, type, BaseException]]
+        documents: List[Union[dict, type, Exception]]
         """A list of documents that should be returned."""
         repeat_documents: Optional[str] = field(
             validator=validators.instance_of(bool), default=False
@@ -57,6 +57,6 @@ class DummyInput(Input):
 
         document = self._documents.pop(0)
 
-        if (document.__class__ == type) and issubclass(document, BaseException):
+        if (document.__class__ == type) and issubclass(document, Exception):
             raise document
         return document, None

--- a/logprep/connector/file/input.py
+++ b/logprep/connector/file/input.py
@@ -2,7 +2,7 @@
 FileInput
 ==========
 A generic line input that returns the documents it was initialized with.
-If a "document" is derived from BaseException, that exception will be thrown instead of
+If a "document" is derived from Exception, that exception will be thrown instead of
 returning a document. The exception will be removed and subsequent calls may return documents or
 throw other exceptions in the given order.
 

--- a/logprep/connector/json/input.py
+++ b/logprep/connector/json/input.py
@@ -4,7 +4,7 @@ JsonInput
 
 A json input that returns the documents it was initialized with.
 
-If a "document" is derived from BaseException, that exception will be thrown instead of
+If a "document" is derived from Exception, that exception will be thrown instead of
 returning a document. The exception will be removed and subsequent calls may return documents or
 throw other exceptions in the given order.
 

--- a/logprep/connector/jsonl/input.py
+++ b/logprep/connector/jsonl/input.py
@@ -4,7 +4,7 @@ JsonlInput
 
 A json line input that returns the documents it was initialized with.
 
-If a "document" is derived from BaseException, that exception will be thrown instead of
+If a "document" is derived from Exception, that exception will be thrown instead of
 returning a document. The exception will be removed and subsequent calls may return documents or
 throw other exceptions in the given order.
 

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -6,7 +6,7 @@ from itertools import chain, zip_longest
 from typing import Any, List
 
 
-class FilterExpressionError(BaseException):
+class FilterExpressionError(Exception):
     """Base class for FilterExpression related exceptions."""
 
 

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -130,7 +130,7 @@ from logprep.filter.expression.filter_expression import (
 logger = logging.getLogger("LuceneFilter")
 
 
-class LuceneFilterError(BaseException):
+class LuceneFilterError(Exception):
     """Base class for LuceneFilter related exceptions."""
 
 

--- a/logprep/processor/amides/detection.py
+++ b/logprep/processor/amides/detection.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import MinMaxScaler
 from logprep.processor.amides.features import CommaSeparation
 
 
-class DetectionModelError(BaseException):
+class DetectionModelError(Exception):
     """Base exception class for all RuleModel-related errors."""
 
 
@@ -98,7 +98,7 @@ class MisuseDetector(DetectionModel):
         return False, round(confidence_value, 3)
 
 
-class RuleAttributorError(BaseException):
+class RuleAttributorError(Exception):
     """Base class for all RuleAttributor-related Errors."""
 
 

--- a/logprep/processor/dissector/processor.py
+++ b/logprep/processor/dissector/processor.py
@@ -70,9 +70,7 @@ class Dissector(FieldManager):
                 if loop_content is None:
                     if rule.ignore_missing_fields:
                         continue
-                    error = BaseException(
-                        f"dissector: mapping field '{source_field}' does not exist"
-                    )
+                    error = Exception(f"dissector: mapping field '{source_field}' does not exist")
                     self._handle_warning_error(event, rule, error)
             if delimiter is not None and loop_content is not None:
                 content, _, loop_content = loop_content.partition(delimiter)

--- a/logprep/processor/field_manager/processor.py
+++ b/logprep/processor/field_manager/processor.py
@@ -197,8 +197,7 @@ class FieldManager(Processor):
 
     def _get_missing_fields_error(self, source_fields, field_values):
         missing_fields = [key for key, value in zip(source_fields, field_values) if value is None]
-        error = BaseException(f"{self.name}: missing source_fields: {missing_fields}")
-        return error
+        return Exception(f"{self.name}: missing source_fields: {missing_fields}")
 
     @staticmethod
     def _get_flatten_source_fields(source_fields_values):

--- a/logprep/processor/labeler/labeling_schema.py
+++ b/logprep/processor/labeler/labeling_schema.py
@@ -12,7 +12,7 @@ from logprep.processor.base.exceptions import (
 from logprep.util.getter import GetterFactory
 
 
-class LabelingSchemaError(BaseException):
+class LabelingSchemaError(Exception):
     """Base class for LabelingSchema related exceptions."""
 
 

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -36,7 +36,7 @@ from logprep.processor.list_comparison.rule import ListComparisonRule
 from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
-class ListComparisonError(BaseException):
+class ListComparisonError(Exception):
     """Base class for ListComparison related exceptions."""
 
     def __init__(self, name: str, message: str):

--- a/logprep/processor/template_replacer/processor.py
+++ b/logprep/processor/template_replacer/processor.py
@@ -45,7 +45,7 @@ from logprep.util.getter import GetterFactory
 from logprep.util.helper import add_field_to, get_dotted_field_value
 
 
-class TemplateReplacerError(BaseException):
+class TemplateReplacerError(Exception):
     """Base class for TemplateReplacer related exceptions."""
 
     def __init__(self, name: str, message: str):

--- a/logprep/util/auto_rule_tester/auto_rule_tester.py
+++ b/logprep/util/auto_rule_tester/auto_rule_tester.py
@@ -77,7 +77,7 @@ yaml = YAML(typ="safe", pure=True)
 
 
 # pylint: disable=protected-access
-class AutoRuleTesterException(BaseException):
+class AutoRuleTesterException(Exception):
     """Base class for AutoRuleTester related exceptions."""
 
     def __init__(self, message: str):

--- a/logprep/util/grok_pattern_loader.py
+++ b/logprep/util/grok_pattern_loader.py
@@ -6,7 +6,7 @@ from typing import Optional
 PATTERN_CONVERSION = [("[[:alnum:]]", r"\w")]
 
 
-class GrokPatternLoaderError(BaseException):
+class GrokPatternLoaderError(Exception):
     """Base class for GrokPatternLoader related exceptions."""
 
     def __init__(self, message: str):

--- a/logprep/util/pre_detector_rule_matching_tester.py
+++ b/logprep/util/pre_detector_rule_matching_tester.py
@@ -23,7 +23,7 @@ yaml = YAML(typ="safe", pure=True)
 
 
 # pylint: disable=protected-access
-class MatchingRuleTesterException(BaseException):
+class MatchingRuleTesterException(Exception):
     """Base class for MatchingRuleTester related exceptions."""
 
     def __init__(self, message: str):

--- a/tests/unit/connector/test_confluent_kafka_common.py
+++ b/tests/unit/connector/test_confluent_kafka_common.py
@@ -31,7 +31,7 @@ class CommonConfluentKafkaTestCase:
     def test_error_callback_logs_error(self):
         self.object.metrics.number_of_errors = 0
         with mock.patch("logging.Logger.error") as mock_error:
-            test_error = BaseException("test error")
+            test_error = Exception("test error")
             self.object._error_callback(test_error)
             mock_error.assert_called()
             mock_error.assert_called_with(f"{self.object.describe()}: {test_error}")

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -225,7 +225,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
 
     def test_commit_callback_raises_warning_error_and_counts_failures(self):
         with pytest.raises(InputWarning, match="Could not commit offsets"):
-            self.object._commit_callback(BaseException, ["topic_partition"])
+            self.object._commit_callback(Exception, ["topic_partition"])
             assert self.object._commit_failures == 1
 
     def test_commit_callback_counts_commit_success(self):

--- a/tests/unit/connector/test_dummy_input.py
+++ b/tests/unit/connector/test_dummy_input.py
@@ -10,7 +10,7 @@ from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
 
 
-class DummyError(BaseException):
+class DummyError(Exception):
     pass
 
 
@@ -44,9 +44,9 @@ class TestDummyInput(BaseInputTestCase):
 
     def test_raises_exceptions_instead_of_returning_them(self):
         config = copy.deepcopy(self.CONFIG)
-        config["documents"] = [BaseException]
+        config["documents"] = [Exception]
         self.object = Factory.create({"Test Instance Name": config})
-        with raises(BaseException):
+        with raises(Exception):
             self.object.get_next(self.timeout)
 
     def test_repeat_documents_repeats_documents(self):

--- a/tests/unit/connector/test_dummy_output.py
+++ b/tests/unit/connector/test_dummy_output.py
@@ -45,7 +45,7 @@ class TestDummyOutput(BaseOutputTestCase):
         config.update({"exceptions": ["FatalOutputError"]})
         dummy_output = Factory.create({"test connector": config})
 
-        with raises(BaseException, match="FatalOutputError"):
+        with raises(Exception, match="FatalOutputError"):
             dummy_output.store({"order": 0})
 
     def test_raises_exception_on_call_to_store_custom(self):

--- a/tests/unit/connector/test_json_input.py
+++ b/tests/unit/connector/test_json_input.py
@@ -11,7 +11,7 @@ from logprep.factory import Factory
 from tests.unit.connector.base import BaseInputTestCase
 
 
-class DummyError(BaseException):
+class DummyError(Exception):
     pass
 
 

--- a/tests/unit/processor/clusterer/test_clusterer_signature_phase.py
+++ b/tests/unit/processor/clusterer/test_clusterer_signature_phase.py
@@ -48,14 +48,14 @@ class TestSignatureEngine:
     def test_exception_if_raw_text_with_start_tag():
         log_record = LogRecord(raw_text="Test log with start tag <+> must raise an exception")
         sign_engine = SignatureEngine()
-        with pytest.raises(BaseException, match=r"Start-tag <\+> in raw log message"):
+        with pytest.raises(Exception, match=r"Start-tag <\+> in raw log message"):
             sign_engine.run(log_record, LogSaltModeTestComposition.rules[0])
 
     @staticmethod
     def test_exception_if_raw_text_with_end_tag():
         log_record = LogRecord(raw_text="Test log with end tag </+> must raise an exception")
         sign_engine = SignatureEngine()
-        with pytest.raises(BaseException, match=r"End-tag </\+> in raw log message"):
+        with pytest.raises(Exception, match=r"End-tag </\+> in raw log message"):
             sign_engine.run(log_record, LogSaltModeTestComposition.rules[0])
 
     @staticmethod
@@ -64,7 +64,7 @@ class TestSignatureEngine:
             "Test log with a start tag <+>, but a missing end tag, " "must raise an exception"
         )
         stp = SignatureTagParser()
-        with pytest.raises(BaseException):
+        with pytest.raises(Exception):
             stp.calculate_signature(sig_text)
 
 

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -489,11 +489,11 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         assert not self.object._check_if_file_not_exists_or_stale(time.time())
 
     def test_check_if_file_stale_after_enough_time_has_passed(self):
-        time.sleep(0.2)  # nosemgrep
+        time.sleep(0.2)
         assert self.object._check_if_file_not_exists_or_stale(time.time())
 
     def test_check_if_file_not_stale_after_enough_time_has_passed_but_file_has_been_changed(self):
-        time.sleep(0.2)  # nosemgrep
+        time.sleep(0.2)
         with open(self.object._db_file_path, "r", encoding="utf-8") as db_file:
             file_temp = db_file.read()
         now = time.time()
@@ -561,7 +561,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         document_2 = {"add_from_sql_db_table": "Test", "source": "TEST_0.test.123"}
 
         self.object.process(document_1)
-        time.sleep(0.2)  # nosemgrep
+        time.sleep(0.2)
         mock_simulate_table_change()
         self.object.process(document_2)
 
@@ -579,7 +579,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         self.object._db_table = {}
         self.object._initialize_sql(self.CONFIG["sql_config"])
         mock_simulate_table_change()
-        time.sleep(0.2)  # nosemgrep
+        time.sleep(0.2)
         self.object.process(document)
 
         assert document == expected
@@ -621,14 +621,14 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         assert self.object._db_connector.time_to_check_for_change() is False
 
     def test_time_to_check_for_change_read_for_change(self):
-        time.sleep(self.object._file_check_interval)  # nosemgrep
+        time.sleep(self.object._file_check_interval)
         assert self.object._db_connector.time_to_check_for_change() is True
 
     def test_update_from_db_and_write_to_file_change_and_stale(self):
         assert os.path.isfile(self.object._db_file_path)
         last_file_change = os.path.getmtime(self.object._db_file_path)
         mock_simulate_table_change()
-        time.sleep(self.object._file_check_interval)  # nosemgrep
+        time.sleep(self.object._file_check_interval)
         self.object._update_from_db_and_write_to_file()
         assert self.object._db_table == {
             "TEST_0": (["b", "fi"], ["c", "fo"]),
@@ -640,7 +640,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
     def test_update_from_db_and_write_to_file_no_change_and_stale(self):
         assert os.path.isfile(self.object._db_file_path)
         last_file_change = os.path.getmtime(self.object._db_file_path)
-        time.sleep(self.object._file_check_interval)  # nosemgrep
+        time.sleep(self.object._file_check_interval)
         self.object._update_from_db_and_write_to_file()
         assert self.object._db_table == {
             "TEST_0": (["b", "foo"], ["c", "bar"]),
@@ -654,7 +654,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         last_file_change = os.path.getmtime(self.object._db_file_path)
         self.object._file_check_interval = 9999999
         mock_simulate_table_change()
-        time.sleep(0.01)  # nosemgrep
+        time.sleep(0.01)
         self.object._update_from_db_and_write_to_file()
         assert self.object._db_table == {
             "TEST_0": (["b", "fi"], ["c", "fo"]),
@@ -667,7 +667,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
         assert os.path.isfile(self.object._db_file_path)
         last_file_change = os.path.getmtime(self.object._db_file_path)
         self.object._file_check_interval = 9999999
-        time.sleep(0.01)  # nosemgrep
+        time.sleep(0.01)
         self.object._update_from_db_and_write_to_file()
         assert self.object._db_table == {
             "TEST_0": (["b", "foo"], ["c", "bar"]),
@@ -679,7 +679,7 @@ class TestGenericAdderProcessorSQLWithoutAddedTarget(BaseTestGenericAdderSQLTest
     def test_update_from_db_and_write_to_file_no_existing_file_stale(self):
         assert os.path.isfile(self.object._db_file_path)
         os.remove(self.object._db_file_path)
-        time.sleep(self.object._file_check_interval)  # nosemgrep
+        time.sleep(self.object._file_check_interval)
         self.object._db_connector._last_table_checksum = None
         self.object._update_from_db_and_write_to_file()
         assert self.object._db_table == {


### PR DESCRIPTION
- Replaced `BaseException` with `Exception` for custom errors.
- Removed `# nosemgrep` comments from `time.sleep` calls in test files.