### PR TITLE
add scheduled workflow for weekly image build

### DIFF
--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -17,15 +17,15 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
-          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')"
+          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')" >> "GITHUB_OUTPUT"
 
       - name: debug tag
         run: echo ${{ steps.get-tag.outputs.tag }}
 
-#  containerbuild:
-#    uses: ./.github/workflows/container-build.yml
-#    needs: get-lastest-release
-#    secrets: inherit
-#    with:
-#      build-version: ${{ needs.get-latest-release.outputs.tag }}
-#      tags: "${{ needs.get-latest-release.outputs.tag }}-weekly"
+  containerbuild:
+    uses: ./.github/workflows/container-build.yml
+    needs: get-lastest-release
+    secrets: inherit
+    with:
+      build-version: ${{ needs.get-latest-release.outputs.tag }}
+      tags: "${{ needs.get-latest-release.outputs.tag }}-weekly"

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
-          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')" >> "GITHUB_OUTPUT"
+          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')" >> "$GITHUB_OUTPUT"
 
       - name: debug tag
         run: echo ${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
-          echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")'
+          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')"
 
       - name: debug tag
         run: echo ${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -19,10 +19,13 @@ jobs:
         run: |
           echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")' >> "GITHUB_OUTPUT"
 
-  containerbuild:
-    uses: ./.github/workflows/container-build.yml
-    needs: get-lastest-release
-    secrets: inherit
-    with:
-      build-version: ${{ needs.get-latest-release.outputs.tag }}
-      tags: "${{ needs.get-latest-release.outputs.tag }}-weekly"
+      - name: debug tag
+        run: echo ${{ steps.get-tag.outputs.tag }}
+
+#  containerbuild:
+#    uses: ./.github/workflows/container-build.yml
+#    needs: get-lastest-release
+#    secrets: inherit
+#    with:
+#      build-version: ${{ needs.get-latest-release.outputs.tag }}
+#      tags: "${{ needs.get-latest-release.outputs.tag }}-weekly"

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  get-lastest-release:
+  get-latest-release:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -11,8 +11,11 @@ on:
 jobs:
   get-lastest-release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
     steps:
       - name: Get latest tag
+        id: get-tag
         run: |
           echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")' >> "GITHUB_OUTPUT"
 
@@ -21,5 +24,5 @@ jobs:
     needs: get-lastest-release
     secrets: inherit
     with:
-      build-version: ${{ jobs.get-latest-release.outputs.tag }}
-      tags: "${{ jobs.get-latest-release.outputs.tag }}-weekly"
+      build-version: ${{ needs.get-latest-release.outputs.tag }}
+      tags: "${{ needs.get-latest-release.outputs.tag }}-weekly"

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
-          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v')" >> "$GITHUB_OUTPUT"
+          echo "tag=$(curl -s -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' 'https://api.github.com/repos/fkie-cad/Logprep/tags' | jq '.[0].name' | tr -d 'v\"')" >> "$GITHUB_OUTPUT"
 
       - name: debug tag
         run: echo ${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -1,0 +1,25 @@
+name: Weekly Image Build of last Release
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+on:
+#  schedule:
+#    - cron: "5 0 * * 1"  # At 00:05 on Monday
+  pull_request:  # just for debugging
+    types: [opened, synchronize]
+
+
+jobs:
+  get-lastest-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest tag
+        run: |
+          echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")' >> "GITHUB_OUTPUT"
+
+  containerbuild:
+    uses: ./.github/workflows/container-build.yml
+    needs: get-lastest-release
+    secrets: inherit
+    with:
+      build-version: ${{ jobs.get-latest-release.outputs.tag }}
+      tags: "${{ jobs.get-latest-release.outputs.tag }}-weekly"

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
-          echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")' >> "GITHUB_OUTPUT"
+          echo 'tag=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }} "https://api.github.com/repos/fkie-cad/Logprep/tags" | jq ".[0].name" | tr -d "v")'
 
       - name: debug tag
         run: echo ${{ steps.get-tag.outputs.tag }}

--- a/.github/workflows/weekly-build-of-last-release.yml
+++ b/.github/workflows/weekly-build-of-last-release.yml
@@ -24,7 +24,7 @@ jobs:
 
   containerbuild:
     uses: ./.github/workflows/container-build.yml
-    needs: get-lastest-release
+    needs: get-latest-release
     secrets: inherit
     with:
       build-version: ${{ needs.get-latest-release.outputs.tag }}


### PR DESCRIPTION
- adds a new workflow that is scheduled to run once a week
- create the latest released image again with a new tag using the suffix "weekly"
- that way new CVE fixes from the underlying bitnami baseimage are automatically integrated