### PR TITLE
add ability to write the full event to one singular target field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## next release
 ### Breaking
 ### Features
+
+* adds new config parameter `event_original_field` to http input which can be used to write the original event in a designated target field
+* adds a new preprocessor `add_full_event_to_target_field` which adds the full event as an escaped string to a designated target field
+
 ### Improvements
 ### Bugfix
 

--- a/logprep/abc/connector.py
+++ b/logprep/abc/connector.py
@@ -10,7 +10,7 @@ class Connector(Component):
     """Abstract Connector Class to define the Interface"""
 
     @define(kw_only=True)
-    class Config:
+    class Config(Component.Config):
         """Configuration for the connector"""
 
     @define(kw_only=True)

--- a/logprep/abc/connector.py
+++ b/logprep/abc/connector.py
@@ -10,6 +10,10 @@ class Connector(Component):
     """Abstract Connector Class to define the Interface"""
 
     @define(kw_only=True)
+    class Config:
+        """Configuration for the connector"""
+
+    @define(kw_only=True)
     class Metrics(Component.Metrics):
         """Tracks statistics about this connector"""
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -260,7 +260,7 @@ class Input(Connector):
         return bool(self._config.preprocessing.get("enrich_by_env_variables"))
 
     @property
-    def _add_full_event_to_target_field(self):
+    def _add_full_event_to_target_field(self) -> bool:
         """Check and return if the event should be written into one singular field."""
         return bool(self._config.preprocessing.get("add_full_event_to_target_field"))
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -102,7 +102,7 @@ class TimeDeltaConfig:
 @define(kw_only=True)
 class FullEventConfig:
     """Full Event Configurations
-    Works only if the preprocessor add_full_event_to_target_field is set."""
+    Works only if the preprocessor :code:`add_full_event_to_target_field` is set."""
 
     format: str = field(validator=validators.in_(["dict", "str"]), default="str")
     """Defines the Format in hich the event should be written to the new field

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -116,6 +116,7 @@ class Input(Connector):
                         "log_arrival_time_target_field": Optional[str],
                         "log_arrival_timedelta": Optional[TimeDeltaConfig],
                         "enrich_by_env_variables": Optional[dict],
+                        "onboarding_mode": Optional[str],
                     },
                 ),
             ],
@@ -176,6 +177,10 @@ class Input(Connector):
         - `enrich_by_env_variables` - If required it is possible to automatically enrich incoming
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
+        - `onboarding_mode` - If required it is possible to automatically write all fields in an event
+          to one singular field or subfield. The exact fields in the event do not have to be known
+           to activate the onboarding mode. To activate this preprocessor the fields value has to 
+          represent the target field where the fields of the event should be written to.
         """
 
         _version_information: dict = field(
@@ -232,6 +237,11 @@ class Input(Connector):
     def _add_env_enrichment(self):
         """Check and return if the env enrichment should be added to the event."""
         return bool(self._config.preprocessing.get("enrich_by_env_variables"))
+
+    @property
+    def _onboarding_mode(self):
+        """Check and return if the env enrichment should be added to the event."""
+        return bool(self._config.preprocessing.get("onboarding_mode"))
 
     def _get_raw_event(self, timeout: float) -> bytes | None:  # pylint: disable=unused-argument
         """Implements the details how to get the raw event
@@ -298,6 +308,8 @@ class Input(Connector):
                 self._add_arrival_timedelta_information_to_event(event)
             if self._add_env_enrichment:
                 self._add_env_enrichment_to_event(event)
+            if self._onboarding_mode:
+                self._onboarding_mode_to_event(event, raw_event)
         except FieldExistsWarning as error:
             raise CriticalInputError(self, error.args[0], event) from error
         return event
@@ -332,6 +344,14 @@ class Input(Connector):
             add_fields_to(event, {original_target: time}, overwrite_target=True)
             add_fields_to(event, {f"{target}.@original": target_value})
             assert True
+
+    def _onboarding_mode_to_event(self, event_dict: dict, raw_event: bytearray):
+        target = self._config.preprocessing.get("onboarding_mode")
+        if raw_event is None:
+            raw_event = self._encoder.encode(event_dict)
+        complete_event = self._decoder.decode(raw_event.decode("utf-8"))
+        event_dict.clear()
+        add_fields_to(event_dict, fields={target: complete_event}, overwrite_target=True)
 
     def _add_arrival_timedelta_information_to_event(self, event: dict):
         log_arrival_timedelta_config = self._config.preprocessing.get("log_arrival_timedelta")

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -179,7 +179,7 @@ class Input(Connector):
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
         - `add_full_event_to_target_field` - If required it is possible to automatically write all fields in an event
-          to one singular field or subfield. The exact fields in the event do not have to be known
+          to one singular field or subfield as a string. The exact fields in the event do not have to be known
            to use this preprocessor. To activate this preprocessor the fields value has to 
           represent the target field where the fields of the event should be written to. The event is
           automatically escaped so this can be used to identify mapping errors thrown by opensearch 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -104,7 +104,7 @@ class FullEventConfig:
     """Full Event Configurations
     Works only if the preprocessor add_full_event_to_target_field is set."""
 
