### PR TITLE
fix revoke callback error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 ### Improvements
 ### Bugfix
+
 - Fixed logging error in _revoke_callback() by adding error handling
 
 ## 16.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 ### Improvements
 ### Bugfix
+- Fixed logging error in _revoke_callback() by adding error handling
 
 ## 16.1.0
 ### Deprecations

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -492,7 +492,7 @@ class ConfluentKafkaInput(Input):
             offset, partition = topic_partition.offset, topic_partition.partition
             logger.info(
                 "%s was assigned to topic: %s | partition %s",
-                consumer.memberid(),  # This supposedely should fail
+                consumer.memberid(),
                 topic_partition.topic,
                 partition,
             )
@@ -521,7 +521,6 @@ class ConfluentKafkaInput(Input):
                 topic_partition.topic,
                 topic_partition.partition,
             )
-
         self.batch_finished_callback()
 
     def _lost_callback(self, consumer, topic_partitions):

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -505,9 +505,6 @@ class ConfluentKafkaInput(Input):
 
     def _revoke_callback(self, consumer, topic_partitions):
 
-        if getattr(consumer, "closed", False):
-            raise RuntimeError("Cannot revoke: consumer is already closed")
-
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
             member_id = self._get_memberid()
@@ -535,6 +532,7 @@ class ConfluentKafkaInput(Input):
             member_id = self._consumer.memberid()
         except RuntimeError as error:
             logger.error("Failed to retrieve member ID: %s", error)
+            member_id = None
         return member_id
 
     def shut_down(self) -> None:

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -130,11 +130,16 @@ class ConfluentKafkaInput(Input):
 
         librdkafka_replyq: GaugeMetric = field(
             factory=lambda: GaugeMetric(
-                description="Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll()",
+                description=(
+                    "Number of ops (callbacks, events, etc) waiting in "
+                    "queue for application to serve with rd_kafka_poll()"
+                ),
                 name="confluent_kafka_input_librdkafka_replyq",
             )
         )
-        """Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll()"""
+        """Number of ops (callbacks, events, etc) waiting in queue for application
+           to serve with rd_kafka_poll()
+        """
         librdkafka_tx: GaugeMetric = field(
             factory=lambda: GaugeMetric(
                 description="Total number of requests sent to Kafka brokers",
@@ -166,14 +171,22 @@ class ConfluentKafkaInput(Input):
         """Total number of bytes received from Kafka brokers"""
         librdkafka_rxmsgs: GaugeMetric = field(
             factory=lambda: GaugeMetric(
-                description="Total number of messages consumed, not including ignored messages (due to offset, etc), from Kafka brokers.",
+                description=(
+                    "Total number of messages consumed, not including ignored messages"
+                    "(due to offset, etc), from Kafka brokers."
+                ),
                 name="confluent_kafka_input_librdkafka_rxmsgs",
             )
         )
-        """Total number of messages consumed, not including ignored messages (due to offset, etc), from Kafka brokers."""
+        """Total number of messages consumed, not including ignored messages
+           (due to offset, etc), from Kafka brokers.
+        """
         librdkafka_rxmsg_bytes: GaugeMetric = field(
             factory=lambda: GaugeMetric(
-                description="Total number of message bytes (including framing) received from Kafka brokers",
+                description=(
+                    "Total number of message bytes (including framing)"
+                    "received from Kafka brokers"
+                ),
                 name="confluent_kafka_input_librdkafka_rxmsg_bytes",
             )
         )
@@ -195,11 +208,11 @@ class ConfluentKafkaInput(Input):
         """Time elapsed since last rebalance (assign or revoke) (milliseconds)."""
         librdkafka_cgrp_rebalance_cnt: GaugeMetric = field(
             factory=lambda: GaugeMetric(
-                description="Total number of rebalances (assign or revoke).",
+                description="Total number of rebalance (assign or revoke).",
                 name="confluent_kafka_input_librdkafka_cgrp_rebalance_cnt",
             )
         )
-        """Total number of rebalances (assign or revoke)."""
+        """Total number of rebalance (assign or revoke)."""
         librdkafka_cgrp_assignment_size: GaugeMetric = field(
             factory=lambda: GaugeMetric(
                 description="Current assignment's partition count.",
@@ -487,12 +500,13 @@ class ConfluentKafkaInput(Input):
         except KafkaException as error:
             raise InputWarning(self, f"{error}, {self._last_valid_record}") from error
 
-    def _assign_callback(self, consumer: Consumer, topic_partitions: list[TopicPartition]) -> None:
+    def _assign_callback(self, topic_partitions: list[TopicPartition]) -> None:
         for topic_partition in topic_partitions:
             offset, partition = topic_partition.offset, topic_partition.partition
+            member_id = self._get_memberid()
             logger.info(
                 "%s was assigned to topic: %s | partition %s",
-                consumer.memberid(),
+                member_id,
                 topic_partition.topic,
                 partition,
             )
@@ -528,11 +542,11 @@ class ConfluentKafkaInput(Input):
             )
 
     def _get_memberid(self) -> str | None:
+        member_id = None
         try:
             member_id = self._consumer.memberid()
         except RuntimeError as error:
             logger.error("Failed to retrieve member ID: %s", error)
-            member_id = None
         return member_id
 
     def shut_down(self) -> None:

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -503,7 +503,7 @@ class ConfluentKafkaInput(Input):
             self.metrics.committed_offsets.add_with_labels(offset, labels)
             self.metrics.current_offsets.add_with_labels(offset, labels)
 
-    def _revoke_callback(self, consumer, topic_partitions):
+    def _revoke_callback(self, topic_partitions):
 
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
@@ -516,7 +516,7 @@ class ConfluentKafkaInput(Input):
             )
         self.batch_finished_callback()
 
-    def _lost_callback(self, consumer, topic_partitions):
+    def _lost_callback(self, topic_partitions):
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
             member_id = self._get_memberid()
@@ -527,7 +527,9 @@ class ConfluentKafkaInput(Input):
                 topic_partition.partition,
             )
 
-    def _get_memberid(self) -> str | None:
+    def _get_memberid(
+        self,
+    ) -> str | None:
         try:
             member_id = self._consumer.memberid()
         except RuntimeError as error:

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -316,7 +316,7 @@ class ConfluentKafkaInput(Input):
             the error that occurred
         """
         self.metrics.number_of_errors += 1
-        logger.error(f"{self.describe()}: {error}")
+        logger.error("%s: %s", self.describe(), error)
 
     def _stats_callback(self, stats_raw: str) -> None:
         """Callback for statistics data. This callback is triggered by poll()
@@ -487,7 +487,7 @@ class ConfluentKafkaInput(Input):
         except KafkaException as error:
             raise InputWarning(self, f"{error}, {self._last_valid_record}") from error
 
-    def _assign_callback(self, consumer, topic_partitions):
+    def _assign_callback(self, consumer: Consumer, topic_partitions: list[TopicPartition]) -> None:
         for topic_partition in topic_partitions:
             offset, partition = topic_partition.offset, topic_partition.partition
             logger.info(
@@ -503,7 +503,7 @@ class ConfluentKafkaInput(Input):
             self.metrics.committed_offsets.add_with_labels(offset, labels)
             self.metrics.current_offsets.add_with_labels(offset, labels)
 
-    def _revoke_callback(self, topic_partitions):
+    def _revoke_callback(self, topic_partitions: list[TopicPartition]) -> None:
 
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
@@ -516,7 +516,7 @@ class ConfluentKafkaInput(Input):
             )
         self.batch_finished_callback()
 
-    def _lost_callback(self, topic_partitions):
+    def _lost_callback(self, topic_partitions: list[TopicPartition]) -> None:
         for topic_partition in topic_partitions:
             self.metrics.number_of_warnings += 1
             member_id = self._get_memberid()
@@ -527,9 +527,7 @@ class ConfluentKafkaInput(Input):
                 topic_partition.partition,
             )
 
