### PR TITLE
Add missing SSL config to kafka admin clients

### DIFF
--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -288,6 +288,9 @@ class ConfluentKafkaInput(Input):
             confluent_kafka admin client object
         """
         admin_config = {"bootstrap.servers": self._config.kafka_config["bootstrap.servers"]}
+        for key, value in self._config.kafka_config.items():
+            if key.startswith(("security.", "ssl.")):
+                admin_config[key] = value
         return AdminClient(admin_config)
 
     @cached_property

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -273,7 +273,8 @@ class ConfluentKafkaInput(Input):
         DEFAULTS.update({"client.id": getfqdn()})
         DEFAULTS.update(
             {
-                "group.instance.id": f"{getfqdn().strip('.')}-Pipeline{self.pipeline_index}-pid{os.getpid()}"
+                "group.instance.id": f"{getfqdn().strip('.')}-"
+                f"Pipeline{self.pipeline_index}-pid{os.getpid()}"
             }
         )
         return DEFAULTS | self._config.kafka_config | injected_config
@@ -315,7 +316,7 @@ class ConfluentKafkaInput(Input):
             the error that occurred
         """
         self.metrics.number_of_errors += 1
-        logger.error(f"{self.describe()}: {error}")
+        logger.error(f"{self.describe()}: {error}", ())
 
     def _stats_callback(self, stats: str) -> None:
         """Callback for statistics data. This callback is triggered by poll()
@@ -378,7 +379,8 @@ class ConfluentKafkaInput(Input):
             if offset in SPECIAL_OFFSETS:
                 offset = 0
             labels = {
-                "description": f"topic: {self._config.topic} - partition: {topic_partition.partition}"
+                "description": f"topic: {self._config.topic} - "
+                f"partition: {topic_partition.partition}"
             }
             self.metrics.committed_offsets.add_with_labels(offset, labels)
 
@@ -476,7 +478,8 @@ class ConfluentKafkaInput(Input):
         """
         if self._enable_auto_offset_store:
             return
-        # in case the ConfluentKafkaInput._revoke_callback is triggered before the first message was polled
+        # in case the ConfluentKafkaInput._revoke_callback is triggered before the first message
+        # was polled
         if not self._last_valid_record:
             return
         try:

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -316,7 +316,7 @@ class ConfluentKafkaInput(Input):
             the error that occurred
         """
         self.metrics.number_of_errors += 1
-        logger.error(f"{self.describe()}: {error}", ())
+        logger.error(f"{self.describe()}: {error}")
 
     def _stats_callback(self, stats: str) -> None:
         """Callback for statistics data. This callback is triggered by poll()

--- a/logprep/connector/confluent_kafka/output.py
+++ b/logprep/connector/confluent_kafka/output.py
@@ -212,6 +212,9 @@ class ConfluentKafkaOutput(Output):
             confluent_kafka admin client object
         """
         admin_config = {"bootstrap.servers": self._config.kafka_config["bootstrap.servers"]}
+        for key, value in self._config.kafka_config.items():
+            if key.startswith(("security.", "ssl.")):
+                admin_config[key] = value
         return AdminClient(admin_config)
 
     @cached_property

--- a/logprep/connector/confluent_kafka/output.py
+++ b/logprep/connector/confluent_kafka/output.py
@@ -269,7 +269,10 @@ class ConfluentKafkaOutput(Output):
 
         """
         base_description = super().describe()
-        return f"{base_description} - Kafka Output: {self._config.kafka_config.get('bootstrap.servers')}"
+        return (
+            f"{base_description} - Kafka Output: "
+            f"{self._config.kafka_config.get('bootstrap.servers')}"
+        )
 
     def store(self, document: dict) -> Optional[bool]:
         """Store a document in the producer topic.

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
-from confluent_kafka import OFFSET_BEGINNING, KafkaError, KafkaException, Message
+from confluent_kafka import OFFSET_BEGINNING, KafkaError, KafkaException
 
 from logprep.abc.input import (
     CriticalInputError,
@@ -71,7 +71,8 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         mock_record.error = mock.MagicMock(
             return_value=KafkaError(
                 error=3,
-                reason="Subscribed topic not available: (Test Instance Name) : Broker: Unknown topic or partition",
+                reason="Subscribed topic not available: (Test Instance Name) : "
+                "Broker: Unknown topic or partition",
                 fatal=False,
                 retriable=False,
                 txn_requires_abort=False,

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -110,7 +110,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         kafka_consumer.store_offsets.assert_called_with(message=message)
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
-    def test_batch_finished_callback_calls_store_offsets(self, _):
+    def test_batch_finished_callback_does_not_call_store_offsets(self, _):
         input_config = deepcopy(self.CONFIG)
         kafka_input = Factory.create({"test": input_config})
         kafka_consumer = kafka_input._consumer

--- a/tests/unit/connector/test_confluent_kafka_output.py
+++ b/tests/unit/connector/test_confluent_kafka_output.py
@@ -168,3 +168,32 @@ class TestConfluentKafkaOutput(BaseOutputTestCase, CommonConfluentKafkaTestCase)
     def test_health_returns_bool(self):
         with mock.patch.object(self.object, "_admin"):
             super().test_health_returns_bool()
+
+    @pytest.mark.parametrize(
+        ["kafka_config_update", "expected_admin_client_config"],
+        [
+            ({}, {"bootstrap.servers": "localhost:9092"}),
+            ({"statistics.foo": "bar"}, {"bootstrap.servers": "localhost:9092"}),
+            (
+                {"security.foo": "bar"},
+                {"bootstrap.servers": "localhost:9092", "security.foo": "bar"},
+            ),
+            (
+                {"ssl.foo": "bar"},
+                {"bootstrap.servers": "localhost:9092", "ssl.foo": "bar"},
+            ),
+            (
+                {"security.foo": "bar", "ssl.foo": "bar"},
+                {"bootstrap.servers": "localhost:9092", "security.foo": "bar", "ssl.foo": "bar"},
+            ),
+        ],
+    )
+    @mock.patch("logprep.connector.confluent_kafka.output.AdminClient")
+    def test_set_security_related_config_in_admin_client(
+        self, admin_client, kafka_config_update, expected_admin_client_config
+    ):
+        new_kafka_config = deepcopy(self.CONFIG)
+        new_kafka_config["kafka_config"].update(kafka_config_update)
+        output_connector = Factory.create({"output_connector": new_kafka_config})
+        _ = output_connector._admin
+        admin_client.assert_called_with(expected_admin_client_config)

--- a/tests/unit/connector/test_confluent_kafka_output.py
+++ b/tests/unit/connector/test_confluent_kafka_output.py
@@ -3,7 +3,6 @@
 # pylint: disable=wrong-import-position
 # pylint: disable=wrong-import-order
 # pylint: disable=attribute-defined-outside-init
-# pylint: disable=no-self-use
 
 import json
 from copy import deepcopy


### PR DESCRIPTION
The SSL config was missing in the kafka admin client, which led to errors and failed health checks if SSL was used.