### PR TITLE
test: cover empty http list and empty line handling in list_comparison

### DIFF
--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -412,12 +412,12 @@ Heinz
         http_list_content,
         expected_result,
     ):
+        url_template = "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla"
         list_name = "bad_users.list"
-        final_url = f"http://localhost/tests/testdata/{list_name}?ref=bla"
 
         responses.add(
             responses.GET,
-            final_url,
+            url=Template(url_template).substitute({"LOGPREP_LIST": list_name}),
             body=http_list_content,
             status=200,
         )
@@ -433,7 +433,7 @@ Heinz
             "description": "",
         }
 
-        url_template = "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla"
+        
         config = {
             "type": "list_comparison",
             "rules": [],

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -415,11 +415,11 @@ Heinz
     ):
         url_template = "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla"
         list_name = "bad_users.list"
-        final_url = Template(url_template).substitute({"LOGPREP_LIST": list_name})
+        url = Template(url_template).substitute({"LOGPREP_LIST": list_name})
 
         responses.add(
             responses.GET,
-            url=final_url,
+            url=url,
             body=http_list_content,
             status=200,
         )
@@ -450,6 +450,9 @@ Heinz
         processor.setup()
         processor.process(document)
 
+        unmodified_document = {"user": "Foo"}
+        assert document == unmodified_document
+
         assert len(responses.calls) == 1
-        assert responses.calls[0].request.url == final_url
+        assert responses.calls[0].request.url == url
         assert rule.compare_sets[list_name] == expected_result

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 import json
 from pathlib import Path
+from string import Template
 from unittest import mock
 
 import pytest
@@ -414,10 +415,11 @@ Heinz
     ):
         url_template = "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla"
         list_name = "bad_users.list"
+        final_url = Template(url_template).substitute({"LOGPREP_LIST": list_name})
 
         responses.add(
             responses.GET,
-            url=Template(url_template).substitute({"LOGPREP_LIST": list_name}),
+            url=final_url,
             body=http_list_content,
             status=200,
         )
@@ -433,7 +435,6 @@ Heinz
             "description": "",
         }
 
-        
         config = {
             "type": "list_comparison",
             "rules": [],

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -426,7 +426,7 @@ Heinz
 
         document = {"user": "Foo"}
         rule_dict = {
-            "filter": "system",
+            "filter": "user",
             "list_comparison": {
                 "source_fields": ["user"],
                 "target_field": "user_results",
@@ -450,8 +450,8 @@ Heinz
         processor.setup()
         processor.process(document)
 
-        unmodified_document = {"user": "Foo"}
-        assert document == unmodified_document
+        expected_document = {"user": "Foo", "user_results": {"not_in_list": ["bad_users.list"]}}
+        assert document == expected_document
 
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -413,6 +413,9 @@ Heinz
         http_list_content,
         expected_result,
     ):
+        document = {"user": "Foo"}
+        expected_document = {"user": "Foo", "user_results": {"not_in_list": ["bad_users.list"]}}
+
         url_template = "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla"
         list_name = "bad_users.list"
         url = Template(url_template).substitute({"LOGPREP_LIST": list_name})
@@ -424,7 +427,6 @@ Heinz
             status=200,
         )
 
-        document = {"user": "Foo"}
         rule_dict = {
             "filter": "user",
             "list_comparison": {
@@ -450,9 +452,7 @@ Heinz
         processor.setup()
         processor.process(document)
 
-        expected_document = {"user": "Foo", "user_results": {"not_in_list": ["bad_users.list"]}}
         assert document == expected_document
-
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
         assert rule.compare_sets[list_name] == expected_result


### PR DESCRIPTION
## Description

* add regression test for list_comparison when HTTP list content is empty ("") or contains an empty line ("\n")
* verify compare_sets is updated deterministically for both edge cases and processing does not crash

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* List of (preferably easy reproducible) tests including OS

Run: 
`uv run pytest   tests/unit/processor/list_comparison/test_list_comparison.py::TestListComparison::test_list_comparison_empty_http_list_or_empty_line_updates_compare_sets -vv`

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--930.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->