### PR TITLE
build: add CI job to verify uv.lock consistency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,3 +28,4 @@
 - [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
 - [ ] [Documentation](#documentation) is up-to-date
 - [ ] Tests (unit & acceptance) are meaningful and not over-mocked
+- [ ] If dependencies were added, removed, or updated, the `uv.lock` file is present and correctly synchronized with the changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,3 @@
 - [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
 - [ ] [Documentation](#documentation) is up-to-date
 - [ ] Tests (unit & acceptance) are meaningful and not over-mocked
-- [ ] If dependencies were added, removed, or updated, the `uv.lock` file is present and correctly synchronized with the changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  check-uv-lockfile:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Check lockfile is consistent with pyproject.toml
+        run: uv lock --check
   test:
     uses: ./.github/workflows/testing.yml
   build-docs:


### PR DESCRIPTION
## Description

* Briefly summarize your changes in a few bullet points (can and should correspond to [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md))
* Relates to #XXX (insert issue number here), if there is a corresponding GH issue

## Assignee
- [ ] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [ ] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [ ] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [ ] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [ ] [Preview for docs](#readthedocs-preview) looks fine
- [ ] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [ ] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [ ] Patch test coverage > 95% and does not decrease
- [ ] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* List of (preferably easy reproducible) tests including OS

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked
- [ ] If dependencies were added, removed, or updated, the `uv.lock` file is present and correctly synchronized with the changes

<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--927.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->