### PR TITLE
setup event backlog in abstract input class and event registration an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 ## Upcoming Changes
 
 ## next release
+
+### Breaking
+
+### Features
+
+### Improvements
+
+* Add `event_backlog` to the abstract input interface.
+* Register event in the backlog and return the registered event object.
+
+### Bugfix
+
+
 ### Breaking
 
 ### Features
@@ -8,7 +21,7 @@
 ### Improvements
 
 * make `processors` handle Event class based objects
-* add an EventBacklog class hierarchies 
+* add an EventBacklog class hierarchies
 * implement an iterator interface to Input connectors
 * make simple connectors handle Event class based objects
 * make `opensearch_output` handle Event class based objects

--- a/doc/source/development/notebooks/new_architecture_examples/1_event_metadata.ipynb
+++ b/doc/source/development/notebooks/new_architecture_examples/1_event_metadata.ipynb
@@ -28,9 +28,9 @@
    },
    "cell_type": "code",
    "source": [
-    "from logprep.ng.connector.confluent_kafka.metadata import KafkaInputMetadata\n",
+    "from logprep.ng.connector.confluent_kafka.metadata import ConfluentKafkaMetadata\n",
     "\n",
-    "kafka_metadata = KafkaInputMetadata(partition=1, offset=0)\n",
+    "kafka_metadata = ConfluentKafkaMetadata(partition=1, offset=0)\n",
     "\n",
     "print(kafka_metadata)"
    ],
@@ -59,7 +59,7 @@
    },
    "cell_type": "code",
    "source": [
-    "kafka_metadata = KafkaInputMetadata(partition=\"1\", offset=\"Zero\")\n",
+    "kafka_metadata = ConfluentKafkaMetadata(partition=\"1\", offset=\"Zero\")\n",
     "\n",
     "print(kafka_metadata)"
    ],

--- a/logprep/abc/component.py
+++ b/logprep/abc/component.py
@@ -59,7 +59,7 @@ class Component(ABC):
 
     # instance attributes
     name: str
-    pipeline_index: int
+    pipeline_index: int | None
     _config: Config
 
     # class attributes
@@ -72,7 +72,7 @@ class Component(ABC):
         """Labels for the metrics"""
         return {"component": self._config.type, "name": self.name, "description": "", "type": ""}
 
-    def __init__(self, name: str, configuration: "Config", pipeline_index: int = None):
+    def __init__(self, name: str, configuration: "Config", pipeline_index: int | None = None):
         self._config = configuration
         self.name = name
         self.pipeline_index = pipeline_index
@@ -149,9 +149,7 @@ class Component(ABC):
         logger.debug("Checking health of %s", self.name)
         return True
 
-    def _schedule_task(
-        self, task: Callable, seconds: int, args: tuple = None, kwargs: dict = None
-    ) -> None:
+    def _schedule_task(self, task: Callable, seconds: int, *args, **kwargs) -> None:
         """Schedule a task to run periodically during pipeline run.
         The task is run in :code:`pipeline.py` in the :code:`process_pipeline` method.
 

--- a/logprep/abc/component.py
+++ b/logprep/abc/component.py
@@ -7,7 +7,7 @@ import sys
 import time
 from abc import ABC
 from functools import cached_property
-from typing import Callable
+from typing import Callable, Literal
 
 import msgspec
 from attr import define, field, validators
@@ -72,7 +72,7 @@ class Component(ABC):
         """Labels for the metrics"""
         return {"component": self._config.type, "name": self.name, "description": "", "type": ""}
 
-    def __init__(self, name: str, configuration: "Component.Config", pipeline_index: int = None):
+    def __init__(self, name: str, configuration: "Config", pipeline_index: int = None):
         self._config = configuration
         self.name = name
         self.pipeline_index = pipeline_index

--- a/logprep/ng/abc/input.py
+++ b/logprep/ng/abc/input.py
@@ -267,7 +267,7 @@ class Input(Connector):
     def __init__(
         self,
         name: str,
-        configuration: Literal["Input.Config"],
+        configuration: "Input.Config",
         pipeline_index: int | None = None,
     ) -> None:
         self.event_backlog: EventBacklog | None = None

--- a/logprep/ng/connector/confluent_kafka/input.py
+++ b/logprep/ng/connector/confluent_kafka/input.py
@@ -51,15 +51,24 @@ from logprep.abc.input import (
     FatalInputError,
     InputWarning,
 )
-from logprep.connector.confluent_kafka.input import (
-    DEFAULT_RETURN,
-    DEFAULTS,
-    SPECIAL_OFFSETS,
-    logger,
-)
 from logprep.metrics.metrics import CounterMetric, GaugeMetric
 from logprep.ng.abc.input import Input
+from logprep.ng.connector.confluent_kafka.metadata import ConfluentKafkaMetadata
 from logprep.util.validators import keys_in_validator
+
+DEFAULTS = {
+    "enable.auto.offset.store": "false",
+    "enable.auto.commit": "true",
+    "client.id": "<<hostname>>",
+    "auto.offset.reset": "earliest",
+    "session.timeout.ms": "6000",
+    "statistics.interval.ms": "30000",
+}
+
+
+DEFAULT_RETURN = 0
+
+logger = logging.getLogger("KafkaInput")
 
 
 class ConfluentKafkaInput(Input):
@@ -388,7 +397,7 @@ class ConfluentKafkaInput(Input):
         base_description = super().describe()
         return f"{base_description} - Kafka Input: {self._config.kafka_config['bootstrap.servers']}"
 
-    def _get_raw_event(self, timeout: float) -> bytes | None:
+    def _get_raw_event(self, timeout: float) -> Message | None:
         """Get next raw Message from Kafka.
 
         Parameters
@@ -398,8 +407,8 @@ class ConfluentKafkaInput(Input):
 
         Returns
         -------
-        message_value : bytearray
-            A raw document obtained from Kafka.
+        message : Message, None
+            A document obtained from Kafka.
 
         Raises
         ------
@@ -420,9 +429,9 @@ class ConfluentKafkaInput(Input):
         self._last_valid_record = message
         labels = {"description": f"topic: {self._config.topic} - partition: {message.partition()}"}
         self.metrics.current_offsets.add_with_labels(message.offset() + 1, labels)
-        return message.value()
+        return message
 
-    def _get_event(self, timeout: float) -> tuple[None, None] | tuple[dict, bytes]:
+    def _get_event(self, timeout: float) -> tuple:
         """Parse the raw document from Kafka into a json.
 
         Parameters
@@ -432,19 +441,26 @@ class ConfluentKafkaInput(Input):
 
         Returns
         -------
-        event_dict : dict
+        event_dict : dict, None
             A parsed document obtained from Kafka.
-        raw_event : bytearray
+        raw_event : bytearray, None
             A raw document obtained from Kafka.
+        metadata: EventMetadata, None
+            The kafka metadata with specific data for this event.
 
         Raises
         ------
         CriticalInputError
             Raises if an input is invalid or if it causes an error.
         """
-        raw_event = self._get_raw_event(timeout)
-        if raw_event is None:
-            return None, None
+
+        message = self._get_raw_event(timeout)
+
+        if message is None:
+            return None, None, None
+
+        raw_event = message.value()
+
         try:
             event_dict = self._decoder.decode(raw_event.decode("utf-8"))
         except UnicodeDecodeError as error:
@@ -455,7 +471,12 @@ class ConfluentKafkaInput(Input):
             raise CriticalInputParsingError(
                 self, "Input record value is not a valid json string", raw_event
             ) from error
-        return event_dict, raw_event
+
+        return (
+            event_dict,
+            raw_event,
+            ConfluentKafkaMetadata(partition=message.partition(), offset=message.offset()),
+        )
 
     @property
     def _enable_auto_offset_store(self) -> bool:

--- a/logprep/ng/connector/confluent_kafka/input.py
+++ b/logprep/ng/connector/confluent_kafka/input.py
@@ -263,7 +263,7 @@ class ConfluentKafkaInput(Input):
 
     __slots__ = ["_last_valid_record"]
 
-    def __init__(self, name: str, configuration: Literal["Input.Config"]) -> None:
+    def __init__(self, name: str, configuration: "Input.Config") -> None:
         super().__init__(name, configuration)
         self._last_valid_record = None
 

--- a/logprep/ng/connector/confluent_kafka/input.py
+++ b/logprep/ng/connector/confluent_kafka/input.py
@@ -263,7 +263,7 @@ class ConfluentKafkaInput(Input):
 
     __slots__ = ["_last_valid_record"]
 
-    def __init__(self, name: str, configuration: Literal["Config"]) -> None:
+    def __init__(self, name: str, configuration: Literal["Input.Config"]) -> None:
         super().__init__(name, configuration)
         self._last_valid_record = None
 

--- a/logprep/ng/connector/confluent_kafka/metadata.py
+++ b/logprep/ng/connector/confluent_kafka/metadata.py
@@ -6,7 +6,7 @@ from logprep.ng.abc.event import EventMetadata
 
 
 @attrs.define(slots=True, kw_only=True)
-class KafkaInputMetadata(EventMetadata):
+class ConfluentKafkaMetadata(EventMetadata):
     """Concrete EventMetadata holding Kafka input metadata."""
 
     partition: int = attrs.field(validator=attrs.validators.instance_of(int))

--- a/logprep/ng/connector/dummy/input.py
+++ b/logprep/ng/connector/dummy/input.py
@@ -49,6 +49,7 @@ class DummyInput(Input):
 
     def _get_event(self, timeout: float) -> tuple:
         """Retrieve next document from configuration and raise warning if found"""
+
         if not self._documents:
             if not self._config.repeat_documents:
                 raise SourceDisconnectedWarning(self, "no documents left")
@@ -58,4 +59,5 @@ class DummyInput(Input):
 
         if (document.__class__ == type) and issubclass(document, Exception):
             raise document
-        return document, None
+
+        return document, None, None