-    format: str = field(validator=validators.instance_of(str), default="str")
+    format: str = field(validator=validators.in_(["dict", "str"]), default="str")
     """Defines the Format in hich the event should be written to the new field
     the default ist str. With the string format the event string is automatically escaped"""
     target_field: str = field(validator=validators.instance_of(str), default="event.original")

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -351,8 +351,8 @@ class Input(Connector):
     def _write_full_event_to_target_field(self, event_dict: dict, raw_event: bytearray):
         target = self._config.preprocessing.get("add_full_event_to_target_field")
         if raw_event is None:
-            raw_event = json.dumps(event_dict)
-        complete_event = json.dumps(raw_event)
+            raw_event = self._encoder.encode(event_dict)
+        complete_event = json.dumps(raw_event.decode("utf-8"))
         event_dict.clear()
         add_fields_to(event_dict, fields={target: complete_event}, overwrite_target=True)
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -99,6 +99,19 @@ class TimeDeltaConfig:
     The calculation will be the arrival time minus the time of this reference field."""
 
 
+@define(kw_only=True)
+class FullEventConfig:
+    """Full Event Configurations
+    Works only if the preprocessor add_full_event_to_target_field is set."""
+
+    format: str = field(validator=validators.instance_of(str), default="str")
+    """Defines the Format in hich the event should be written to the new field
+    the default ist str. With the string format the event string is automatically escaped"""
+    target_field: str = field(validator=validators.instance_of(str), default="event.original")
+    """Defines the fieldname which the event should be written to. The default target field 
+    is event.original"""
+
+
 class Input(Connector):
     """Connect to a source for log data."""
 
@@ -117,7 +130,7 @@ class Input(Connector):
                         "log_arrival_time_target_field": Optional[str],
                         "log_arrival_timedelta": Optional[TimeDeltaConfig],
                         "enrich_by_env_variables": Optional[dict],
-                        "add_full_event_to_target_field": Optional[dict],
+                        "add_full_event_to_target_field": Optional[FullEventConfig],
                     },
                 ),
             ],

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -193,7 +193,7 @@ class Input(Connector):
         - `enrich_by_env_variables` - If required it is possible to automatically enrich incoming
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
-        - `add_full_event_to_target_field` - If required it is possible to automatically write
+        - `add_full_event_to_target_field` - If required it is possible to automatically copy
         all event fields to one singular field or subfield. If needed as an escaped string.
         The exact fields in the event do not have to be known to use this preprocessor. To use this
         preprocessor the fields :code:`format` and :code:`target_field` have to bet set. When the
@@ -202,8 +202,10 @@ class Input(Connector):
 
             - :code:`format` - specifies the format which the event is written in. The default
             format ist :code:`str` which leads to automatic json escaping of the given event. Also
-            possible is the value :code:`dict` which writes the event as mapping to the specified
-            :code:`target_field`.
+            possible is the value :code:`dict` which copies the event as mapping to the specified
+            :code:`target_field`. If the format :code:`str` is set it is necessary to have a 
+            timestamp set in the event for opensearch to receive the event in the string format. 
+            This can be achived by using the :code:`log_arrival_time_target_field` preprocessor.
             - :code:`target_field` - specifies the field to which the event should be written to.
             the default is :code:`event.original`
         """

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -191,15 +191,16 @@ class Input(Connector):
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
         - `add_full_event_to_target_field` - If required it is possible to automatically write 
-        all event fields to one singular field or subfield. If needed as an escaped string. The exact fields 
-        in the event do not have to be known to use this preprocessor. To use this preprocessor 
-        the fields :code:`format` and :code:`target_field` have to bet set. When the format :code:`str` ist set 
-        the event is automatically escaped. This can be used to identify and resolve mapping errors thrown by 
-        opensearch.
+        all event fields to one singular field or subfield. If needed as an escaped string. 
+        The exact fields in the event do not have to be known to use this preprocessor. To use this
+        preprocessor the fields :code:`format` and :code:`target_field` have to bet set. When the 
+        format :code:`str` ist set the event is automatically escaped. This can be used to identify
+        and resolve mapping errors thrown by opensearch.
 
