### PR TITLE
change eventstate handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ tests/testdata/external/
 .profile/
 *.prof
 *.pyc
-.venv
+.venv*
 coverage.xml
 cov.xml
 -

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -75,7 +75,7 @@ class Event(ABC):
         self._state: EventState = EventState()
         if state is not None:
             if not isinstance(state, EventStateType):
-                raise TypeError("state must be an instance of EventStateType")
+                raise TypeError("state must be an instance of EventStateType or None")
             self._state.current_state = state
         self.data: dict[str, Any] = data
         self.warnings: list[str] = []

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -3,7 +3,7 @@
 """abstract module for event"""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 from logprep.ng.event.event_state import EventState, EventStateType
 from logprep.util.helper import (
@@ -73,7 +73,7 @@ class Event(ABC):
         """
         self._state: EventState = EventState()
         if state is not None:
-            if state not in cast(str, EventStateType):
+            if state not in list(EventStateType):
                 raise TypeError("state must be an instance of EventStateType or None")
             self._state.current_state = state
         self.data: dict[str, Any] = data

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -42,7 +42,7 @@ class Event(ABC):
         ----------
         data : dict[str, Any]
             The raw or processed data associated with the event.
-        state : EventState, optional
+        state : EventStateType, optional
             An optional initial EventState. Defaults to a new EventState() if not provided.
 
         Examples
@@ -55,9 +55,8 @@ class Event(ABC):
         >>> event.state.current_state.name
         'RECEIVING'
 
-        Providing a custom state:
-
-        >>> custom_state = EventState()
+        Providing a custom state
+        >>> custom_state = EventStateType.PROCESSED
         >>> event = Event({"source": "api"}, state=custom_state)
         >>> event.state is custom_state
         True
@@ -74,7 +73,7 @@ class Event(ABC):
         """
         self._state: EventState = EventState()
         if state is not None:
-            if not isinstance(state, EventStateType):
+            if state not in EventStateType:
                 raise TypeError("state must be an instance of EventStateType or None")
             self._state.current_state = state
         self.data: dict[str, Any] = data
@@ -225,14 +224,14 @@ class ExtraDataEvent(Event):
     outputs: tuple[dict[str, str]]
 
     def __init__(
-        self, data: dict[str, str], *, outputs: tuple[dict], state: EventState | None = None
+        self, data: dict[str, str], *, outputs: tuple[dict], state: EventStateType | None = None
     ) -> None:
         """
         Parameters
         ----------
         data : dict[str, str]
             The main data payload for the SRE event.
-        state : EventState
+        state : EventStateType
             The state of the SRE event.
         outputs : Iterable[str]
             The collection of output connector names associated with the SRE event

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -3,7 +3,7 @@
 """abstract module for event"""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union, cast
 
 from logprep.ng.event.event_state import EventState, EventStateType
 from logprep.util.helper import (
@@ -73,7 +73,7 @@ class Event(ABC):
         """
         self._state: EventState = EventState()
         if state is not None:
-            if state not in EventStateType:
+            if state not in cast(str, EventStateType):
                 raise TypeError("state must be an instance of EventStateType or None")
             self._state.current_state = state
         self.data: dict[str, Any] = data

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -33,7 +33,7 @@ class Event(ABC):
         self,
         data: dict[str, Any],
         *,
-        state: EventState | None = None,
+        state: EventStateType | None = None,
     ) -> None:
         """
         Initialize an Event instance.
@@ -72,8 +72,11 @@ class Event(ABC):
         >>> isinstance(event.errors[0], ValueError)
         True
         """
-
-        self._state: EventState = EventState() if state is None else state
+        self._state: EventState = EventState()
+        if state is not None:
+            if not isinstance(state, EventStateType):
+                raise TypeError("state must be an instance of EventStateType")
+            self._state.current_state = state
         self.data: dict[str, Any] = data
         self.warnings: list[str] = []
         self.errors: list[Exception] = []

--- a/logprep/ng/event/error_event.py
+++ b/logprep/ng/event/error_event.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from logprep.ng.abc.event import Event
-from logprep.ng.event.event_state import EventState
+from logprep.ng.event.event_state import EventStateType
 from logprep.ng.event.log_event import LogEvent
 
 
@@ -14,7 +14,7 @@ class ErrorEvent(Event):
     """
 
     def __init__(
-        self, log_event: LogEvent, reason: Exception, *, state: EventState | None = None
+        self, log_event: LogEvent, reason: Exception, *, state: EventStateType | None = None
     ) -> None:
         """
         Parameters