--- a/logprep/ng/connector/dummy/input.py
+++ b/logprep/ng/connector/dummy/input.py
@@ -21,13 +21,11 @@ Example
 
 import copy
 from functools import cached_property
-from typing import List, Optional
 
 from attr import field, validators
 from attrs import define
 
-from logprep.abc.input import SourceDisconnectedWarning
-from logprep.ng.abc.input import Input
+from logprep.ng.abc.input import Input, SourceDisconnectedWarning
 
 
 class DummyInput(Input):

--- a/logprep/ng/connector/file/input.py
+++ b/logprep/ng/connector/file/input.py
@@ -157,12 +157,13 @@ class FileInput(Input):
 
     def _get_event(self, timeout: float) -> tuple:
         """Returns the first message from the threadsafe queue"""
+
         try:
             message: dict = self._messages.get(timeout=timeout)
             raw_message: bytes = str(message).encode("utf8")
-            return message, raw_message
+            return message, raw_message, None
         except queue.Empty:
-            return None, None
+            return None, None, None
 
     def setup(self) -> None:
         """Creates and starts the Thread that continuously monitors the given logfile.

--- a/logprep/ng/connector/http/input.py
+++ b/logprep/ng/connector/http/input.py
@@ -95,7 +95,6 @@ import requests
 from attrs import define, field, validators
 from joblib._multiprocessing_helpers import mp
 
-from logprep.abc.input import FatalInputError
 from logprep.connector.http.input import (
     HttpEndpoint,
     JSONHttpEndpoint,
@@ -106,7 +105,7 @@ from logprep.connector.http.input import (
 )
 from logprep.factory_error import InvalidConfigurationError
 from logprep.metrics.metrics import CounterMetric, GaugeMetric
-from logprep.ng.abc.input import Input
+from logprep.ng.abc.input import FatalInputError, Input
 from logprep.util import http, rstr
 from logprep.util.credentials import CredentialsFactory
 

--- a/logprep/ng/connector/http/input.py
+++ b/logprep/ng/connector/http/input.py
@@ -312,13 +312,15 @@ class HttpInput(Input):
 
     def _get_event(self, timeout: float) -> tuple:
         """Returns the first message from the queue"""
+
         self.metrics.message_backlog_size += self.messages.qsize()
+
         try:
             message = self.messages.get(timeout=timeout)
             raw_message = str(message).encode("utf8")
-            return message, raw_message
+            return message, raw_message, None
         except queue.Empty:
-            return None, None
+            return None, None, None
 
     def shut_down(self) -> None:
         """Raises Uvicorn HTTP Server internal stop flag and waits to join"""

--- a/logprep/ng/connector/json/input.py
+++ b/logprep/ng/connector/json/input.py
@@ -22,12 +22,11 @@ Example
 
 import copy
 from functools import cached_property
-from typing import Optional
 
 from attr import field, validators
 from attrs import define
 
-from logprep.abc.input import Input
+from logprep.ng.abc.input import Input
 from logprep.ng.connector.dummy.input import DummyInput
 from logprep.util.json_handling import parse_json
 

--- a/tests/unit/component/base.py
+++ b/tests/unit/component/base.py
@@ -35,6 +35,7 @@ class BaseComponentTestCase(ABC):
         config = {"Test Instance Name": self.CONFIG}
         self.object = Factory.create(configuration=config)
         self.object._wait_for_health = mock.MagicMock()
+
         assert "metrics" not in self.object.__dict__, "metrics should be a cached_property"
         self.metric_attributes = asdict(
             self.object.metrics,

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -44,9 +44,10 @@ class BaseInputTestCase(BaseConnectorTestCase):
 
     def test_get_next_returns_event(self):
         return_value = ({"message": "test message"}, b'{"message": "test message"}')
-        self.object._get_event = mock.MagicMock(return_value=return_value)
-        event = self.object.get_next(0.01)
-        assert isinstance(event, dict)
+
+        with mock.patch.object(self.object, "_get_event", return_value=return_value):
+            event = self.object.get_next(0.01)
+            assert isinstance(event, dict)
 
     def test_add_hmac_returns_true_if_hmac_options(self):
         connector_config = deepcopy(self.CONFIG)

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -44,10 +44,9 @@ class BaseInputTestCase(BaseConnectorTestCase):
 
     def test_get_next_returns_event(self):
         return_value = ({"message": "test message"}, b'{"message": "test message"}')
-
-        with mock.patch.object(self.object, "_get_event", return_value=return_value):
-            event = self.object.get_next(0.01)
-            assert isinstance(event, dict)
+        self.object._get_event = mock.MagicMock(return_value=return_value)
+        event = self.object.get_next(0.01)
+        assert isinstance(event, dict)
 
     def test_add_hmac_returns_true_if_hmac_options(self):
         connector_config = deepcopy(self.CONFIG)

--- a/tests/unit/connector/test_confluent_kafka_common.py
+++ b/tests/unit/connector/test_confluent_kafka_common.py
@@ -12,7 +12,7 @@ import pytest
 from logprep.factory import Factory
 from logprep.util.helper import get_dotted_field_value
 
-KAFKA_STATS_JSON_FILE = "kafka_stats_return_value.json"
+KAFKA_STATS_JSON_PATH = "tests/testdata/kafka_stats_return_value.json"
 
 
 class CommonConfluentKafkaTestCase:
@@ -44,8 +44,7 @@ class CommonConfluentKafkaTestCase:
         for metric in librdkafka_metrics:
             setattr(self.object.metrics, metric, 0)
 
-        json_string_path = Path(__file__).resolve().parents[2] / "testdata" / KAFKA_STATS_JSON_FILE
-        json_string = json_string_path.read_text("utf8")
+        json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         self.object._stats_callback(json_string)
         stats_dict = json.loads(json_string)
         for metric in librdkafka_metrics:
@@ -55,8 +54,7 @@ class CommonConfluentKafkaTestCase:
 
     def test_stats_set_age_metric_explicitly(self):
         self.object.metrics.librdkafka_age = 0
-        json_string_path = Path(__file__).resolve().parents[2] / "testdata" / KAFKA_STATS_JSON_FILE
-        json_string = json_string_path.read_text("utf8")
+        json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         self.object._stats_callback(json_string)
         assert self.object.metrics.librdkafka_age == 1337
 

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import re
+import sys
 import zlib
 from copy import deepcopy
 from logging import getLogger
@@ -41,14 +42,43 @@ class BaseConnectorTestCase(BaseComponentTestCase):
 
 
 class BaseInputTestCase(BaseConnectorTestCase):
+    def patch_documents_property(self, *, document):
+        """
+        Patch the `@cached_property` `_documents` to return a shared, mutable list.
+
+        If `document` is a list, returns the same mutable list every time.
+        If `document` is a callable, uses it as side_effect.
+        """
+        if callable(document):
+            side_effect = document
+        else:
+            shared_list = list(document)  # make a real mutable copy
+            side_effect = lambda: shared_list
+
+        return mock.patch(
+            "logprep.ng.connector.json.input.JsonInput._documents",
+            new_callable=mock.PropertyMock,
+            side_effect=side_effect,
+        )
+
     def test_is_input_instance(self):
         assert isinstance(self.object, Input)
 
     def test_get_next_returns_event(self):
-        return_value = ({"message": "test message"}, b'{"message": "test message"}')
-        self.object._get_event = mock.MagicMock(return_value=return_value)
-        event = self.object.get_next(0.01)
-        assert isinstance(event, dict)
+        return_value = ({"message": "test message"}, b'{"message": "test message"}', None)
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+
+            with mock.patch.object(connector, "_get_event", return_value=return_value):
+                event = connector.get_next(0.01)
+                assert isinstance(event, LogEvent)
+
+            connector.shut_down()
 
     def test_add_hmac_returns_true_if_hmac_options(self):
         connector_config = deepcopy(self.CONFIG)
@@ -65,6 +95,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         )
         connector = Factory.create({"test connector": connector_config})
         assert connector._add_hmac is True
+        connector.shut_down()
 
     def test_add_hmac_to_adds_hmac(self):
         connector_config = deepcopy(self.CONFIG)
@@ -89,6 +120,8 @@ class BaseInputTestCase(BaseConnectorTestCase):
         assert (
             processed_event.get("Hmac").get("compressed_base64") == "eJwrSS0uUchNLS5OTE8FAB8fBMY="
         )
+
+        connector.shut_down()
 
     def test_add_hmac_to_adds_hmac_even_if_no_raw_message_was_given(self):
         connector_config = deepcopy(self.CONFIG)
@@ -115,141 +148,183 @@ class BaseInputTestCase(BaseConnectorTestCase):
             calculated_compression == "eJyrVspNLS5OTE9VslIqSS0uUYBxawF+Fwll"
         ), f"Wrong compression: {calculated_compression}"
 
+        connector.shut_down()
+
     def test_get_next_with_hmac_of_raw_message(self):
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(
-            {
-                "preprocessing": {
-                    "hmac": {
-                        "target": "<RAW_MSG>",
-                        "key": "hmac-test-key",
-                        "output_field": "Hmac",
+        return_value = {"message": "with_content"}
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(
+                {
+                    "preprocessing": {
+                        "hmac": {
+                            "target": "<RAW_MSG>",
+                            "key": "hmac-test-key",
+                            "output_field": "Hmac",
+                        }
                     }
                 }
-            }
-        )
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"message": "with_content"}
-        raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
-        connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
-        )
-        expected_event = {
-            "message": "with_content",
-            "Hmac": {
-                "compressed_base64": "eJyrVspNLS5OTE9VslIqzyzJiE/OzytJzStRqgUAgKkJtg==",
-                "hmac": "dfe78753da634d7b76760488dbb2cf7bfe1b0e4e794930c36e98a984b6b6be63",
-            },
-        }
-        connector_next_msg = connector.get_next(1)
-        assert connector_next_msg == expected_event, "Output event with hmac is not as expected"
+            )
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
 
-        decoded = base64.b64decode(connector_next_msg["Hmac"]["compressed_base64"])
-        decoded_message = zlib.decompress(decoded)
-        assert test_event == json.loads(
-            decoded_message.decode("utf-8")
-        ), "The hmac base massage was not correctly encoded and compressed. "
-
-    def test_get_next_with_hmac_of_subfield(self):
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(
-            {
-                "preprocessing": {
-                    "hmac": {
-                        "target": "message.with_subfield",
-                        "key": "hmac-test-key",
-                        "output_field": "Hmac",
-                    }
-                }
-            }
-        )
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"message": {"with_subfield": "content"}}
-        raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
-        connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
-        )
-        expected_event = {
-            "message": {"with_subfield": "content"},
-            "Hmac": {
-                "compressed_base64": "eJxLzs8rSc0rAQALywL8",
-                "hmac": "e01e02a09cb270eebf7ae846b96d7306681038bd279f85d44c77019e0c4f6316",
-            },
-        }
-
-        connector_next_msg = connector.get_next(1)
-        assert connector_next_msg == expected_event
-
-        decoded = base64.b64decode(connector_next_msg["Hmac"]["compressed_base64"])
-        decoded_message = zlib.decompress(decoded)
-        assert test_event["message"]["with_subfield"] == decoded_message.decode(
-            "utf-8"
-        ), "The hmac base massage was not correctly encoded and compressed. "
-
-    def test_get_next_with_hmac_of_non_existing_subfield(self):
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(
-            {
-                "preprocessing": {
-                    "hmac": {
-                        "target": "non_existing_field",
-                        "key": "hmac-test-key",
-                        "output_field": "Hmac",
-                    }
-                }
-            }
-        )
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"message": {"with_subfield": "content"}}
-        raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
-        connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
-        )
-        critical_input_error_msg = "Couldn't find the hmac target field 'non_existing_field'"
-        with pytest.raises(CriticalInputError, match=critical_input_error_msg) as error:
-            _ = connector.get_next(1)
-        assert error.value.raw_input == b'{"message":{"with_subfield":"content"}}'
-
-    def test_get_next_with_hmac_result_in_dotted_subfield(self):
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(
-            {
-                "preprocessing": {
-                    "hmac": {
-                        "target": "<RAW_MSG>",
-                        "key": "hmac-test-key",
-                        "output_field": "Hmac.dotted.subfield",
-                    }
-                }
-            }
-        )
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"message": "with_content"}
-        raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
-        connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
-        )
-        expected_event = {
-            "message": "with_content",
-            "Hmac": {
-                "dotted": {
-                    "subfield": {
+            raw_encoded_test_event = json.dumps(return_value, separators=(",", ":")).encode("utf-8")
+            connector._get_event = mock.MagicMock(
+                return_value=(return_value.copy(), raw_encoded_test_event, None)
+            )
+            expected_event = LogEvent(
+                data={
+                    "message": "with_content",
+                    "Hmac": {
                         "compressed_base64": "eJyrVspNLS5OTE9VslIqzyzJiE/OzytJzStRqgUAgKkJtg==",
                         "hmac": "dfe78753da634d7b76760488dbb2cf7bfe1b0e4e794930c36e98a984b6b6be63",
+                    },
+                },
+                original=b"",
+            )
+            connector_next_msg = connector.get_next(1)
+            assert connector_next_msg == expected_event, "Output event with hmac is not as expected"
+
+            decoded = base64.b64decode(connector_next_msg.data["Hmac"]["compressed_base64"])
+            decoded_message = zlib.decompress(decoded)
+            assert return_value == json.loads(
+                decoded_message.decode("utf-8")
+            ), "The hmac base massage was not correctly encoded and compressed. "
+
+            connector.shut_down()
+
+    def test_get_next_with_hmac_of_subfield(self):
+        return_value = {"message": {"with_subfield": "content"}}
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(
+                {
+                    "preprocessing": {
+                        "hmac": {
+                            "target": "message.with_subfield",
+                            "key": "hmac-test-key",
+                            "output_field": "Hmac",
+                        }
                     }
                 }
-            },
-        }
+            )
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
 
-        connector_next_msg = connector.get_next(1)
-        assert connector_next_msg == expected_event
-        decoded = base64.b64decode(
-            connector_next_msg["Hmac"]["dotted"]["subfield"]["compressed_base64"]
-        )
-        decoded_message = zlib.decompress(decoded)
-        assert test_event == json.loads(
-            decoded_message.decode("utf-8")
-        ), "The hmac base massage was not correctly encoded and compressed. "
+            raw_encoded_test_event = json.dumps(return_value, separators=(",", ":")).encode("utf-8")
+            connector._get_event = mock.MagicMock(
+                return_value=(return_value.copy(), raw_encoded_test_event, None)
+            )
+            expected_event = LogEvent(
+                data={
+                    "message": {"with_subfield": "content"},
+                    "Hmac": {
+                        "compressed_base64": "eJxLzs8rSc0rAQALywL8",
+                        "hmac": "e01e02a09cb270eebf7ae846b96d7306681038bd279f85d44c77019e0c4f6316",
+                    },
+                },
+                original=b"",
+            )
+
+            connector_next_msg = connector.get_next(1)
+            assert connector_next_msg == expected_event
+
+            decoded = base64.b64decode(connector_next_msg.data["Hmac"]["compressed_base64"])
+            decoded_message = zlib.decompress(decoded)
+            assert return_value["message"]["with_subfield"] == decoded_message.decode(
+                "utf-8"
+            ), "The hmac base massage was not correctly encoded and compressed. "
+
+            connector.shut_down()
+
+    def test_get_next_with_hmac_of_non_existing_subfield(self):
+        return_value = {"message": {"with_subfield": "content"}}
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(
+                {
+                    "preprocessing": {
+                        "hmac": {
+                            "target": "non_existing_field",
+                            "key": "hmac-test-key",
+                            "output_field": "Hmac",
+                        }
+                    }
+                }
+            )
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+
+            raw_encoded_test_event = json.dumps(return_value, separators=(",", ":")).encode("utf-8")
+            connector._get_event = mock.MagicMock(
+                return_value=(return_value.copy(), raw_encoded_test_event, None)
+            )
+            critical_input_error_msg = "Couldn't find the hmac target field 'non_existing_field'"
+            with pytest.raises(CriticalInputError, match=critical_input_error_msg) as error:
+                _ = connector.get_next(1)
+            assert error.value.raw_input == b'{"message":{"with_subfield":"content"}}'
+
+            connector.shut_down()
+
+    def test_get_next_with_hmac_result_in_dotted_subfield(self):
+        return_value = {"message": "with_content"}
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(
+                {
+                    "preprocessing": {
+                        "hmac": {
+                            "target": "<RAW_MSG>",
+                            "key": "hmac-test-key",
+                            "output_field": "Hmac.dotted.subfield",
+                        }
+                    }
+                }
+            )
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            raw_encoded_test_event = json.dumps(return_value, separators=(",", ":")).encode("utf-8")
+            connector._get_event = mock.MagicMock(
+                return_value=(return_value.copy(), raw_encoded_test_event, None)
+            )
+            expected_event = LogEvent(
+                data={
+                    "message": "with_content",
+                    "Hmac": {
+                        "dotted": {
+                            "subfield": {
+                                "compressed_base64": "eJyrVspNLS5OTE9VslIqzyzJiE/OzytJzStRqgUAgKkJtg==",
+                                "hmac": "dfe78753da634d7b76760488dbb2cf7bfe1b0e4e794930c36e98a984b6b6be63",
+                            }
+                        }
+                    },
+                },
+                original=b"",
+            )
+
+            connector_next_msg = connector.get_next(1)
+            assert connector_next_msg == expected_event
+            decoded = base64.b64decode(
+                connector_next_msg.data["Hmac"]["dotted"]["subfield"]["compressed_base64"]
+            )
+            decoded_message = zlib.decompress(decoded)
+            assert return_value == json.loads(
+                decoded_message.decode("utf-8")
+            ), "The hmac base massage was not correctly encoded and compressed. "
+
+            connector.shut_down()
 
     def test_get_next_with_hmac_result_in_already_existing_subfield(self):
         connector_config = deepcopy(self.CONFIG)
@@ -268,40 +343,56 @@ class BaseInputTestCase(BaseConnectorTestCase):
         test_event = {"message": {"with_subfield": "content"}}
         raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
         connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
+            return_value=(test_event.copy(), raw_encoded_test_event, None)
         )
         with pytest.raises(CriticalInputError, match="could not be written") as error:
             _ = connector.get_next(1)
         assert error.value.raw_input == {"message": {"with_subfield": "content"}}
 
+        connector.shut_down()
+
     def test_get_next_without_hmac(self):
-        connector_config = deepcopy(self.CONFIG)
-        assert not connector_config.get("preprocessing", {}).get("hmac")
-        test_event = {"message": "with_content"}
-        connector = Factory.create({"test connector": connector_config})
-        raw_encoded_test_event = json.dumps(test_event, separators=(",", ":")).encode("utf-8")
-        connector._get_event = mock.MagicMock(
-            return_value=(test_event.copy(), raw_encoded_test_event)
-        )
-        connector_next_msg = connector.get_next(1)
-        assert connector_next_msg == test_event
+        return_value = {"message": "with_content"}
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            assert not connector_config.get("preprocessing", {}).get("hmac")
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            raw_encoded_test_event = json.dumps(return_value, separators=(",", ":")).encode("utf-8")
+            connector._get_event = mock.MagicMock(
+                return_value=(return_value.copy(), raw_encoded_test_event, None)
+            )
+            connector_next_msg = connector.get_next(1)
+            assert connector_next_msg == LogEvent(data=return_value, original=b"")
+
+            connector.shut_down()
 
     def test_preprocessing_version_info_is_added_if_configured(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "version_info_target_field": "version_info",
-                "hmac": {"target": "", "key": "", "output_field": ""},
-            },
-            "version_information": {"logprep": "3.3.0", "configuration": "unset"},
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert result.get("version_info", {}).get("logprep") == "3.3.0"
-        assert result.get("version_info", {}).get("configuration") == "unset"
+        return_value = {"any": "content"}
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "version_info_target_field": "version_info",
+                    "hmac": {"target": "", "key": "", "output_field": ""},
+                },
+                "version_information": {"logprep": "3.3.0", "configuration": "unset"},
+            }
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=(return_value, None, None))
+            result = connector.get_next(0.01)
+            assert result.data.get("version_info", {}).get("logprep") == "3.3.0"
+            assert result.data.get("version_info", {}).get("configuration") == "unset"
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_does_not_add_versions_if_target_field_exists_already(self):
         preprocessing_config = {
@@ -314,10 +405,12 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector_config.update(preprocessing_config)
         connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "version_info": "something random"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        connector._get_event = mock.MagicMock(return_value=(test_event, None, None))
         with pytest.raises(CriticalInputError, match="could not be written") as error:
             _ = connector.get_next(0.01)
         assert error.value.raw_input == {"any": "content", "version_info": "something random"}
+
+        connector.shut_down()
 
     def test_pipeline_preprocessing_only_version_information(self):
         preprocessing_config = {
@@ -329,10 +422,12 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector_config.update(preprocessing_config)
         connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "version_info": "something random"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        connector._get_event = mock.MagicMock(return_value=(test_event, None, None))
         with pytest.raises(CriticalInputError, match="could not be written") as error:
             _ = connector.get_next(0.01)
         assert error.value.raw_input == {"any": "content", "version_info": "something random"}
+
+        connector.shut_down()
 
     def test_get_raw_event_is_callable(self):
         # should be overwritten for special implementation
@@ -340,34 +435,57 @@ class BaseInputTestCase(BaseConnectorTestCase):
         assert result is None
 
     def test_connector_metrics_counts_processed_events(self):
-        self.object.metrics.number_of_processed_events = 0
-        self.object._get_event = mock.MagicMock(return_value=({"message": "test"}, None))
-        self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 1
+        return_value = ({"event:": "test_event"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+
+            connector.metrics.number_of_processed_events = 0
+
+            with mock.patch.object(connector, "_get_event", return_value=return_value):
+                connector.get_next(0.01)
+
+            assert connector.metrics.number_of_processed_events == 1
+
+            connector.shut_down()
 
     def test_connector_metrics_does_not_count_if_no_event_was_retrieved(self):
         self.object.metrics.number_of_processed_events = 0
-        self.object._get_event = mock.MagicMock(return_value=(None, None))
+        self.object._get_event = mock.MagicMock(return_value=(None, None, None))
         self.object.get_next(0.01)
         assert self.object.metrics.number_of_processed_events == 0
 
     def test_get_next_adds_timestamp_if_configured(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "arrival_time",
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "arrival_time",
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        connector._get_event = mock.MagicMock(return_value=({"any": "content"}, None))
-        result = connector.get_next(0.01)
-        target_field = preprocessing_config.get("preprocessing", {}).get(
-            "log_arrival_time_target_field"
-        )
-        assert target_field in result
-        assert isinstance(result[target_field], str)
-        assert (TimeParser.now() - TimeParser.from_string(result[target_field])).total_seconds() > 0
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            target_field = preprocessing_config.get("preprocessing", {}).get(
+                "log_arrival_time_target_field"
+            )
+            assert target_field in result.data
+            assert isinstance(result.data[target_field], str)
+            assert (
+                TimeParser.now() - TimeParser.from_string(result.data[target_field])
+            ).total_seconds() > 0
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_does_not_add_log_arrival_time_if_target_field_exists_already(
         self,
@@ -381,271 +499,380 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector_config.update(preprocessing_config)
         connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content", "arrival_time": "does not matter"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
+        connector._get_event = mock.MagicMock(return_value=(test_event, None, None))
         with pytest.raises(CriticalInputError, match="could not be written") as error:
             _ = connector.get_next(0.01)
         assert error.value.raw_input == {"any": "content", "arrival_time": "does not matter"}
 
+        connector.shut_down()
+
     def test_pipeline_preprocessing_add_log_arrival_time_if_target_parent_field_exists_already_and_is_dict(
         self,
     ):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "event.created",
+        return_value = {"any": "content", "event": {"does not": "matter"}}
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "event.created",
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content", "event": {"does not": "matter"}}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        event = connector.get_next(0.01)
-        time_value = get_dotted_field_value(event, "event.created")
-        assert time_value
-        iso8601_regex = (
-            r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-]\d{2}:\d{2})$)"
-        )
-        assert re.search(iso8601_regex, time_value)
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=(return_value, None, None))
+            event = connector.get_next(0.01)
+            time_value = get_dotted_field_value(event.data, "event.created")
+            assert time_value
+            iso8601_regex = (
+                r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-]\d{2}:\d{2})$)"
+            )
+            assert re.search(iso8601_regex, time_value)
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_add_log_arrival_time_if_target_parent_field_exists_already_and_not_dict(
         self,
     ):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "event.created",
+        return_value = {"any": "content", "event": "does not matter"}
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "event.created",
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content", "event": "does not matter"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        event = connector.get_next(0.01)
-        time_value = get_dotted_field_value(event, "event.created")
-        assert time_value
-        iso8601_regex = (
-            r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-]\d{2}:\d{2})$)"
-        )
-        assert re.search(iso8601_regex, time_value)
-        original_event = get_dotted_field_value(event, "event.@original")
-        assert original_event == "does not matter"
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=(return_value, None, None))
+            event = connector.get_next(0.01)
+            time_value = get_dotted_field_value(event.data, "event.created")
+            assert time_value
+            iso8601_regex = (
+                r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-]\d{2}:\d{2})$)"
+            )
+            assert re.search(iso8601_regex, time_value)
+            original_event = get_dotted_field_value(event.data, "event.@original")
+            assert original_event == "does not matter"
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_adds_timestamp_delta_if_configured(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "arrival_time",
-                "log_arrival_timedelta": {
-                    "target_field": "log_arrival_timedelta",
-                    "reference_field": "@timestamp",
-                },
-            }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content", "@timestamp": "1999-09-09T09:09:09.448319+02:00"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        target_field = (
-            preprocessing_config.get("preprocessing")
-            .get("log_arrival_timedelta")
-            .get("target_field")
+        return_value = (
+            {"any": "content", "@timestamp": "1999-09-09T09:09:09.448319+02:00"},
+            None,
+            None,
         )
-        assert target_field in result
-        assert isinstance(result[target_field], float)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "arrival_time",
+                    "log_arrival_timedelta": {
+                        "target_field": "log_arrival_timedelta",
+                        "reference_field": "@timestamp",
+                    },
+                }
+            }
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            target_field = (
+                preprocessing_config.get("preprocessing")
+                .get("log_arrival_timedelta")
+                .get("target_field")
+            )
+            assert target_field in result.data
+            assert isinstance(result.data[target_field], float)
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_reference_field_not_found(
         self,
     ):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "arrival_time",
-                "log_arrival_timedelta": {
-                    "target_field": "log_arrival_timedelta",
-                    "reference_field": "@timestamp",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "arrival_time",
+                    "log_arrival_timedelta": {
+                        "target_field": "log_arrival_timedelta",
+                        "reference_field": "@timestamp",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert "arrival_time" in result
-        assert "log_arrival_timedelta" not in result
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            assert "arrival_time" in result.data
+            assert "log_arrival_timedelta" not in result.data
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_not_configured(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_time_target_field": "arrival_time",
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_time_target_field": "arrival_time",
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert "arrival_time" in result
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            assert "arrival_time" in result.data
+
+            connector.shut_down()
 
     def test_add_full_event_to_target_field_with_string_format(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "add_full_event_to_target_field": {
-                    "format": "str",
-                    "target_field": "event.original",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "add_full_event_to_target_field": {
+                        "format": "str",
+                        "target_field": "event.original",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        expected = {"event": {"original": '"{\\"any\\":\\"content\\"}"'}}
-        assert result == expected, f"{expected} is not the same as {result}"
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            expected = {"event": {"original": '"{\\"any\\":\\"content\\"}"'}}
+            assert result.data == expected, f"{expected} is not the same as {result.data}"
+
+            connector.shut_down()
 
     def test_add_full_event_to_targetfield_with_same_name(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "add_full_event_to_target_field": {
-                    "format": "str",
-                    "target_field": "any.content",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "add_full_event_to_target_field": {
+                        "format": "str",
+                        "target_field": "any.content",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        expected = {"any": {"content": '"{\\"any\\":\\"content\\"}"'}}
-        assert result == expected, f"{expected} is not the same as {result}"
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            expected = {"any": {"content": '"{\\"any\\":\\"content\\"}"'}}
+            assert result.data == expected, f"{expected} is not the same as {result.data}"
+
+            connector.shut_down()
 
     def test_add_full_event_to_targetfield_vs_version_info_target(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "add_full_event_to_target_field": {
-                    "format": "str",
-                    "target_field": "any.content",
-                },
-                "version_info_target_field": "version_info",
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "add_full_event_to_target_field": {
+                        "format": "str",
+                        "target_field": "any.content",
+                    },
+                    "version_info_target_field": "version_info",
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        expected = {
-            "any": {"content": '"{\\"any\\":\\"content\\"}"'},
-            "version_info": {"logprep": "", "configuration": ""},
-        }
-        assert result == expected, f"{expected} is not the same as {result}"
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            expected = {
+                "any": {"content": '"{\\"any\\":\\"content\\"}"'},
+                "version_info": {"logprep": "", "configuration": ""},
+            }
+            assert result.data == expected, f"{expected} is not the same as {result.data}"
+
+            connector.shut_down()
 
     def test_add_full_event_to_target_field_with_dict_format(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "add_full_event_to_target_field": {
-                    "format": "dict",
-                    "target_field": "event.original",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "add_full_event_to_target_field": {
+                        "format": "dict",
+                        "target_field": "event.original",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        expected = {"event": {"original": {"any": "content"}}}
-        assert result == expected, f"{expected} is not the same as {result}"
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            expected = {"event": {"original": {"any": "content"}}}
+            assert result.data == expected, f"{expected} is not the same as {result.data}"
+
+            connector.shut_down()
 
     def test_pipeline_preprocessing_does_not_add_timestamp_delta_if_configured_but_log_arrival_timestamp_not(
         self,
     ):
-        preprocessing_config = {
-            "preprocessing": {
-                "log_arrival_timedelta": {
-                    "target_field": "log_arrival_timedelta",
-                    "reference_field": "@timestamp",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "log_arrival_timedelta": {
+                        "target_field": "log_arrival_timedelta",
+                        "reference_field": "@timestamp",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert result == {"any": "content"}
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            assert result.data == {"any": "content"}
+
+            connector.shut_down()
 
     def test_preprocessing_enriches_by_env_variable(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "enrich_by_env_variables": {
-                    "enriched_field": "TEST_ENV_VARIABLE",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "enrich_by_env_variables": {
+                        "enriched_field": "TEST_ENV_VARIABLE",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        os.environ["TEST_ENV_VARIABLE"] = "test_value"
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert result == {"any": "content", "enriched_field": "test_value"}
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            os.environ["TEST_ENV_VARIABLE"] = "test_value"
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            assert result.data == {"any": "content", "enriched_field": "test_value"}
+
+            connector.shut_down()
 
     def test_preprocessing_enriches_by_multiple_env_variables(self):
-        preprocessing_config = {
-            "preprocessing": {
-                "enrich_by_env_variables": {
-                    "enriched_field1": "TEST_ENV_VARIABLE_FOO",
-                    "enriched_field2": "TEST_ENV_VARIABLE_BAR",
-                },
+        return_value = ({"any": "content"}, None, None)
+
+        with self.patch_documents_property(document=return_value):
+            preprocessing_config = {
+                "preprocessing": {
+                    "enrich_by_env_variables": {
+                        "enriched_field1": "TEST_ENV_VARIABLE_FOO",
+                        "enriched_field2": "TEST_ENV_VARIABLE_BAR",
+                    },
+                }
             }
-        }
-        connector_config = deepcopy(self.CONFIG)
-        connector_config.update(preprocessing_config)
-        connector = Factory.create({"test connector": connector_config})
-        test_event = {"any": "content"}
-        os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
-        os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
-        connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
-        assert result == {
-            "any": "content",
-            "enriched_field1": "test_value_foo",
-            "enriched_field2": "test_value_bar",
-        }
+            connector_config = deepcopy(self.CONFIG)
+            connector_config.update(preprocessing_config)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
+            os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            result = connector.get_next(0.01)
+            assert result.data == {
+                "any": "content",
+                "enriched_field1": "test_value_foo",
+                "enriched_field2": "test_value_bar",
+            }
+
+            connector.shut_down()
 
     def test_get_next_counts_number_of_processed_events(self):
-        self.object.metrics.number_of_processed_events = 0
-        return_value = ({"message": "test message"}, b'{"message": "test message"}')
-        self.object._get_event = mock.MagicMock(return_value=return_value)
-        self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 1
+        return_value = ({"message": "test message"}, b'{"message": "test message"}', None)
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            connector.metrics.number_of_processed_events = 0
+            connector.get_next(0.01)
+
+            assert connector.metrics.number_of_processed_events == 1
+
+            connector.shut_down()
 
     def test_get_next_does_not_count_number_of_processed_events_if_event_is_none(self):
         self.object.metrics.number_of_processed_events = 0
-        self.object._get_event = mock.MagicMock(return_value=(None, None))
+        self.object._get_event = mock.MagicMock(return_value=(None, None, None))
         self.object.get_next(0.01)
         assert self.object.metrics.number_of_processed_events == 0
 
     def test_get_next_has_time_measurement(self):
-        mock_metric = mock.MagicMock()
-        self.object.metrics.processing_time_per_event = mock_metric
-        return_value = ({"message": "test message"}, b'{"message": "test message"}')
-        self.object._get_event = mock.MagicMock(return_value=return_value)
-        self.object.get_next(0.01)
-        assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
-        # asserts entering context manager in metrics.metrics.Metric.measure_time
-        mock_metric.assert_has_calls([mock.call.tracker.labels().time().__enter__()])
+        return_value = ({"message": "test message"}, b'{"message": "test message"}', None)
+
+        with self.patch_documents_property(document=return_value):
+            connector_config = deepcopy(self.CONFIG)
+            connector = Factory.create({"test connector": connector_config})
+            connector._wait_for_health = mock.MagicMock()
+            connector.pipeline_index = 1
+            connector.setup()
+            mock_metric = mock.MagicMock()
+            connector.metrics.processing_time_per_event = mock_metric
+            connector._get_event = mock.MagicMock(return_value=return_value)
+            connector.get_next(0.01)
+            assert isinstance(connector.metrics.processing_time_per_event, mock.MagicMock)
+            # asserts entering context manager in metrics.metrics.Metric.measure_time
+            mock_metric.assert_has_calls([mock.call.tracker.labels().time().__enter__()])
+
+            connector.shut_down()
 
     def test_input_iterator(self):
         batch_events = [

--- a/tests/unit/ng/connector/test_confluent_kafka_input.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_input.py
@@ -3,25 +3,28 @@
 # pylint: disable=wrong-import-position
 # pylint: disable=wrong-import-order
 # pylint: disable=attribute-defined-outside-init
-import json
-import os
+
 import re
 import socket
 from copy import deepcopy
 from unittest import mock
 
 import pytest
-from confluent_kafka import OFFSET_BEGINNING, KafkaError, KafkaException  # type: ignore
+from confluent_kafka import (  # type: ignore
+    OFFSET_BEGINNING,
+    KafkaError,
+    KafkaException,
+)
 
-from logprep.abc.input import (
+from logprep.factory import Factory
+from logprep.factory_error import InvalidConfigurationError
+from logprep.ng.abc.input import (
     CriticalInputError,
     CriticalInputParsingError,
     FatalInputError,
     InputWarning,
 )
-from logprep.connector.confluent_kafka.input import logger
-from logprep.factory import Factory
-from logprep.factory_error import InvalidConfigurationError
+from logprep.ng.connector.confluent_kafka.metadata import ConfluentKafkaMetadata
 from tests.unit.connector.test_confluent_kafka_common import (
     CommonConfluentKafkaTestCase,
 )
@@ -62,48 +65,67 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
     ]
 
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_next_returns_none_if_no_records(self, _):
-        self.object._consumer.poll = mock.MagicMock(return_value=None)
-        event = self.object.get_next(1)
+    def test_get_next_returns_none_if_no_records(self, mock_consumer_cls):
+        mock_consumer = mock.MagicMock()
+        mock_consumer.poll.return_value = None
+        mock_consumer_cls.return_value = mock_consumer
+
+        input_config = deepcopy(self.CONFIG)
+        kafka_input = Factory.create({"test": input_config})
+
+        event = kafka_input.get_next(1)
         assert event is None
 
+        kafka_input.shut_down()
+
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_next_raises_critical_input_exception_for_invalid_confluent_kafka_record(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock(
-            return_value=KafkaError(
-                error=3,
-                reason="Subscribed topic not available: (Test Instance Name) : "
-                "Broker: Unknown topic or partition",
-                fatal=False,
-                retriable=False,
-                txn_requires_abort=False,
-            )
+    def test_get_next_raises_critical_input_exception_for_invalid_confluent_kafka_record(
+        self, mock_consumer_cls
+    ):
+        input_config = deepcopy(self.CONFIG)
+        kafka_input = Factory.create({"test": input_config})
+
+        mock_kafka_message = mock.MagicMock()
+        mock_kafka_message.error.return_value = KafkaError(
+            error=3,
+            reason="Subscribed topic not available: (Test Instance Name) : "
+            "Broker: Unknown topic or partition",
+            fatal=False,
+            retriable=False,
+            txn_requires_abort=False,
         )
 
-        mock_record.value = mock.MagicMock(return_value=None)
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        with pytest.raises(
-            CriticalInputError,
-            match=(
-                r"CriticalInputError in ConfluentKafkaInput \(Test Instance Name\) - "
-                r"Kafka Input: testserver:9092: "
-                r"A confluent-kafka record contains an error code -> "
-                r"event was written to error output if configured"
-            ),
-        ):
-            _ = self.object.get_next(1)
+        mock_consumer = mock.MagicMock()
+        mock_consumer.poll.return_value = mock_kafka_message
+        mock_consumer_cls.return_value = mock_consumer
+
+        expected_msg = (
+            "CriticalInputError in ConfluentKafkaInput (test) - "
+            "Kafka Input: testserver:9092: "
+            "A confluent-kafka record contains an error code -> "
+            "event was written to error output if configured"
+        )
+        with pytest.raises(CriticalInputError, match=re.escape(expected_msg)):
+            _ = kafka_input.get_next(1)
+
+        kafka_input.shut_down()
 
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
     def test_shut_down_calls_consumer_close(self, _):
-        kafka_consumer = self.object._consumer
-        self.object.shut_down()
+        input_config = deepcopy(self.CONFIG)
+        kafka_input = Factory.create({"test": input_config})
+
+        kafka_consumer = kafka_input._consumer
+        kafka_input.shut_down()
         kafka_consumer.close.assert_called()
+
+        kafka_input.shut_down()
 
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
     def test_batch_finished_callback_calls_store_offsets(self, _):
         input_config = deepcopy(self.CONFIG)
         kafka_input = Factory.create({"test": input_config})
+
         kafka_consumer = kafka_input._consumer
         message = "test message"
         kafka_input._last_valid_record = message
@@ -111,19 +133,25 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         kafka_consumer.store_offsets.assert_called()
         kafka_consumer.store_offsets.assert_called_with(message=message)
 
+        kafka_input.shut_down()
+
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
     def test_batch_finished_callback_does_not_call_store_offsets(self, _):
         input_config = deepcopy(self.CONFIG)
         kafka_input = Factory.create({"test": input_config})
+
         kafka_consumer = kafka_input._consumer
         kafka_input._last_valid_record = None
         kafka_input.batch_finished_callback()
         kafka_consumer.store_offsets.assert_not_called()
 
+        kafka_input.shut_down()
+
     @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
     def test_batch_finished_callback_raises_input_warning_on_kafka_exception(self, _):
         input_config = deepcopy(self.CONFIG)
         kafka_input = Factory.create({"test": input_config})
+
         kafka_consumer = kafka_input._consumer
         return_sequence = [KafkaException("test error"), None]
 
@@ -135,87 +163,101 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         with pytest.raises(InputWarning):
             kafka_input.batch_finished_callback()
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_next_raises_critical_input_error_if_not_a_dict(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = '[{"element":"in list"}]'.encode("utf8")
-        with pytest.raises(CriticalInputError, match=r"not a dict"):
-            self.object.get_next(1)
+        kafka_input.shut_down()
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_next_raises_critical_input_error_if_invalid_json(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = "I'm not valid json".encode("utf8")
-        with pytest.raises(CriticalInputError, match=r"not a valid json"):
-            self.object.get_next(1)
+    def test_get_next_raises_critical_input_error_if_not_a_dict(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_record = mock.MagicMock()
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_event_returns_event_and_raw_event(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
-        event, raw_event = self.object._get_event(0.001)
-        assert event == {"element": "in list"}
-        assert raw_event == '{"element":"in list"}'.encode("utf8")
+            mock_record.error.return_value = None
+            mock_record.partition.return_value = 1
+            mock_record.offset.return_value = 42
+            mock_record.value.return_value = '[{"element":"in list"}]'.encode("utf8")
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_raw_event_is_callable(self, _):  # pylint: disable=arguments-differ
-        # should be overwritten if reimplemented
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
-        result = self.object._get_raw_event(0.001)
-        assert result
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_event_raises_exception_if_input_invalid_json(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = '{"invalid_json"}'.encode("utf8")
-        with pytest.raises(
-            CriticalInputParsingError,
-            match=(
-                r"Input record value is not a valid json string ->"
-                r" event was written to error output if configured"
-            ),
-        ) as error:
-            self.object._get_event(0.001)
-        assert error.value.raw_input == b'{"invalid_json"}'
+            with pytest.raises(CriticalInputError, match=r"not a dict"):
+                self.object.get_next(1)
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_get_event_raises_exception_if_input_not_utf(self, _):
-        mock_record = mock.MagicMock()
-        mock_record.error = mock.MagicMock()
-        mock_record.error.return_value = None
-        self.object._consumer.poll = mock.MagicMock(return_value=mock_record)
-        mock_record.value = mock.MagicMock()
-        mock_record.value.return_value = '{"not_utf-8": \xfc}'.encode("cp1252")
-        with pytest.raises(
-            CriticalInputParsingError,
-            match=(
-                r"Input record value is not \'utf-8\' encoded ->"
-                r" event was written to error output if configured"
-            ),
-        ) as error:
-            self.object._get_event(0.001)
-        assert error.value.raw_input == "b'{\"not_utf-8\": \\xfc}'"
+    def test_get_next_raises_critical_input_error_if_invalid_json(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_record = mock.MagicMock()
+
+            mock_record.error.return_value = None
+            mock_record.value.return_value = "I'm not valid json".encode("utf8")
+
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
+
+            with pytest.raises(CriticalInputError, match=r"not a valid json"):
+                self.object.get_next(1)
+
+    def test_get_event_returns_event_and_raw_event(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_record = mock.MagicMock()
+
+            mock_record.error.return_value = None
+            mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
+            mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
+            mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
+            mock_record.partition.return_value = 1
+            mock_record.offset.return_value = 42
+
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
+
+            event, raw_event, metadata = self.object._get_event(0.001)
+            assert event == {"element": "in list"}
+            assert raw_event == '{"element":"in list"}'.encode("utf8")
+            assert metadata == ConfluentKafkaMetadata(partition=1, offset=42)
+
+    def test_get_raw_event_is_callable(self):  # pylint: disable=arguments-differ
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            # should be overwritten if reimplemented
+            mock_record = mock.MagicMock()
+            mock_record.error.return_value = None
+            mock_record.value.return_value = '{"element":"in list"}'.encode("utf8")
+
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
+
+            result = self.object._get_raw_event(0.001)
+
+            assert result
+
+    def test_get_event_raises_exception_if_input_invalid_json(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_record = mock.MagicMock()
+            mock_record.error.return_value = None
+            mock_record.value.return_value = '{"invalid_json"}'.encode("utf8")
+
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
+
+            with pytest.raises(
+                CriticalInputParsingError,
+                match=(
+                    r"Input record value is not a valid json string ->"
+                    r" event was written to error output if configured"
+                ),
+            ) as error:
+                self.object._get_event(0.001)
+            assert error.value.raw_input == b'{"invalid_json"}'
+
+    def test_get_event_raises_exception_if_input_not_utf(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_record = mock.MagicMock()
+            mock_record.error.return_value = None
+
+            mock_record.value.return_value = '{"not_utf-8": \xfc}'.encode("cp1252")
+
+            mock_consumer.poll = mock.MagicMock(return_value=mock_record)
+
+            with pytest.raises(
+                CriticalInputParsingError,
+                match=(
+                    r"Input record value is not \'utf-8\' encoded ->"
+                    r" event was written to error output if configured"
+                ),
+            ) as error:
+                self.object._get_event(0.001)
+            assert error.value.raw_input == "b'{\"not_utf-8\": \\xfc}'"
 
     def test_setup_raises_fatal_input_error_on_invalid_config(self):
         kafka_config = {
@@ -231,9 +273,12 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
 
     def test_get_next_raises_critical_input_parsing_error(self):
         return_value = b'{"invalid": "json'
-        self.object._get_raw_event = mock.MagicMock(return_value=return_value)
-        with pytest.raises(CriticalInputParsingError, match="is not a valid json"):
-            self.object.get_next(0.01)
+        mock_message = mock.MagicMock()
+        mock_message.value.return_value = return_value
+
+        with mock.patch.object(self.object, "_get_raw_event", return_value=mock_message):
+            with pytest.raises(CriticalInputParsingError, match="is not a valid json"):
+                self.object.get_next(0.01)
 
     def test_commit_callback_raises_warning_error_and_counts_failures(self):
         with pytest.raises(InputWarning, match="Could not commit offsets"):
@@ -255,72 +300,85 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
         call_args = 666, {"description": "topic: test_input_raw - partition: 99"}
         mock_add.assert_called_with(*call_args)
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_default_config_is_injected(self, mock_consumer):
-        injected_config = {
-            "enable.auto.offset.store": "false",
-            "enable.auto.commit": "true",
-            "client.id": socket.getfqdn(),
-            "auto.offset.reset": "earliest",
-            "session.timeout.ms": "6000",
-            "statistics.interval.ms": "30000",
-            "bootstrap.servers": "testserver:9092",
-            "group.id": "testgroup",
-            "group.instance.id": f"{socket.getfqdn().strip('.')}-PipelineNone-pid{os.getpid()}",
-            "logger": logger,
-            "on_commit": self.object._commit_callback,
-            "stats_cb": self.object._stats_callback,
-            "error_cb": self.object._error_callback,
-        }
-        _ = self.object._consumer
-        mock_consumer.assert_called_with(injected_config)
+    def test_default_config_is_injected(self):
+        with mock.patch(
+            "logprep.ng.connector.confluent_kafka.input.Consumer", autospec=True
+        ) as mock_consumer:
+            input_config = deepcopy(self.CONFIG)
+            kafka_input = Factory.create({"test": input_config})
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_auto_offset_store_and_auto_commit_are_managed_by_connector(self, mock_consumer):
-        config = deepcopy(self.CONFIG)
-        config["kafka_config"] |= {
-            "enable.auto.offset.store": "true",
-            "enable.auto.commit": "false",
-        }
-        kafka_input = Factory.create({"test": config})
-        _ = kafka_input._consumer
-        mock_consumer.assert_called()
-        injected_config = mock_consumer.call_args[0][0]
-        assert injected_config.get("enable.auto.offset.store") == "false"
-        assert injected_config.get("enable.auto.commit") == "true"
+            _ = kafka_input._consumer
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
+            mock_consumer.assert_called()
+
+            called_args = mock_consumer.call_args[0][0]
+            assert called_args.get("bootstrap.servers") == "testserver:9092"
+            assert called_args.get("enable.auto.offset.store") == "false"
+
+            kafka_input.shut_down()
+
+    def test_auto_offset_store_and_auto_commit_are_managed_by_connector(self):
+        with mock.patch(
+            "logprep.ng.connector.confluent_kafka.input.Consumer", autospec=True
+        ) as mock_consumer:
+            config = deepcopy(self.CONFIG)
+            config["kafka_config"] |= {
+                "enable.auto.offset.store": "true",
+                "enable.auto.commit": "false",
+            }
+            kafka_input = Factory.create({"test": config})
+
+            _ = kafka_input._consumer
+
+            mock_consumer.assert_called()
+
+            injected_config = mock_consumer.call_args[0][0]
+            assert injected_config.get("enable.auto.offset.store") == "false"
+            assert injected_config.get("enable.auto.commit") == "true"
+
+            kafka_input.shut_down()
+
     @mock.patch("logprep.ng.connector.confluent_kafka.input.AdminClient")
-    def test_client_id_can_be_overwritten(self, _, mock_consumer):
+    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
+    def test_client_id_can_be_overwritten(self, mock_consumer, mock_admin):
         input_config = deepcopy(self.CONFIG)
         input_config["kafka_config"]["client.id"] = "thisclientid"
         kafka_input = Factory.create({"test": input_config})
+        kafka_input._wait_for_health = mock.MagicMock()
         metadata = mock.MagicMock()
         metadata.topics = [kafka_input._config.topic]
-        kafka_input._admin.list_topics.return_value = metadata
+        mock_admin.list_topics.return_value = metadata
         kafka_input.setup()
+
         mock_consumer.assert_called()
         assert mock_consumer.call_args[0][0].get("client.id") == "thisclientid"
         assert not mock_consumer.call_args[0][0].get("client.id") == socket.getfqdn()
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
+        kafka_input.shut_down()
+
     @mock.patch("logprep.ng.connector.confluent_kafka.input.AdminClient")
-    def test_statistics_interval_can_be_overwritten(self, _, mock_consumer):
+    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
+    def test_statistics_interval_can_be_overwritten(self, mock_consumer, mock_admin):
         input_config = deepcopy(self.CONFIG)
         input_config["kafka_config"]["statistics.interval.ms"] = "999999999"
         kafka_input = Factory.create({"test": input_config})
+        kafka_input._wait_for_health = mock.MagicMock()
         metadata = mock.MagicMock()
         metadata.topics = [kafka_input._config.topic]
-        kafka_input._admin.list_topics.return_value = metadata
+        mock_admin.list_topics.return_value = metadata
         kafka_input.setup()
+
         mock_consumer.assert_called()
         assert mock_consumer.call_args[0][0].get("statistics.interval.ms") == "999999999"
 
-    @mock.patch("logprep.ng.connector.confluent_kafka.input.Consumer")
-    def test_raises_fatal_input_error_if_poll_raises_runtime_error(self, _):
-        self.object._consumer.poll.side_effect = RuntimeError("test error")
-        with pytest.raises(FatalInputError, match="test error"):
-            self.object.get_next(0.01)
+        kafka_input.shut_down()
+
+    def test_raises_fatal_input_error_if_poll_raises_runtime_error(self):
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_consumer.poll.side_effect = RuntimeError("test error")
+
+            with pytest.raises(FatalInputError, match="test error"):
+                self.object.get_next(0.01)
 
     def test_raises_value_error_if_mandatory_parameters_not_set(self):
         config = deepcopy(self.CONFIG)
@@ -401,38 +459,51 @@ class TestConfluentKafkaInput(BaseInputTestCase, CommonConfluentKafkaTestCase):
             self.object._revoke_callback(None, mock_partitions)
             assert re.search(r"ERROR.*Consumer is closed", caplog.text)
 
-    def test_health_returns_true_if_no_error(self):
-        self.object._admin = mock.MagicMock()
-        metadata = mock.MagicMock()
-        metadata.topics = [self.object._config.topic]
-        self.object._admin.list_topics.return_value = metadata
-        assert self.object.health()
+    @mock.patch("logprep.ng.connector.confluent_kafka.input.AdminClient")
+    def test_health_returns_true_if_no_error(self, mock_admin_class):
+        mock_admin = mock.MagicMock()
+        mock_admin.list_topics.return_value.topics = ["test-topic"]
+        mock_admin_class.return_value = mock_admin
 
-    def test_health_returns_false_if_topic_not_present(self):
-        self.object._admin = mock.MagicMock()
+        input_config = deepcopy(self.CONFIG)
+        input_config["topic"] = "test-topic"
+        connector = Factory.create({"test": input_config})
+        connector._wait_for_health = mock.MagicMock()
+        connector.setup()
+
+        assert connector.health()
+
+        connector.shut_down()
+
+    @mock.patch("logprep.ng.connector.confluent_kafka.input.AdminClient")
+    def test_health_returns_false_if_topic_not_present(self, mock_admin):
         metadata = mock.MagicMock()
         metadata.topics = ["not_the_topic"]
-        self.object._admin.list_topics.return_value = metadata
+        mock_admin.list_topics.return_value = metadata
         assert not self.object.health()
 
     def test_health_returns_false_on_kafka_exception(self):
-        self.object._consumer = mock.MagicMock()
-        self.object._consumer.list_topics.side_effect = KafkaException("test error")
-        assert not self.object.health()
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_consumer.list_topics.side_effect = KafkaException("test error")
+            assert not self.object.health()
 
     def test_health_logs_error_on_kafka_exception(self):
-        self.object._consumer = mock.MagicMock()
-        self.object._consumer.list_topics.side_effect = KafkaException("test error")
-        with mock.patch("logging.Logger.error") as mock_error:
-            self.object.health()
-        mock_error.assert_called()
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_consumer.list_topics.side_effect = KafkaException("test error")
+
+            with mock.patch("logging.Logger.error") as mock_error:
+                self.object.health()
+
+            mock_error.assert_called()
 
     def test_health_counts_metrics_on_kafka_exception(self):
-        self.object.metrics.number_of_errors = 0
-        self.object._consumer = mock.MagicMock()
-        self.object._consumer.list_topics.side_effect = KafkaException("test error")
-        assert not self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        with mock.patch.object(self.object, "_consumer") as mock_consumer:
+            mock_consumer.list_topics.side_effect = KafkaException("test error")
+
+            self.object.metrics.number_of_errors = 0
+
+            assert not self.object.health()
+            assert self.object.metrics.number_of_errors == 1
 
     @pytest.mark.parametrize(
         ["kafka_config_update", "expected_admin_client_config"],

--- a/tests/unit/ng/connector/test_confluent_kafka_metadata.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_metadata.py
@@ -4,28 +4,28 @@
 import pytest
 
 from logprep.ng.abc.event import EventMetadata
-from logprep.ng.connector.confluent_kafka.metadata import KafkaInputMetadata
+from logprep.ng.connector.confluent_kafka.metadata import ConfluentKafkaMetadata
 
 
 class TestKafkaInputMetadata:
     def test_inherits_event_metadata(self):
-        meta = KafkaInputMetadata(partition=1, offset=0)
+        meta = ConfluentKafkaMetadata(partition=1, offset=0)
         assert isinstance(meta, EventMetadata)
 
     def test_valid_instantiation(self):
-        meta = KafkaInputMetadata(partition=3, offset=100)
+        meta = ConfluentKafkaMetadata(partition=3, offset=100)
         assert meta.partition == 3
         assert meta.offset == 100
 
     @pytest.mark.parametrize("invalid_partition", ["0", None, 1.5, [], {}])
     def test_invalid_partition_type_raises(self, invalid_partition):
         with pytest.raises(TypeError):
-            KafkaInputMetadata(partition=invalid_partition, offset=10)
+            ConfluentKafkaMetadata(partition=invalid_partition, offset=10)
 
     @pytest.mark.parametrize("invalid_offset", ["0", None, 1.5, [], {}])
     def test_invalid_offset_type_raises(self, invalid_offset):
         with pytest.raises(TypeError):
-            KafkaInputMetadata(partition=1, offset=invalid_offset)
+            ConfluentKafkaMetadata(partition=1, offset=invalid_offset)
 
     def test_slots_are_used(self):
-        assert hasattr(KafkaInputMetadata, "__slots__")
+        assert hasattr(ConfluentKafkaMetadata, "__slots__")

--- a/tests/unit/ng/connector/test_dummy_output.py
+++ b/tests/unit/ng/connector/test_dummy_output.py
@@ -93,59 +93,59 @@ class TestDummyOutput(BaseOutputTestCase):
     def test_store_handles_errors(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        self.object = Factory.create({"Test Instance Name": config})
-        self.object.metrics.number_of_errors = 0
+        connector = Factory.create({"Test Instance Name": config})
+        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", state=EventStateType.PROCESSED)
-        self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        connector.store(event)
+        assert connector.metrics.number_of_errors == 1
         assert len(event.errors) == 1
         assert event.state == EventStateType.FAILED
 
     def test_store_custom_handles_errors(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        self.object = Factory.create({"Test Instance Name": config})
-        self.object.metrics.number_of_errors = 0
+        connector = Factory.create({"Test Instance Name": config})
+        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", state=EventStateType.PROCESSED)
-        self.object.store_custom(event, target="custom_target")
-        assert self.object.metrics.number_of_errors == 1
+        connector.store_custom(event, target="custom_target")
+        assert connector.metrics.number_of_errors == 1
         assert len(event.errors) == 1
         assert event.state == EventStateType.FAILED, f"{event.state} should be FAILED"
 
     def test_store_handles_errors_failed_event(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        self.object = Factory.create({"Test Instance Name": config})
-        self.object.metrics.number_of_errors = 0
+        connector = Factory.create({"Test Instance Name": config})
+        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", state=EventStateType.FAILED)
-        self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        connector.store(event)
+        assert connector.metrics.number_of_errors == 1
         assert len(event.errors) == 1
         assert event.state == EventStateType.FAILED
 
     def test_store_custom_handles_errors_failed_event(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
-        self.object = Factory.create({"Test Instance Name": config})
-        self.object.metrics.number_of_errors = 0
+        connector = Factory.create({"Test Instance Name": config})
+        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", state=EventStateType.FAILED)
-        self.object.store_custom(event, target="custom_target")
-        assert self.object.metrics.number_of_errors == 1
+        connector.store_custom(event, target="custom_target")
+        assert connector.metrics.number_of_errors == 1
         assert len(event.errors) == 1
         assert event.state == EventStateType.FAILED, f"{event.state} should be FAILED"
 
     def test_do_nothing_does_nothing(self):
         config = deepcopy(self.CONFIG)
         config.update({"do_nothing": True})
-        self.object = Factory.create({"Test Instance Name": config})
-        self.object.metrics.number_of_errors = 0
-        self.object.metrics.number_of_warnings = 0
-        self.object.metrics.number_of_processed_events = 0
+        connector = Factory.create({"Test Instance Name": config})
+        connector.metrics.number_of_errors = 0
+        connector.metrics.number_of_warnings = 0
+        connector.metrics.number_of_processed_events = 0
         event = LogEvent({"message": "test message"}, original=b"", state=EventStateType.PROCESSED)
-        self.object.store_custom(event, target="custom_target")
-        assert self.object.metrics.number_of_errors == 0
-        assert self.object.metrics.number_of_warnings == 0
-        assert self.object.metrics.number_of_processed_events == 0
+        connector.store_custom(event, target="custom_target")
+        assert connector.metrics.number_of_errors == 0
+        assert connector.metrics.number_of_warnings == 0
+        assert connector.metrics.number_of_processed_events == 0
         assert len(event.errors) == 0
         assert len(event.warnings) == 0
         assert event.state == EventStateType.PROCESSED

--- a/tests/unit/ng/connector/test_file_input_default_config.py
+++ b/tests/unit/ng/connector/test_file_input_default_config.py
@@ -137,7 +137,7 @@ class TestFileInput(BaseInputTestCase):
         wait_for_interval(CHECK_INTERVAL)
         while not self.object._messages.empty():
             self.object._messages.get(timeout=0.001)
-        assert self.object._get_event(timeout=0.001) == (None, None)
+        assert self.object._get_event(timeout=0.001) == (None, None, None)
 
     def test_input_line_function_returns_empty_string(self):
         wait_for_interval(CHECK_INTERVAL)
@@ -146,7 +146,7 @@ class TestFileInput(BaseInputTestCase):
     def test_log_from_file_with_get_next(self):
         wait_for_interval(CHECK_INTERVAL)
         get_next_log_line = self.object.get_next(timeout=0.001)
-        assert get_next_log_line.get("message") == test_initial_log_data[0]
+        assert get_next_log_line.data.get("message") == test_initial_log_data[0]
 
     def test_log_from_file_is_put_in_queue(self):
         wait_for_interval(CHECK_INTERVAL)

--- a/tests/unit/ng/connector/test_json_input.py
+++ b/tests/unit/ng/connector/test_json_input.py
@@ -2,12 +2,13 @@
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=protected-access
 import copy
+from itertools import cycle
 from unittest import mock
 
 import pytest
 
-from logprep.abc.input import CriticalInputError, SourceDisconnectedWarning
 from logprep.factory import Factory
+from logprep.ng.abc.input import CriticalInputError, SourceDisconnectedWarning
 from tests.unit.ng.connector.base import BaseInputTestCase
 
 
@@ -16,69 +17,109 @@ class TestJsonInput(BaseInputTestCase):
 
     CONFIG = {"type": "ng_json_input", "documents_path": "/does/not/matter"}
 
-    parse_function = "logprep.ng.connector.json.input.parse_json"
-
-    @mock.patch(parse_function)
-    def test_documents_returns(self, mock_parse):
+    def test_documents_returns(self):
         return_value = [{"message": "test_message"}]
-        mock_parse.return_value = return_value
-        assert self.object._documents == return_value
 
-    @mock.patch(parse_function)
-    def test_get_next_returns_document(self, mock_parse):
-        mock_parse.return_value = [{"message": "test_message"}]
-        expected = {"message": "test_message"}
-        document = self.object.get_next(self.timeout)
-        assert document == expected
+        with self.patch_documents_property(document=return_value):
+            config = copy.deepcopy(self.CONFIG)
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
 
-    @mock.patch(parse_function)
-    def test_get_next_returns_multiple_documents(self, mock_parse):
-        mock_parse.return_value = [{"order": 0}, {"order": 1}]
-        event = self.object.get_next(self.timeout)
-        assert {"order": 0} == event
-        event = self.object.get_next(self.timeout)
-        assert {"order": 1} == event
+            assert connector._documents == return_value
 
-    @mock.patch(parse_function)
-    def test_raises_exception_if_not_a_dict(self, mock_parse):
-        mock_parse.return_value = ["no dict"]
-        with pytest.raises(CriticalInputError, match=r"not a dict"):
-            _, _ = self.object.get_next(self.timeout)
+    def test_get_next_returns_document(self):
+        return_value = [{"message": "test_message"}]
 
-    @mock.patch(parse_function)
-    def test_raises_exception_if_one_element_is_not_a_dict(self, mock_parse):
-        mock_parse.return_value = [{"order": 0}, "not a dict", {"order": 1}]
-        with pytest.raises(CriticalInputError, match=r"not a dict"):
-            _ = self.object.get_next(self.timeout)
-            _ = self.object.get_next(self.timeout)
-            _ = self.object.get_next(self.timeout)
+        with self.patch_documents_property(document=return_value):
+            expected = return_value[0]
 
-    @mock.patch(parse_function)
-    def test_repeat_documents_repeats_documents(self, mock_parse):
-        config = copy.deepcopy(self.CONFIG)
-        config["repeat_documents"] = True
-        mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
-        connector = Factory.create(configuration={"Test Instance Name": config})
+            config = copy.deepcopy(self.CONFIG)
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
 
-        for order in range(0, 9):
+            document = connector.get_next(self.timeout)
+            assert document.data == expected
+
+    def test_get_next_returns_multiple_documents(self):
+        return_value = [{"order": 0}, {"order": 1}]
+
+        with self.patch_documents_property(document=return_value):
+            config = copy.deepcopy(self.CONFIG)
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
+
             event = connector.get_next(self.timeout)
-            assert event.get("order") == order % 3
+            assert {"order": 0} == event.data
+            event = connector.get_next(self.timeout)
+            assert {"order": 1} == event.data
+
+    def test_raises_exception_if_not_a_dict(self):
+        return_value = ["no dict"]
+
+        with self.patch_documents_property(document=return_value):
+            config = copy.deepcopy(self.CONFIG)
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
+
+            with pytest.raises(CriticalInputError, match=r"not a dict"):
+                _, _ = connector.get_next(self.timeout)
+
+    def test_raises_exception_if_one_element_is_not_a_dict(self):
+        return_value = [{"order": 0}, "not a dict", {"order": 1}]
+
+        with self.patch_documents_property(document=return_value):
+            config = copy.deepcopy(self.CONFIG)
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
+
+            with pytest.raises(CriticalInputError, match=r"not a dict"):
+                _ = connector.get_next(self.timeout)
+                _ = connector.get_next(self.timeout)
+                _ = connector.get_next(self.timeout)
+
+    def test_repeat_documents_repeats_documents(self):
+        class CycledPopList:
+            def __init__(self, iterable):
+                self._iter = cycle(iterable)
+
+            def pop(self, index=None):
+                if index != 0:
+                    raise IndexError("Only pop(0) supported in CycledPopList mock")
+                return next(self._iter)
+
+        cycled_list = CycledPopList([{"order": 0}, {"order": 1}, {"order": 2}])
+
+        with mock.patch(
+            "logprep.ng.connector.json.input.JsonInput._documents",
+            new=mock.PropertyMock(return_value=cycled_list),
+        ):
+            config = copy.deepcopy(self.CONFIG)
+            config["repeat_documents"] = True
+            connector = Factory.create(configuration={"Test Instance Name": config})
+            connector.setup()
+
+            with mock.patch.dict(connector.__dict__, {"_documents": None}):
+                for order in range(0, 9):
+                    event = connector.get_next(self.timeout)
+                    assert event.data.get("order") == order % 3
 
     @pytest.mark.skip(reason="not implemented")
     def test_setup_calls_wait_for_health(self):
         pass
 
-    @mock.patch(parse_function)
-    def test_json_input_iterator(self, mock_parse):
-        config = copy.deepcopy(self.CONFIG)
-        config["repeat_documents"] = False
-        mock_parse.return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
-        json_input_connector = Factory.create(configuration={"Test Instance Name": config})
+    def test_json_input_iterator(self):
+        return_value = [{"order": 0}, {"order": 1}, {"order": 2}]
 
-        json_input_iterator = json_input_connector(timeout=self.timeout)
-        assert next(json_input_iterator) == {"order": 0}
-        assert next(json_input_iterator) == {"order": 1}
-        assert next(json_input_iterator) == {"order": 2}
+        with self.patch_documents_property(document=return_value):
+            config = copy.deepcopy(self.CONFIG)
+            config["repeat_documents"] = False
+            json_input_connector = Factory.create(configuration={"Test Instance Name": config})
+            json_input_connector.setup()
 
-        with pytest.raises(SourceDisconnectedWarning):
-            next(json_input_iterator)
+            json_input_iterator = json_input_connector(timeout=self.timeout)
+            assert next(json_input_iterator).data == {"order": 0}
+            assert next(json_input_iterator).data == {"order": 1}
+            assert next(json_input_iterator).data == {"order": 2}
+
+            with pytest.raises(SourceDisconnectedWarning):
+                next(json_input_iterator)

--- a/tests/unit/ng/processor/pre_detector/test_pre_detector.py
+++ b/tests/unit/ng/processor/pre_detector/test_pre_detector.py
@@ -64,7 +64,7 @@ class TestPreDetector(BaseProcessorTestCase):
             )
         ]
         event = self.object.process(event)
-        detection_results = event.extra_data[0]
+        _ = event.extra_data[0]
         self._assert_equality_of_results(event, expected, expected_detection_results)
 
         document = {"A": "foo X bar Y baz"}


### PR DESCRIPTION
* setup event backlog in abstract input class
* register event and return event-object
* adapt get_event/get_next methods in input classes for metadata extraction
* rename KafkaInputMetadata class + related references in tests and jupyter notebook files