-            - :code:`format` - specifies the format which the event is written in. The default format ist 
-            :code:`str` which leads to automatic json escaping of the given event. Also possible is the value :code:`dict`
-            which writes the event as mapping to the specified :code:`target_field`.
+            - :code:`format` - specifies the format which the event is written in. The default 
+            format ist :code:`str` which leads to automatic json escaping of the given event. Also 
+            possible is the value :code:`dict` which writes the event as mapping to the specified 
+            :code:`target_field`.
             - :code:`target_field` - specifies the field to which the event should be written to.
             the default is :code:`event.original`
         """
@@ -319,6 +320,8 @@ class Input(Connector):
         if not isinstance(event, dict):
             raise CriticalInputError(self, "not a dict", event)
         try:
+            if self._add_full_event_to_target_field:
+                self._write_full_event_to_target_field(event, raw_event)
             if self._add_hmac:
                 event = self._add_hmac_to(event, raw_event)
             if self._add_version_info:
@@ -329,8 +332,6 @@ class Input(Connector):
                 self._add_arrival_timedelta_information_to_event(event)
             if self._add_env_enrichment:
                 self._add_env_enrichment_to_event(event)
-            if self._add_full_event_to_target_field:
-                self._write_full_event_to_target_field(event, raw_event)
         except FieldExistsWarning as error:
             raise CriticalInputError(self, error.args[0], event) from error
         return event

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -181,7 +181,9 @@ class Input(Connector):
         - `add_full_event_to_target_field` - If required it is possible to automatically write all fields in an event
           to one singular field or subfield. The exact fields in the event do not have to be known
            to use this preprocessor. To activate this preprocessor the fields value has to 
-          represent the target field where the fields of the event should be written to.
+          represent the target field where the fields of the event should be written to. The event is
+          automatically escaped so this can be used to identify mapping errors thrown by opensearch 
+          that are present in the raw event.
         """
 
         _version_information: dict = field(

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -4,6 +4,7 @@ New input endpoint types are created by implementing it.
 
 import base64
 import hashlib
+import json
 import os
 import zlib
 from abc import abstractmethod
@@ -348,8 +349,8 @@ class Input(Connector):
     def _write_full_event_to_target_field(self, event_dict: dict, raw_event: bytearray):
         target = self._config.preprocessing.get("add_full_event_to_target_field")
         if raw_event is None:
-            raw_event = self._encoder.encode(event_dict)
-        complete_event = raw_event.decode("utf-8")
+            raw_event = json.dumps(event_dict)
+        complete_event = json.dumps(raw_event)
         event_dict.clear()
         add_fields_to(event_dict, fields={target: complete_event}, overwrite_target=True)
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -214,7 +214,7 @@ class Input(Connector):
         )
 
     @property
-    def _add_hmac(self):
+    def _add_hmac(self) -> bool:
         """Check and return if a hmac should be added or not."""
         hmac_options = self._config.preprocessing.get("hmac")
         if not hmac_options:
@@ -222,22 +222,22 @@ class Input(Connector):
         return all(bool(hmac_options[option_key]) for option_key in hmac_options)
 
     @property
-    def _add_version_info(self):
+    def _add_version_info(self) -> bool:
         """Check and return if the version info should be added to the event."""
         return bool(self._config.preprocessing.get("version_info_target_field"))
 
     @cached_property
-    def _log_arrival_timestamp_timezone(self):
+    def _log_arrival_timestamp_timezone(self) -> ZoneInfo:
         """Returns the timezone for log arrival timestamps"""
         return ZoneInfo("UTC")
 
     @property
-    def _add_log_arrival_time_information(self):
+    def _add_log_arrival_time_information(self) -> bool:
         """Check and return if the log arrival time info should be added to the event."""
         return bool(self._config.preprocessing.get("log_arrival_time_target_field"))
 
     @property
-    def _add_log_arrival_timedelta_information(self):
+    def _add_log_arrival_timedelta_information(self) -> bool:
         """Check and return if the log arrival timedelta info should be added to the event."""
         log_arrival_timedelta_present = self._add_log_arrival_time_information
         log_arrival_time_target_field_present = bool(
@@ -256,7 +256,7 @@ class Input(Connector):
         }
 
     @property
-    def _add_env_enrichment(self):
+    def _add_env_enrichment(self) -> bool:
         """Check and return if the env enrichment should be added to the event."""
         return bool(self._config.preprocessing.get("enrich_by_env_variables"))
 
@@ -336,10 +336,10 @@ class Input(Connector):
             raise CriticalInputError(self, error.args[0], event) from error
         return event
 
-    def batch_finished_callback(self):
+    def batch_finished_callback(self) -> None:
         """Can be called by output connectors after processing a batch of one or more records."""
 
-    def _add_env_enrichment_to_event(self, event: dict):
+    def _add_env_enrichment_to_event(self, event: dict) -> None:
         """Add the env enrichment information to the event"""
         enrichments = self._config.preprocessing.get("enrich_by_env_variables")
         if not enrichments:
@@ -350,7 +350,7 @@ class Input(Connector):
         }
         add_fields_to(event, fields)
 
-    def _add_arrival_time_information_to_event(self, event: dict):
+    def _add_arrival_time_information_to_event(self, event: dict) -> None:
         target = self._config.preprocessing.get("log_arrival_time_target_field")
         time = TimeParser.now(self._log_arrival_timestamp_timezone).isoformat()
         try:
@@ -381,7 +381,7 @@ class Input(Connector):
             event_dict, fields={target["target_field"]: complete_event}, overwrite_target=True
         )
 
