### PR TITLE
Fix thread and threadpool

### DIFF
--- a/logprep/abc/controller.py
+++ b/logprep/abc/controller.py
@@ -2,8 +2,9 @@
 
 import logging
 import signal
+import threading
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from logging import Logger
 
 from logprep.abc.output import Output
@@ -41,6 +42,7 @@ class Controller(ABC):
         # manipulator = Manipulator(**self.config)
         # directory = manipulator.template()
         self.file_loader.start()
+        print(f"Start thread Fileloader active threads: {threading.active_count()}")
         batcher = Batcher(self.file_loader.read_lines(), **self.config)
         self.sender = Sender(batcher, self.output, **self.config)
         signal.signal(signal.SIGTERM, self.stop)
@@ -52,13 +54,15 @@ class Controller(ABC):
 
     def _generate_load(self):
         with ThreadPoolExecutor(max_workers=self.thread_count) as executor:
-            while True:
-                future = executor.submit(self.sender.send_batch)
-                result = future.result()
+            futures = {executor.submit(self.sender.send_batch) for _ in range(self.thread_count)}
+
+            for future in as_completed(futures):
+                result = future.result()  # Wait for a completed task
+                print(f"During generate load active threads: {threading.active_count()}")
                 print(f"{result=}")
-                if not result:
-                    break
-                logger.info("Finished processing all events")
+                logger.info("Finished processing a batch")
+
+        print(f"After generate load active threads: {threading.active_count()}")
 
     def stop(self, signum, frame):
         self.file_loader.close()

--- a/logprep/generator/http/batcher.py
+++ b/logprep/generator/http/batcher.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from itertools import islice
 from typing import Generator, Iterable, List, Tuple
 
@@ -12,17 +13,18 @@ class Batcher:
 
     def __init__(self, batches: Iterable, **config) -> None:
         self.batch_size: int = config.get("batch_size", DEFAULT_BATCH_SIZE)
-        self.events = batches
+        self.events = iter(batches)
         self._batch: List[str] = []
+        self.lock = threading.Lock()
 
     def get_batch(self) -> Generator[Tuple[str], None, None]:
         "Batch data into tuples of length n. The last batch may be shorter."
         # TODO: Refactor this method to itertools.batched if support for 3.11 is dropped
         if self.batch_size < 1:
             raise ValueError("'batch_size' must be at least one")
-        it = iter(self.events)
-        print(f"{self.batch_size=}")
-        print(it)
-        while batch := tuple(islice(it, self.batch_size)):
-            print(f"Batch: {batch}")
-            yield batch
+        while True:
+            with self.lock:
+                batch = tuple(islice(self.events, self.batch_size))
+                if not batch:
+                    return
+                yield batch

--- a/logprep/generator/http/loader.py
+++ b/logprep/generator/http/loader.py
@@ -38,6 +38,7 @@ class EventBuffer:
                         "Message backlog queue is full. Blocking until space is available."
                     )
                 self._message_backlog.put(line)
+        self._message_backlog.put(self._sentinel)
 
     def read_lines(self) -> Generator[str, None, None]:
         """Reads lines from the message backlog queue.


### PR DESCRIPTION
Fixed the ThreadPoolExecutor in _generate_load() and made the generator in batcher thread safe.
Testing showed , that the desired number of threads were opened and all were closed later.