--- a/logprep/ng/event/event_state.py
+++ b/logprep/ng/event/event_state.py
@@ -94,18 +94,6 @@ class EventState:
 
         self.current_state: EventStateType = cast(EventStateType, EventStateType.RECEIVING)
 
-    def __repr__(self) -> str:
-        """
-        Return a string representation of the current event state.
-
-        Returns
-        -------
-        str
-            A string like "<EventState: current_state>".
-        """
-
-        return f"{self.current_state}"
-
     @staticmethod
     def _construct_state_machine() -> dict[EventStateType, list[EventStateType]]:
         """
@@ -227,7 +215,7 @@ class EventState:
         Returns
         -------
         str
-            A string like "<EventState: current_state>".
+            A string like "processed" reflecting the current state.
         """
 
-        return f"<EventState: {self.current_state}>"
+        return f"{self.current_state}"

--- a/logprep/ng/event/event_state.py
+++ b/logprep/ng/event/event_state.py
@@ -94,6 +94,18 @@ class EventState:
 
         self.current_state: EventStateType = cast(EventStateType, EventStateType.RECEIVING)
 
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the current event state.
+
+        Returns
+        -------
+        str
+            A string like "<EventState: current_state>".
+        """
+
+        return f"{self.current_state}"
+
     @staticmethod
     def _construct_state_machine() -> dict[EventStateType, list[EventStateType]]:
         """

--- a/logprep/ng/event/log_event.py
+++ b/logprep/ng/event/log_event.py
@@ -24,7 +24,7 @@ class LogEvent(Event):
         original: bytes,
         extra_data: list[Event] | None = None,
         metadata: EventMetadata | None = None,
-        state: EventState | None = None,
+        state: EventStateType | None = None,
     ) -> None:
         """
         Parameters

--- a/tests/unit/ng/event/test_error_event.py
+++ b/tests/unit/ng/event/test_error_event.py
@@ -7,7 +7,7 @@
 
 from logprep.ng.abc.event import Event
 from logprep.ng.event.error_event import ErrorEvent
-from logprep.ng.event.event_state import EventState, EventStateType
+from logprep.ng.event.event_state import EventStateType
 from logprep.ng.event.log_event import LogEvent
 from tests.unit.ng.event.test_event import TestEventClass
 
@@ -44,8 +44,7 @@ class TestErrorEvents(TestEventClass):
         assert error_event.data["event"] == str(self.log_event.data).encode("utf-8")
 
     def test_error_event_preserves_state_on_init(self) -> None:
-        state = EventState()
-        state.current_state = EventStateType.STORED_IN_OUTPUT
+        state = EventStateType.STORED_IN_OUTPUT
 
         self.log_event.state.current_state = EventStateType.FAILED
         error_event = ErrorEvent(

--- a/tests/unit/ng/event/test_event.py
+++ b/tests/unit/ng/event/test_event.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from logprep.ng.abc.event import Event
-from logprep.ng.event.event_state import EventState
+from logprep.ng.event.event_state import EventState, EventStateType
 
 
 class DummyEvent(Event):
@@ -136,12 +136,12 @@ class TestEventClass:
         and the other attributes must still initialize correctly.
         """
 
-        state = EventState()
+        state_type = EventStateType.RECEIVING
         payload = {"message": "A test message"}
 
-        event = DummyEvent(data=payload, state=state)
+        event = DummyEvent(data=payload, state=state_type)
 
-        assert event.state is state
+        assert event.state.current_state is EventStateType.RECEIVING
         assert event.data == payload
         assert isinstance(event.errors, list)
         assert isinstance(event.warnings, list)
@@ -175,7 +175,7 @@ class TestEventClass:
         Ensure that providing 'state' as a kw argument is allowed.
         """
 
-        DummyEvent({"source": "fail"}, state=EventState())
+        DummyEvent({"source": "fail"}, state=EventStateType.RECEIVED)
 
     @pytest.mark.parametrize(
         "data, warnings, errors, state",
@@ -193,13 +193,13 @@ class TestEventClass:
                 {"status": "ok"},
                 [],
                 [],
-                EventState(),
+                EventStateType.RECEIVED,
             ),
             (
                 {"service": "auth"},
                 ["auth timeout"],
                 [TimeoutError("Service did not respond")],
-                EventState(),
+                EventStateType.PROCESSED,
             ),
         ],
     )
@@ -208,7 +208,7 @@ class TestEventClass:
         data: dict[str, Any],
         warnings: list[str],
         errors: list[Exception],
-        state: EventState | None,
+        state: EventStateType | None,
     ) -> None:
         """
         Ensure that DummyEvent instances with type-consistent

