### PR TITLE
Autofix: CI complains hitting rate limit on trivy scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,19 @@ jobs:
           restore-keys:
             trivy-cache-
       
+      # To avoid the trivy-db becoming outdated, we save the cache for one day
+      - name: Get date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Restore trivy cache
+        uses: actions/cache@v4
+        with:
+          path: cache/db
+          key: trivy-cache-${{ steps.date.outputs.date }}
+          restore-keys:
+            trivy-cache-
+      
       - name: Scan image using Trivy
         uses: aquasecurity/trivy-action@0.24.0
         env:
@@ -160,6 +173,12 @@ jobs:
           scan-type: image
           image-ref: ghcr.io/fkie-cad/logprep:py${{ matrix.python-version }}-${{ github.head_ref }}
           trivy-config: trivy.yaml
+
+      # Trivy-db uses `0600` permissions.
+      # But `action/cache` use `runner` user by default
+      # So we need to change the permissions before caching the database.
+      - name: Change permissions for trivy.db
+        run: sudo chmod 0644 ./cache/db/trivy.db
 
       # Trivy-db uses `0600` permissions.
       # But `action/cache` use `runner` user by default


### PR DESCRIPTION
Modified the .github/workflows/ci.yml file to cache the Trivy DB for one day, reducing the number of requests and mitigating the rate limit issue. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    