### PR TITLE
Fix FieldsExist warning using `LOGPREP_APPEND_MEASUREMENT_TO_EVENT `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ the list is now fixed inside the packaged logprep
 * fix `_get_value` in `FilterExpression` so that keys don't match on values
 * fix `auto_rule_tester` to work with `LOGPREP_BYPASS_RULE_TREE` enabled
 * fix `opensearch_output` not draining `message_backlog` on shutdown
+* silence `FieldExists` warning in metrics when `LOGPREP_APPEND_MEASUREMENT_TO_EVENT` is active
 
 ## 14.0.0
 ### Breaking

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -117,14 +117,14 @@ Processor Specific Metrics
 
 import os
 import time
+from _socket import gethostname
 from abc import ABC, abstractmethod
 from typing import Any, Union
 
-from _socket import gethostname
 from attrs import define, field, validators
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
-from logprep.util.helper import add_fields_to
+from logprep.util.helper import _add_field_to_silent_fail
 
 
 @define(kw_only=True, slots=False)
@@ -222,14 +222,22 @@ class Metric(ABC):
                 if hasattr(self, "rule_type"):
                     event = args[0]
                     if event:
-                        add_fields_to(
-                            event, fields={f"processing_times.{self.rule_type}": duration}
+                        _add_field_to_silent_fail(
+                            event=event,
+                            field=(f"processing_times.{self.rule_type}", duration),
+                            rule=None,
                         )
                 if hasattr(self, "_logprep_config"):  # attribute of the Pipeline class
                     event = args[0]
                     if event:
-                        add_fields_to(event, fields={"processing_times.pipeline": duration})
-                        add_fields_to(event, fields={"processing_times.hostname": gethostname()})
+                        _add_field_to_silent_fail(
+                            event=event, field=("processing_times.pipeline", duration), rule=None
+                        )
+                        _add_field_to_silent_fail(
+                            event=event,
+                            field=("processing_times.hostname", gethostname()),
+                            rule=None,
+                        )
                 return result
 
             return inner


### PR DESCRIPTION
Considering that the feature `LOGPREP_APPEND_MEASUREMENT_TO_EVENT ` will be removed in the future I decided to just recreate the previous behavior. Before #696 was merged it was ignored if the value was already present or not. I ensured here now that the same behavior is happing again, by using `_add_field_to_silent_fail`. It is to note though that this means, that only the first processor/rule of a kind will write it's processing times into the event. Consecutive processors/rules of the same type will then be ignored. 

closes #721 