-    def _add_arrival_timedelta_information_to_event(self, event: dict):
+    def _add_arrival_timedelta_information_to_event(self, event: dict) -> None:
         log_arrival_timedelta_config = self._config.preprocessing.get("log_arrival_timedelta")
         log_arrival_time_target_field = self._config.preprocessing.get(
             "log_arrival_time_target_field"
@@ -397,7 +397,7 @@ class Input(Connector):
             ).total_seconds()
             add_fields_to(event, fields={target_field: delta_time_sec})
 
-    def _add_version_information_to_event(self, event: dict):
+    def _add_version_information_to_event(self, event: dict) -> None:
         """Add the version information to the event"""
         target_field = self._config.preprocessing.get("version_info_target_field")
         # pylint: disable=protected-access

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -375,7 +375,7 @@ class Input(Connector):
         complete_event = {}
         if raw_event is None:
             raw_event = self._encoder.encode(event_dict)
-        if target["format"] is "dict":
+        if target["format"] == "dict":
             complete_event = self._decoder.decode(raw_event.decode("utf-8"))
         else:
             complete_event = json.dumps(raw_event.decode("utf-8"))

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -309,7 +309,7 @@ class Input(Connector):
             if self._add_env_enrichment:
                 self._add_env_enrichment_to_event(event)
             if self._onboarding_mode:
-                self._onboarding_mode_to_event(event, raw_event)
+                self._onboarding_mode_target_field_to_event(event, raw_event)
         except FieldExistsWarning as error:
             raise CriticalInputError(self, error.args[0], event) from error
         return event
@@ -345,7 +345,7 @@ class Input(Connector):
             add_fields_to(event, {f"{target}.@original": target_value})
             assert True
 