--- a/tests/unit/ng/event/test_event.py
+++ b/tests/unit/ng/event/test_event.py
@@ -263,3 +263,9 @@ class TestEventClass:
         assert (
             repr(event) == "DummyEvent(data={'user': {'id': 42, 'name': 'Alice'}}, state=receiving)"
         )
+
+    def test_event_repr_with_custom_state(self):
+        event = DummyEvent({"user": {"id": 42, "name": "Alice"}}, state=EventStateType.PROCESSED)
+        assert (
+            repr(event) == "DummyEvent(data={'user': {'id': 42, 'name': 'Alice'}}, state=processed)"
+        )

--- a/tests/unit/ng/event/test_event.py
+++ b/tests/unit/ng/event/test_event.py
@@ -269,3 +269,17 @@ class TestEventClass:
         assert (
             repr(event) == "DummyEvent(data={'user': {'id': 42, 'name': 'Alice'}}, state=processed)"
         )
+
+    @pytest.mark.parametrize(
+        "event_kwargs",
+        [
+            {"data": {"key": "value"}, "state": EventState()},
+            {"data": {"key": "value"}, "state": "invalid"},
+        ],
+    )
+    def test_init_raises_on_invalid_state(self, event_kwargs):
+        """
+        Ensure that initializing an Event with an invalid state raises a TypeError.
+        """
+        with pytest.raises(TypeError, match="state must be an instance of EventStateType or None"):
+            DummyEvent(**event_kwargs)

--- a/tests/unit/ng/event/test_event_state.py
+++ b/tests/unit/ng/event/test_event_state.py
@@ -76,7 +76,7 @@ def test_reset_sets_state_to_initial() -> None:
 def test_str_representation() -> None:
     """String representation should be human-readable."""
     state = EventState()
-    assert str(state) == "<EventState: receiving>"
+    assert str(state) == "receiving"
 
 
 def test_next_raises_exception_when_no_further_state() -> None:

--- a/tests/unit/ng/event/test_filtered_event.py
+++ b/tests/unit/ng/event/test_filtered_event.py
@@ -26,8 +26,7 @@ class TestFilteredEvents(TestEventClass):
         assert isinstance(filtered_event.state, EventState)
 
     def test_sre_event_preserves_state_on_init(self) -> None:
-        state = EventState()
-        state.current_state = EventStateType.STORED_IN_OUTPUT
+        state = EventStateType.STORED_IN_OUTPUT
         outputs = ({"name": "sre_topic"},)
         sre_event = FilteredEvent(data={"msg": "payload"}, state=state, outputs=outputs)
 

--- a/tests/unit/ng/event/test_log_event.py
+++ b/tests/unit/ng/event/test_log_event.py
@@ -30,8 +30,7 @@ class TestLogEvents(TestEventClass):
         assert log_event.state.next_state != log_event._origin_state_next_state_fn
 
     def test_log_event_preserves_state_on_init(self) -> None:
-        state = EventState()
-        state.current_state = cast(EventStateType, EventStateType.STORED_IN_OUTPUT)
+        state = EventStateType.STORED_IN_OUTPUT
         log_event = LogEvent(data={"msg": "payload"}, original=b"event", state=state)
 
         assert log_event.state.current_state is EventStateType.STORED_IN_OUTPUT

--- a/tests/unit/ng/event/test_pseudonym_event.py
+++ b/tests/unit/ng/event/test_pseudonym_event.py
@@ -23,8 +23,7 @@ class TestPseudonymEvents(TestEventClass):
         assert isinstance(pseudonym_event.state, EventState)
 
     def test_pseudonym_event_preserves_state_on_init(self) -> None:
-        state = EventState()
-        state.current_state = EventStateType.STORED_IN_OUTPUT
+        state = EventStateType.STORED_IN_OUTPUT
         outputs = ({"opensearch": "pseudonym_index"},)
         pseudonym_event = PseudonymEvent(data={"msg": "payload"}, state=state, outputs=outputs)
 

--- a/tests/unit/ng/event/test_sre_event.py
+++ b/tests/unit/ng/event/test_sre_event.py
@@ -26,8 +26,7 @@ class TestSreEvents(TestEventClass):
         assert isinstance(sre_event.state, EventState)
 
     def test_sre_event_preserves_state_on_init(self) -> None:
-        state = EventState()
-        state.current_state = EventStateType.STORED_IN_OUTPUT
+        state = EventStateType.STORED_IN_OUTPUT
         outputs = ({"name": "sre_topic"},)
         sre_event = SreEvent(data={"msg": "payload"}, state=state, outputs=outputs)
 


### PR DESCRIPTION
changes state type in `Event.__init__` to EventStateType to make creating Events with custom state more intuitive

add `__repr__` method to event state reflecting the current state