-    def _get_memberid(
-        self,
-    ) -> str | None:
+    def _get_memberid(self) -> str | None:
         try:
             member_id = self._consumer.memberid()
         except RuntimeError as error:

--- a/logprep/connector/confluent_kafka/output.py
+++ b/logprep/connector/confluent_kafka/output.py
@@ -232,7 +232,7 @@ class ConfluentKafkaOutput(Output):
             the error that occurred
         """
         self.metrics.number_of_errors += 1
-        logger.error(f"{self.describe()}: {error}")  # pylint: disable=logging-fstring-interpolation
+        logger.error("%s: %s", self.describe(), error)
 
     def _stats_callback(self, stats_raw: str) -> None:
         """Callback for statistics data. This callback is triggered by poll()

--- a/tests/unit/connector/test_confluent_kafka_common.py
+++ b/tests/unit/connector/test_confluent_kafka_common.py
@@ -34,7 +34,7 @@ class CommonConfluentKafkaTestCase:
             test_error = Exception("test error")
             self.object._error_callback(test_error)
             mock_error.assert_called()
-            mock_error.assert_called_with(f"{self.object.describe()}: {test_error}")
+            mock_error.assert_called_with("%s: %s", self.object.describe(), test_error)
         assert self.object.metrics.number_of_errors == 1
 
     def test_stats_callback_sets_metric_objetc_attributes(self):

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -346,7 +346,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self.object.metrics.number_of_warnings = 0
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
-            self.object._lost_callback(mock_consumer, mock_partitions)
+            self.object._lost_callback(mock_partitions)
         mock_warning.assert_called()
         assert self.object.metrics.number_of_warnings == 1
 
@@ -383,7 +383,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self.object.output_connector = mock.MagicMock()
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
-            self.object._revoke_callback(mock_consumer, mock_partitions)
+            self.object._revoke_callback(mock_partitions)
         mock_warning.assert_called()
         assert self.object.metrics.number_of_warnings == 1
 
@@ -393,7 +393,7 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         self.object.output_connector = mock.MagicMock()
         self.object.batch_finished_callback = mock.MagicMock()
         mock_partitions = [mock.MagicMock()]
-        self.object._revoke_callback(mock_consumer, mock_partitions)
+        self.object._revoke_callback(mock_partitions)
         self.object.batch_finished_callback.assert_called()
 
     def test_health_returns_true_if_no_error(self):


### PR DESCRIPTION
In the confluent Kafka input connector, logging inside ```_revoke_callback`` can crash due the consumer being closed or in an invalid state.