-    def _onboarding_mode_to_event(self, event_dict: dict, raw_event: bytearray):
+    def _onboarding_mode_target_field_to_event(self, event_dict: dict, raw_event: bytearray):
         target = self._config.preprocessing.get("onboarding_mode")
         if raw_event is None:
             raw_event = self._encoder.encode(event_dict)

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -105,8 +105,8 @@ class FullEventConfig:
     Works only if the preprocessor :code:`add_full_event_to_target_field` is set."""
 
     format: str = field(validator=validators.in_(["dict", "str"]), default="str")
-    """Defines the Format in hich the event should be written to the new field
-    the default ist str. With the string format the event string is automatically escaped"""
+    """Defines the Format in which the event should be written to the new field.
+    The default ist :code:`str`, which results in escaped json string"""
     target_field: str = field(validator=validators.instance_of(str), default="event.original")
     """Defines the fieldname which the event should be written to"""
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -108,8 +108,7 @@ class FullEventConfig:
     """Defines the Format in hich the event should be written to the new field
     the default ist str. With the string format the event string is automatically escaped"""
     target_field: str = field(validator=validators.instance_of(str), default="event.original")
-    """Defines the fieldname which the event should be written to. The default target field 
-    is event.original"""
+    """Defines the fieldname which the event should be written to"""
 
 
 class Input(Connector):
@@ -191,12 +190,18 @@ class Input(Connector):
         - `enrich_by_env_variables` - If required it is possible to automatically enrich incoming
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
-        - `add_full_event_to_target_field` - If required it is possible to automatically write all fields in an event
-          to one singular field or subfield as a string. The exact fields in the event do not have to be known
-           to use this preprocessor. To activate this preprocessor the fields value has to 
-          represent the target field where the fields of the event should be written to. The event is
-          automatically escaped so this can be used to identify mapping errors thrown by opensearch 
-          that are present in the raw event.
+        - `add_full_event_to_target_field` - If required it is possible to automatically write 
+        all fields in an event to one singular field or subfield as a string. The exact fields 
+        in the event do not have to be known to use this preprocessor. To use this preprocessor 
+        the fields `format` and `target_field` have to bet set. When the format `str` ist set 
+        the event is automatically escaped so this can be used to identify mapping errors thrown by 
+        opensearch that are present in the raw event.
+
+            - `format` - specifies the format which the event is written in. The default format ist 
+            string with automatic escaping of the given event. Also possible is the value `dict`
+            which writes teh event as dict to the specified `target_field`.
+            - `target_field` - specifies the field to which the event should be written to.
+            the default is event.original
         """
 
         _version_information: dict = field(

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -114,6 +114,9 @@ class FullEventConfig:
 class Input(Connector):
     """Connect to a source for log data."""
 
+    class Metrics(Connector.Metrics):
+        """Input Metrics"""
+
     @define(kw_only=True, slots=False)
     class Config(Connector.Config):
         """Input Configurations"""
@@ -190,16 +193,16 @@ class Input(Connector):
         - `enrich_by_env_variables` - If required it is possible to automatically enrich incoming
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
-        - `add_full_event_to_target_field` - If required it is possible to automatically write 
-        all event fields to one singular field or subfield. If needed as an escaped string. 
+        - `add_full_event_to_target_field` - If required it is possible to automatically write
+        all event fields to one singular field or subfield. If needed as an escaped string.
         The exact fields in the event do not have to be known to use this preprocessor. To use this
-        preprocessor the fields :code:`format` and :code:`target_field` have to bet set. When the 
+        preprocessor the fields :code:`format` and :code:`target_field` have to bet set. When the
         format :code:`str` ist set the event is automatically escaped. This can be used to identify
         and resolve mapping errors thrown by opensearch.
 
-            - :code:`format` - specifies the format which the event is written in. The default 
-            format ist :code:`str` which leads to automatic json escaping of the given event. Also 
-            possible is the value :code:`dict` which writes the event as mapping to the specified 
+            - :code:`format` - specifies the format which the event is written in. The default
+            format ist :code:`str` which leads to automatic json escaping of the given event. Also
+            possible is the value :code:`dict` which writes the event as mapping to the specified
             :code:`target_field`.
             - :code:`target_field` - specifies the field to which the event should be written to.
             the default is :code:`event.original`

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -366,7 +366,7 @@ class Input(Connector):
             add_fields_to(event, {f"{target}.@original": target_value})
             assert True
 
-    def _write_full_event_to_target_field(self, event_dict: dict, raw_event: bytearray):
+    def _write_full_event_to_target_field(self, event_dict: dict, raw_event: bytearray) -> None:
         target = self._config.preprocessing.get("add_full_event_to_target_field")
         complete_event = {}
         if raw_event is None:

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -349,7 +349,7 @@ class Input(Connector):
         target = self._config.preprocessing.get("onboarding_mode")
         if raw_event is None:
             raw_event = self._encoder.encode(event_dict)
-        complete_event = self._decoder.decode(raw_event.decode("utf-8"))
+        complete_event = raw_event.decode("utf-8")
         event_dict.clear()
         add_fields_to(event_dict, fields={target: complete_event}, overwrite_target=True)
 

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -191,17 +191,17 @@ class Input(Connector):
           events by environment variables. To activate this preprocessor the fields value has to be
           a mapping from the target field name (key) to the environment variable name (value).
         - `add_full_event_to_target_field` - If required it is possible to automatically write 
-        all fields in an event to one singular field or subfield as a string. The exact fields 
+        all event fields to one singular field or subfield. If needed as an escaped string. The exact fields 
         in the event do not have to be known to use this preprocessor. To use this preprocessor 
-        the fields `format` and `target_field` have to bet set. When the format `str` ist set 
-        the event is automatically escaped so this can be used to identify mapping errors thrown by 
-        opensearch that are present in the raw event.
+        the fields :code:`format` and :code:`target_field` have to bet set. When the format :code:`str` ist set 
+        the event is automatically escaped. This can be used to identify and resolve mapping errors thrown by 
+        opensearch.
 
-            - `format` - specifies the format which the event is written in. The default format ist 
-            string with automatic escaping of the given event. Also possible is the value `dict`
-            which writes teh event as dict to the specified `target_field`.
-            - `target_field` - specifies the field to which the event should be written to.
-            the default is event.original
+            - :code:`format` - specifies the format which the event is written in. The default format ist 
+            :code:`str` which leads to automatic json escaping of the given event. Also possible is the value :code:`dict`
+            which writes the event as mapping to the specified :code:`target_field`.
+            - :code:`target_field` - specifies the field to which the event should be written to.
+            the default is :code:`event.original`
         """
 
         _version_information: dict = field(

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -109,6 +109,7 @@ from falcon import (  # pylint: disable=no-name-in-module
 )
 
 from logprep.abc.input import FatalInputError, Input
+from logprep.factory_error import InvalidConfigurationError
 from logprep.metrics.metrics import CounterMetric, GaugeMetric
 from logprep.util import http, rstr
 from logprep.util.credentials import Credentials, CredentialsFactory
@@ -457,9 +458,15 @@ class HttpInput(Input):
             default=None,
         )
         """Optional config parameter that writes the full event to one single target field. The
-        format can be specified with the parameter :code:`format`. Possible are :code:`str` and :code:`dict` where 
-        dict is the default format. The target field can be specified with the parameter 
+        format can be specified with the parameter :code:`format`. Possible are :code:`str` and :code:`dict` where
+        dict is the default format. The target field can be specified with the parameter
         :code:`target_field`."""
+
+        def __attrs_post_init__(self):
+            if "add_full_event_to_target_field" in self.preprocessing and self.original_event_field:
+                raise InvalidConfigurationError(
+                    "Cannot configure both add_full_event_to_target_field and original_event_field."
+                )
 
     __slots__: List[str] = ["target", "app", "http_server"]
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -457,9 +457,9 @@ class HttpInput(Input):
             default=None,
         )
         """Optional config parameter that writes the full event to one single target field. The
-        format can be specified with the parameter `format`. Possible are `str` and `dict` where 
+        format can be specified with the parameter :code:`format`. Possible are :code:`str` and :code:`dict` where 
         dict is the default format. The target field can be specified with the parameter 
-        `target_field`."""
+        :code:`target_field`."""
 
     __slots__: List[str] = ["target", "app", "http_server"]
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -280,7 +280,9 @@ class JSONHttpEndpoint(HttpEndpoint):
         if data:
             event = self._decoder.decode(data)
             if self.event_origin_field is not None:
-                event = {self.event_origin_field: event}
+                origin_event = event
+                event = {}
+                add_fields_to(event, {self.event_origin_field: data.decode("utf8")})
             self.messages.put(event | kwargs["metadata"], block=False)
 
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -31,7 +31,8 @@ An example config file would look like:
 The endpoint config supports regex and wildcard patterns:
   * :code:`/second*`: matches everything after asterisk
   * :code:`/(third|fourth)/endpoint` matches either third or forth in the first part
-
+The connector configuration includes an optional parameter called original_event_field.
+When set, the full event is stored as a string in the specified field defined by its value.
 
 Endpoint Credentials Config Example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +280,7 @@ class JSONHttpEndpoint(HttpEndpoint):
         data = await self.get_data(req)
         if data:
             event = self._decoder.decode(data)
-            if self.original_event_field is not None:
+            if self.original_event_field:
                 event = {}
                 add_fields_to(event, {self.original_event_field: data.decode("utf8")})
             self.messages.put(event | kwargs["metadata"], block=False)
@@ -299,7 +300,7 @@ class JSONLHttpEndpoint(HttpEndpoint):
         data = await self.get_data(req)
         events = self._decoder.decode_lines(data)
         for event in events:
-            if self.original_event_field is not None:
+            if self.original_event_field:
                 event = {}
                 add_fields_to(event, {self.original_event_field: data.decode("utf8")})
             self.messages.put(event | kwargs["metadata"], block=False, batch_size=len(events))
@@ -317,7 +318,7 @@ class PlaintextHttpEndpoint(HttpEndpoint):
         self.collect_metrics()
         data = await self.get_data(req)
         event = {"message": data.decode("utf8")}
-        if self.original_event_field is not None:
+        if self.original_event_field:
             event = {}
             add_fields_to(event, {self.original_event_field: data.decode("utf8")})
         self.messages.put(event | kwargs["metadata"], block=False)

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -34,7 +34,7 @@ The endpoint config supports regex and wildcard patterns:
   * :code:`/second*`: matches everything after asterisk
   * :code:`/(third|fourth)/endpoint` matches either third or forth in the first part
 The connector configuration includes an optional parameter called original_event_field.
-When set, the full event is stored as a string or dictionary in a specified field. The 
+When set, the full event is stored as a string or dictionary in a specified field. The
 target field for this operation is set via the parameter `target_field` and the format
 (string or dictionary) ist specified with the `format` parameter.
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -19,7 +19,7 @@ An example config file would look like:
         message_backlog_size: 15000
         collect_meta: False
         metafield_name: "@metadata"
-        original_event_field: 
+        original_event_field:
             "target_field": "event.original"
             "format": "dict"
         uvicorn_config:

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -162,7 +162,7 @@ def add_fields_to(
         event: dict
             The event object to which fields are to be added.
         fields: dict
-            A dicht with key value pairs describing the fields that should be added. The key is the dotted subfield
+            A dict with key value pairs describing the fields that should be added. The key is the dotted subfield
             string indicating the target. The value is the content that should be added to the named target. The
             content can be of type: str, float, int, list, dict.
         rule: Rule

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -8,9 +8,8 @@ from importlib.metadata import version
 from os import remove
 from typing import TYPE_CHECKING, Optional, Union
 
-from logprep.util.ansi import Back, Fore, AnsiBack, AnsiFore
-
 from logprep.processor.base.exceptions import FieldExistsWarning
+from logprep.util.ansi import AnsiBack, AnsiFore, Back, Fore
 from logprep.util.defaults import DEFAULT_CONFIG_LOCATION
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -146,6 +145,7 @@ def _add_field_to_silent_fail(*args, **kwargs) -> None | str:
         _add_field_to(*args, **kwargs)
     except FieldExistsWarning as error:
         return error.skipped_fields[0]
+    return None
 
 
 def add_fields_to(
@@ -190,9 +190,9 @@ def add_fields_to(
         itertools.repeat(merge_with_target, number_fields),
         itertools.repeat(overwrite_target, number_fields),
     )
-    unsuccessful_targets = [item for item in unsuccessful_targets if item is not None]
-    if unsuccessful_targets:
-        raise FieldExistsWarning(rule, event, unsuccessful_targets)
+    unsuccessful_targets_resolved = [item for item in unsuccessful_targets if item is not None]
+    if unsuccessful_targets_resolved:
+        raise FieldExistsWarning(rule, event, unsuccessful_targets_resolved)
 
 
 def _get_slice_arg(slice_item):

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -499,7 +499,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result = connector.get_next(0.01)
-        expected = {"event": {"original": '{"any":"content"}'}}
+        expected = {"event": {"original": '"{\\"any\\":\\"content\\"}"'}}
         assert result == expected, f"{expected} is not the same as {result}"
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -540,8 +540,9 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result = connector.get_next(0.01)
         expected = {
-            "any": {"content": '"{\\"any\\":\\"content\\"}"'}
-        }  # TODO: define expected and adapt
+            "any": {"content": '"{\\"any\\":\\"content\\"}"'},
+            "version_info": {"logprep": "", "configuration": ""},
+        }
         assert result == expected, f"{expected} is not the same as {result}"
 
     def test_add_full_event_to_target_field_with_dict_format(self):

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -490,7 +490,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
     def test_onboarding_mode(self):
         preprocessing_config = {
             "preprocessing": {
-                "onboarding_mode": "event.original",
+                "add_full_event_to_target_field": "event.original",
             }
         }
         connector_config = deepcopy(self.CONFIG)

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -499,7 +499,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         test_event = {"any": "content"}
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result = connector.get_next(0.01)
-        expected = {"event": {"original": {"any": "content"}}}
+        expected = {"event": {"original": '{"any":"content"}'}}
         assert result == expected, f"{expected} stimmt nicht mit {result} überein"
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -487,6 +487,21 @@ class BaseInputTestCase(BaseConnectorTestCase):
         result = connector.get_next(0.01)
         assert "arrival_time" in result
 
+    def test_onboarding_mode(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "onboarding_mode": "event.original",
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config})
+        test_event = {"any": "content"}
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result = connector.get_next(0.01)
+        expected = {"event": {"original": {"any": "content"}}}
+        assert result == expected, f"{expected} stimmt nicht mit {result} überein"
+
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(
         self,
     ):

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -487,7 +487,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         result = connector.get_next(0.01)
         assert "arrival_time" in result
 
-    def test_onboarding_mode(self):
+    def test_add_full_event_to_target_field(self):
         preprocessing_config = {
             "preprocessing": {
                 "add_full_event_to_target_field": "event.original",

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -500,7 +500,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result = connector.get_next(0.01)
         expected = {"event": {"original": '{"any":"content"}'}}
-        assert result == expected, f"{expected} stimmt nicht mit {result} überein"
+        assert result == expected, f"{expected} is not the same as {result}"
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(
         self,

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -487,10 +487,13 @@ class BaseInputTestCase(BaseConnectorTestCase):
         result = connector.get_next(0.01)
         assert "arrival_time" in result
 
-    def test_add_full_event_to_target_field(self):
+    def test_add_full_event_to_target_field_with_string_format(self):
         preprocessing_config = {
             "preprocessing": {
-                "add_full_event_to_target_field": "event.original",
+                "add_full_event_to_target_field": {
+                    "format": "str",
+                    "target_field": "event.original",
+                },
             }
         }
         connector_config = deepcopy(self.CONFIG)
@@ -500,6 +503,24 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
         result = connector.get_next(0.01)
         expected = {"event": {"original": '"{\\"any\\":\\"content\\"}"'}}
+        assert result == expected, f"{expected} is not the same as {result}"
+
+    def test_add_full_event_to_target_field_with_dict_format(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "add_full_event_to_target_field": {
+                    "format": "dict",
+                    "target_field": "event.original",
+                },
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config})
+        test_event = {"any": "content"}
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result = connector.get_next(0.01)
+        expected = {"event": {"original": {"any": "content"}}}
         assert result == expected, f"{expected} is not the same as {result}"
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -505,6 +505,45 @@ class BaseInputTestCase(BaseConnectorTestCase):
         expected = {"event": {"original": '"{\\"any\\":\\"content\\"}"'}}
         assert result == expected, f"{expected} is not the same as {result}"
 
+    def test_add_full_event_to_targetfield_with_same_name(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "add_full_event_to_target_field": {
+                    "format": "str",
+                    "target_field": "any.content",
+                },
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config})
+        test_event = {"any": "content"}
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result = connector.get_next(0.01)
+        expected = {"any": {"content": '"{\\"any\\":\\"content\\"}"'}}
+        assert result == expected, f"{expected} is not the same as {result}"
+
+    def test_add_full_event_to_targetfield_vs_version_info_target(self):
+        preprocessing_config = {
+            "preprocessing": {
+                "add_full_event_to_target_field": {
+                    "format": "str",
+                    "target_field": "any.content",
+                },
+                "version_info_target_field": "version_info",
+            }
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(preprocessing_config)
+        connector = Factory.create({"test connector": connector_config})
+        test_event = {"any": "content"}
+        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        result = connector.get_next(0.01)
+        expected = {
+            "any": {"content": '"{\\"any\\":\\"content\\"}"'}
+        }  # TODO: define expected and adapt
+        assert result == expected, f"{expected} is not the same as {result}"
+
     def test_add_full_event_to_target_field_with_dict_format(self):
         preprocessing_config = {
             "preprocessing": {

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -268,9 +268,9 @@ class TestHttpConnector(BaseInputTestCase):
         assert re.search(r"\d+\.\d+\.\d+\.\d+", message["custom"]["remote_addr"])
         assert isinstance(message["custom"]["user_agent"], str)
 
-    def test_event_original(self):
+    def test_original_event_field(self):
         message = {"message": "my message"}
-        updated_config = {"event_origin_field": "event.original"}
+        updated_config = {"original_event_field": "event.original"}
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(updated_config)
         connector = Factory.create({"test connector": connector_config})
@@ -280,7 +280,7 @@ class TestHttpConnector(BaseInputTestCase):
         resp = client.post("/json", json=message)
         assert resp.status_code == 200
         message = connector.messages.get(timeout=0.5)
-        expected = {"event": {"original": {"message": "my message"}}}
+        expected = {"event": {"original": '{"message": "my message"}'}}
         assert message == expected, f"{expected} does not equal {message}"
 
     def test_server_multiple_config_changes(self):

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -285,6 +285,52 @@ class TestHttpConnector(BaseInputTestCase):
         expected = {"event": {"original": {"message": "my message"}}}
         assert message == expected, f"{expected} does not equal {message}"
 
+    def test_original_event_field_with_preprocessor_active(self):
+        message = {"message": "my message"}
+        updated_config = {
+            "original_event_field": {"target_field": "event.original", "format": "dict"},
+            "preprocessing": {
+                "add_full_event_to_target_field": {
+                    "target_field": "also.original",
+                    "format": "str",
+                }
+            },
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(updated_config)
+        connector = Factory.create({"test connector": connector_config})
+        connector.pipeline_index = 1
+        connector.setup()
+        client = testing.TestClient(connector.app)
+        resp = client.post("/json", json=message)
+        assert resp.status_code == 200
+        message = connector.messages.get(timeout=0.5)
+        expected = {"event": {"original": {"message": "my message"}}}
+        assert message == expected, f"{expected} does not equal {message}"
+
+    def test_original_event_field_with_preprocessor_active_and_writing_to_the_same_field(self):
+        message = {"message": "my message"}
+        updated_config = {
+            "original_event_field": {"target_field": "event.original", "format": "dict"},
+            "preprocessing": {
+                "add_full_event_to_target_field": {
+                    "target_field": "event.original",
+                    "format": "str",
+                }
+            },
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(updated_config)
+        connector = Factory.create({"test connector": connector_config})
+        connector.pipeline_index = 1
+        connector.setup()
+        client = testing.TestClient(connector.app)
+        resp = client.post("/json", json=message)
+        assert resp.status_code == 200
+        message = connector.messages.get(timeout=0.5)
+        expected = {"event": {"original": {"message": "my message"}}}
+        assert message == expected, f"{expected} does not equal {message}"
+
     def test_original_event_field_with_event_as_string(self):
         message = {"message": "my message"}
         updated_config = {

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -328,7 +328,7 @@ class TestHttpConnector(BaseInputTestCase):
         resp = client.post("/json", json=message)
         assert resp.status_code == 200
         message = connector.messages.get(timeout=0.5)
-        expected = {"event": {"original": {"message": "my message"}}}
+        expected = {"event": {"original": '{"message": "my message"}'}}
         assert message == expected, f"{expected} does not equal {message}"
 
     def test_original_event_field_with_event_as_string(self):

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -268,9 +268,28 @@ class TestHttpConnector(BaseInputTestCase):
         assert re.search(r"\d+\.\d+\.\d+\.\d+", message["custom"]["remote_addr"])
         assert isinstance(message["custom"]["user_agent"], str)
 
-    def test_original_event_field(self):
+    def test_original_event_field_with_event_as_dict(self):
         message = {"message": "my message"}
-        updated_config = {"original_event_field": "event.original"}
+        updated_config = {
+            "original_event_field": {"target_field": "event.original", "format": "dict"}
+        }
+        connector_config = deepcopy(self.CONFIG)
+        connector_config.update(updated_config)
+        connector = Factory.create({"test connector": connector_config})
+        connector.pipeline_index = 1
+        connector.setup()
+        client = testing.TestClient(connector.app)
+        resp = client.post("/json", json=message)
+        assert resp.status_code == 200
+        message = connector.messages.get(timeout=0.5)
+        expected = {"event": {"original": {"message": "my message"}}}
+        assert message == expected, f"{expected} does not equal {message}"
+
+    def test_original_event_field_with_event_as_string(self):
+        message = {"message": "my message"}
+        updated_config = {
+            "original_event_field": {"target_field": "event.original", "format": "str"}
+        }
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(updated_config)
         connector = Factory.create({"test connector": connector_config})


### PR DESCRIPTION
This PR schould make it possible for logprep to add a whole event as a string to a designated target field. 