### PR TITLE
Fix timezone for getting current time via TimeParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Resolved `mypy` errors in `BaseProcessorTestCase.` by ensuring `self.object` and `self.patchers` are not `None` before accessing attributes.
 - Fix domain resolver errors for invalid domains
 - Fixed deprecation warnings caused by datetime when using Python >= 3.12
+- Fixed timestamp and timezone mismatch issue
 
 ## 16.1.0
 ### Deprecations

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -56,12 +56,12 @@ class TimeParser:
         return time_object
 
     @classmethod
-    def now(cls, timezone: tzinfo = None) -> datetime:
+    def now(cls, timezone: tzinfo | None = UTC) -> datetime:
         """returns the current time
 
         Parameters
         ----------
-        timezone : tzinfo
+        timezone : tzinfo | None
             the timezone to use for the timestamp
 
         Returns
@@ -69,8 +69,8 @@ class TimeParser:
         datetime
             current date and time as datetime
         """
+        timezone = timezone if timezone else UTC
         time_object = datetime.now(timezone)
-        time_object = cls._set_utc_if_timezone_is_missing(time_object)
         return time_object
 
     @classmethod

--- a/tests/unit/util/test_time.py
+++ b/tests/unit/util/test_time.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 # pylint: disable=too-many-arguments
 from datetime import datetime, UTC
+from math import isclose
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -43,6 +44,9 @@ class TestTimeParser:
 
     def test_now_returns_datetime(self):
         assert isinstance(TimeParser.now(), datetime)
+
+    def test_now_returns_utc_time_by_default(self):
+        assert isclose(TimeParser.now().timestamp(), datetime.now(UTC).timestamp())
 
     @pytest.mark.parametrize(
         "source, format_str, expected",


### PR DESCRIPTION
`TimeParser.now()` created a timestamp with the local timezone and then changed the timezone to UTC if no timezone was specified.
With this pull request a UTC timestamp will be created instead.

Example:
* Let's say the local timezone is `+02:00` and no timezone was provided to `TimeParser.now()`
* `TimeParser` would create a timestamp `2025-01-01T02:00:00.000` in local time, but without a timezone
* The timezone would be set to UTC without adapting the time values, resulting in `2025-01-01T02:00:00.000+00:00`
* However, `2025-01-01T00:00:00.000+00:00` would be correct