### PR TITLE
Make dummy input deepcopy repeated documents instead of shallow copy

### DIFF
--- a/logprep/connector/dummy/input.py
+++ b/logprep/connector/dummy/input.py
@@ -46,7 +46,7 @@ class DummyInput(Input):
 
     @cached_property
     def _documents(self):
-        return copy.copy(self._config.documents)
+        return copy.deepcopy(self._config.documents)
 
     def _get_event(self, timeout: float) -> tuple:
         """Retrieve next document from configuration and raise warning if found"""

--- a/tests/unit/connector/test_dummy_input.py
+++ b/tests/unit/connector/test_dummy_input.py
@@ -58,3 +58,20 @@ class TestDummyInput(BaseInputTestCase):
         for order in range(0, 9):
             event = connector.get_next(self.timeout)
             assert event.get("order") == order % 3
+
+    def test_repeated_documents_are_not_affected_by_previous_changes(self):
+        config = copy.deepcopy(self.CONFIG)
+        config["repeat_documents"] = True
+        config["documents"] = [{"foo": 1, "bar": {"baz": 2}}]
+        connector = Factory.create(configuration={"Test Instance Name": config})
+
+        event = connector.get_next(self.timeout)
+        assert event["foo"] == 1
+        assert event["bar"]["baz"] == 2
+
+        event["foo"] = 3
+        event["bar"]["baz"] = 4
+
+        event = connector.get_next(self.timeout)
+        assert event["foo"] == 1
+        assert event["bar"]["baz"] == 2


### PR DESCRIPTION
Making a shallow copy leads to changes of nested documents being propagated to the next repetition of documents.
Therefore, `copy` has been replaced with `deepcopy`.