### PR TITLE
update CHANGELOG.md for release v17.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 ## Upcoming Changes
 
-## next release
+### Breaking
 
+### Features
+
+### Improvements
+
+### Bugfix
+
+## 17.0.2
 ### Breaking
 
 ### Features
 * add `clear_event` field to `add_full_event_to_target_field`
 
 ### Improvements
-
 * add `acknowledge()` functionality (state change of events and deleting from backlog)
 * add `event_backlog` to the abstract input interface.
 * register event in the backlog and return the registered event object.
@@ -23,7 +29,6 @@
 * add new class `Pipeline` to ng module
 
 ### Bugfix
-
 * fix auto-rule tester getting stuck due to logging
 
 ## 17.0.1


### PR DESCRIPTION
Release preparation v17.0.2

* add `clear_event` field to `add_full_event_to_target_field`
* add `acknowledge()` functionality (state change of events and deleting from backlog)
* add `event_backlog` to the abstract input interface.
* register event in the backlog and return the registered event object.
* make `processors` handle Event class based objects
* add an EventBacklog class hierarchies
* implement an iterator interface to Input connectors
* make simple connectors handle Event class based objects
* make `opensearch_output` handle Event class based objects
* deprecate `s3_output` as it does not fit into new architecture
* deprecate `http_output` as it does not fit into new architecture
* make confluentkafka_output store Event class based objects
* add new class `Pipeline` to ng module
* fix auto-rule tester getting stuck due to logging