### PR TITLE
fix: properly handle falsy resolved values in generic_resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
 * add uv as dependency management, including uv.lock
 * allow configuration (and auto-creation) of service accounts in helm chart
+* generic_resolver now handles all FieldValue types (including None)
 
 ### Improvements
 * simplify Dockerfile and remove docker build support for `LOGPREP_VERSION`
@@ -11,6 +12,7 @@
 ### Bugfix
 * generic_resolver now follows yaml standard and accepts a list instead of relying on the ordering of a dict
 * decoder errors are handled properly as warnings instead of causing pipeline failures
+* generic_resolver now properly handles falsy values in resolve_list
 
 ## 18.0.1
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Bugfix
 * generic_resolver now follows yaml standard and accepts a list instead of relying on the ordering of a dict
 * decoder errors are handled properly as warnings instead of causing pipeline failures
-* generic_resolver now properly handles falsy values in resolve_list
+* generic_resolver now properly handles falsy values in resolve_list and resolve_from_file
 
 ## 18.0.1
 ### Breaking

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -147,7 +147,7 @@ class GenericResolver(FieldManager):
             resolved_content = self._find_content_of_first_matching_pattern(
                 rule, source_field_value
             )
-            if isinstance(resolved_content, Missing):
+            if resolved_content is MISSING:
                 continue
             current_content = get_dotted_field_value(event, target_field)
             if isinstance(current_content, list) and resolved_content in current_content:

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -24,7 +24,7 @@ Processor Configuration
 """
 
 from copy import deepcopy
-from functools import _lru_cache_wrapper, cached_property, lru_cache
+from functools import cached_property, lru_cache
 from typing import Callable, cast
 
 from attrs import define, field, validators
@@ -42,6 +42,7 @@ from logprep.util.helper import (
     add_fields_to,
     get_dotted_field_value,
 )
+from logprep.util.typing import is_lru_cached
 
 
 class GenericResolver(FieldManager):
@@ -125,10 +126,7 @@ class GenericResolver(FieldManager):
     @cached_property
     def _get_lru_cached_value_from_list(
         self,
-    ) -> (
-        Callable[[GenericResolverRule, str], FieldValue | Missing]
-        | _lru_cache_wrapper[FieldValue | Missing]
-    ):
+    ) -> Callable[[GenericResolverRule, str], FieldValue | Missing]:
         """Returns lru cashed method to retrieve values from list if configured"""
         if self.max_cache_entries <= 0:
             return self._resolve_value_from_list
@@ -200,7 +198,7 @@ class GenericResolver(FieldManager):
         return MISSING
 
     def _update_cache_metrics(self) -> None:
-        if not isinstance(self._get_lru_cached_value_from_list, _lru_cache_wrapper):
+        if not is_lru_cached(self._get_lru_cached_value_from_list):
             return
         self._cache_metrics_skip_count += 1
         if self._cache_metrics_skip_count < self.cache_metrics_interval:

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -185,8 +185,9 @@ class GenericResolver(FieldManager):
                 mapping = matches.group("mapping")
                 if rule.ignore_case:
                     mapping = mapping.upper()
-                if mapping in rule.additions:
-                    return rule.additions.get(mapping)
+                content = rule.additions.get(mapping, MISSING)
+                if content is not MISSING:
+                    return content
         return self._get_lru_cached_value_from_list(rule, source_field_value)
 
     def _resolve_value_from_list(

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -23,8 +23,9 @@ Processor Configuration
 .. automodule:: logprep.processor.generic_resolver.rule
 """
 
-from functools import cached_property, lru_cache
-from typing import Callable, Optional
+from copy import deepcopy
+from functools import _lru_cache_wrapper, cached_property, lru_cache
+from typing import Callable, cast
 
 from attrs import define, field, validators
 
@@ -32,8 +33,15 @@ from logprep.metrics.metrics import GaugeMetric
 from logprep.ng.abc.processor import Processor
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.exceptions import FieldExistsWarning
+from logprep.processor.base.rule import Rule
 from logprep.processor.generic_resolver.rule import GenericResolverRule
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import (
+    MISSING,
+    FieldValue,
+    Missing,
+    add_fields_to,
+    get_dotted_field_value,
+)
 
 
 class GenericResolver(FieldManager):
@@ -43,9 +51,7 @@ class GenericResolver(FieldManager):
     class Config(Processor.Config):
         """GenericResolver config"""
 
-        max_cache_entries: Optional[int] = field(
-            validator=validators.optional(validators.instance_of(int)), default=0
-        )
+        max_cache_entries: int = field(validator=validators.instance_of(int), default=0)
         """(Optional) Size of cache for results when resolving from a list.
         The cache can be disabled by setting this option to :code:`0`.
 
@@ -56,9 +62,7 @@ class GenericResolver(FieldManager):
            and OOM situations caused by the generic resolver cache.
 
         """
-        cache_metrics_interval: Optional[int] = field(
-            validator=validators.optional(validators.instance_of(int)), default=1
-        )
+        cache_metrics_interval: int = field(validator=validators.instance_of(int), default=1)
         """(Optional) Cache metrics won't be updated immediately.
         Instead updating is skipped for a number of events before it's next update.
         :code:`cache_metrics_interval` sets the number of events between updates (default: 1)."""
@@ -104,51 +108,67 @@ class GenericResolver(FieldManager):
     rule_class = GenericResolverRule
 
     @property
+    def config(self) -> Config:
+        """Returns the typed GenericResolver.Config"""
+        return cast(GenericResolver.Config, self._config)
+
+    @property
     def max_cache_entries(self) -> int:
         """Returns the configured number of max_cache_entries"""
-        return self._config.max_cache_entries
+        return self.config.max_cache_entries
 
     @property
     def cache_metrics_interval(self) -> int:
         """Returns the configured cache_metrics_interval"""
-        return self._config.cache_metrics_interval
+        return self.config.cache_metrics_interval
 
     @cached_property
-    def _get_lru_cached_value_from_list(self) -> Callable[[GenericResolverRule, str], str | None]:
+    def _get_lru_cached_value_from_list(
+        self,
+    ) -> (
+        Callable[[GenericResolverRule, str], FieldValue | Missing]
+        | _lru_cache_wrapper[FieldValue | Missing]
+    ):
         """Returns lru cashed method to retrieve values from list if configured"""
         if self.max_cache_entries <= 0:
             return self._resolve_value_from_list
         return lru_cache(maxsize=self.max_cache_entries)(self._resolve_value_from_list)
 
-    def _apply_rules(self, event: dict, rule: GenericResolverRule) -> None:
+    def _apply_rules(self, event: dict, rule: Rule) -> None:
         """Apply the given rule to the current event"""
+        _rule = cast(GenericResolverRule, rule)
         source_field_values = [
             get_dotted_field_value(event, source_field)
-            for source_field in rule.field_mapping.keys()
+            for source_field in _rule.field_mapping.keys()
         ]
-        self._handle_missing_fields(event, rule, rule.field_mapping.keys(), source_field_values)
+        self._handle_missing_fields(event, _rule, _rule.field_mapping.keys(), source_field_values)
         conflicting_fields = []
-        for source_field, target_field in rule.field_mapping.items():
+        for source_field, target_field in _rule.field_mapping.items():
             source_field_value = str(get_dotted_field_value(event, source_field))
-            content = self._find_content_of_first_matching_pattern(rule, source_field_value)
-            if not content:
+            resolved_content = self._find_content_of_first_matching_pattern(
+                _rule, source_field_value
+            )
+            if isinstance(resolved_content, Missing):
                 continue
             current_content = get_dotted_field_value(event, target_field)
-            if isinstance(current_content, list) and content in current_content:
+            if isinstance(current_content, list) and resolved_content in current_content:
                 continue
+            if isinstance(resolved_content, (list, dict)):
+                resolved_content = deepcopy(resolved_content)
             try:
                 add_fields_to(
                     event,
                     fields={
                         target_field: (
-                            [content]
-                            if rule.merge_with_target and current_content is None
-                            else content
+                            [resolved_content]
+                            if _rule.merge_with_target and current_content is None
+                            else resolved_content
                         )
                     },
-                    rule=rule,
-                    merge_with_target=rule.merge_with_target,
-                    overwrite_target=rule.overwrite_target,
+                    rule=_rule,
+                    merge_with_target=_rule.merge_with_target,
+                    overwrite_target=_rule.overwrite_target,
+                    skip_none=False,
                 )
             except FieldExistsWarning as error:
                 conflicting_fields.extend(error.skipped_fields)
@@ -156,32 +176,31 @@ class GenericResolver(FieldManager):
         self._update_cache_metrics()
 
         if conflicting_fields:
-            raise FieldExistsWarning(rule, event, conflicting_fields)
+            raise FieldExistsWarning(_rule, event, conflicting_fields)
 
     def _find_content_of_first_matching_pattern(
         self, rule: GenericResolverRule, source_field_value: str
-    ) -> str | None:
+    ) -> FieldValue | Missing:
         if rule.resolve_from_file:
             matches = rule.pattern.match(source_field_value)
             if matches:
                 mapping = matches.group("mapping")
                 if rule.ignore_case:
                     mapping = mapping.upper()
-                content = rule.additions.get(mapping)
-                if content:
-                    return content
+                if mapping in rule.additions:
+                    return rule.additions.get(mapping)
         return self._get_lru_cached_value_from_list(rule, source_field_value)
 
     def _resolve_value_from_list(
         self, rule: GenericResolverRule, source_field_value: str
-    ) -> Optional[str]:
+    ) -> FieldValue | Missing:
         for pattern, content in rule.compiled_resolve_list:
             if pattern.search(source_field_value):
                 return content
-        return None
+        return MISSING
 
     def _update_cache_metrics(self) -> None:
-        if self.max_cache_entries <= 0:
+        if not isinstance(self._get_lru_cached_value_from_list, _lru_cache_wrapper):
             return
         self._cache_metrics_skip_count += 1
         if self._cache_metrics_skip_count < self.cache_metrics_interval:
@@ -192,7 +211,7 @@ class GenericResolver(FieldManager):
         self.metrics.new_results += cache_info.misses
         self.metrics.cached_results += cache_info.hits
         self.metrics.num_cache_entries += cache_info.currsize
-        self.metrics.cache_load += cache_info.currsize / cache_info.maxsize
+        self.metrics.cache_load += cache_info.currsize / self.max_cache_entries
 
     def setup(self) -> None:
         super().setup()

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -147,7 +147,7 @@ class GenericResolver(FieldManager):
             resolved_content = self._find_content_of_first_matching_pattern(
                 rule, source_field_value
             )
-            if isinstance(resolved_content, Missing):
+            if resolved_content is MISSING:
                 continue
             current_content = get_dotted_field_value(event, target_field)
             if isinstance(current_content, list) and resolved_content in current_content:

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -25,7 +25,6 @@ Processor Configuration
 
 from copy import deepcopy
 from functools import cached_property, lru_cache
-from typing import Optional
 
 from attrs import define, field, validators
 
@@ -44,9 +43,7 @@ class GenericResolver(FieldManager):
     class Config(Processor.Config):
         """GenericResolver config"""
 
-        max_cache_entries: Optional[int] = field(
-            validator=validators.optional(validators.instance_of(int)), default=0
-        )
+        max_cache_entries: int = field(validator=validators.instance_of(int), default=0)
         """(Optional) Size of cache for results when resolving from a list.
         The cache can be disabled by setting this option to :code:`0`.
 
@@ -57,9 +54,7 @@ class GenericResolver(FieldManager):
            and OOM situations caused by the generic resolver cache.
 
         """
-        cache_metrics_interval: Optional[int] = field(
-            validator=validators.optional(validators.instance_of(int)), default=1
-        )
+        cache_metrics_interval: int = field(validator=validators.instance_of(int), default=1)
         """(Optional) Cache metrics won't be updated immediately.
         Instead updating is skipped for a number of events before it's next update.
         :code:`cache_metrics_interval` sets the number of events between updates (default: 1)."""

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -33,7 +33,11 @@ from logprep.metrics.metrics import GaugeMetric
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.processor.field_manager.processor import FieldManager
 from logprep.processor.generic_resolver.rule import GenericResolverRule
-from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
+from logprep.util.helper import (
+    NonNoneFieldValue,
+    add_fields_to,
+    get_dotted_field_value,
+)
 
 
 class GenericResolver(FieldManager):
@@ -160,7 +164,7 @@ class GenericResolver(FieldManager):
 
     def _find_content_of_first_matching_pattern(
         self, rule: GenericResolverRule, source_field_value: str
-    ) -> FieldValue | None:
+    ) -> NonNoneFieldValue | None:
         if rule.resolve_from_file:
             matches = rule.pattern.match(source_field_value)
             if matches:
@@ -174,7 +178,7 @@ class GenericResolver(FieldManager):
 
     def _resolve_value_from_list(
         self, rule: GenericResolverRule, source_field_value: str
-    ) -> FieldValue | None:
+    ) -> NonNoneFieldValue | None:
         for pattern, content in rule.compiled_resolve_list:
             if pattern.search(source_field_value):
                 return content

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -185,8 +185,9 @@ class GenericResolver(FieldManager):
                 mapping = matches.group("mapping")
                 if rule.ignore_case:
                     mapping = mapping.upper()
-                if mapping in rule.additions:
-                    return rule.additions.get(mapping)
+                content = rule.additions.get(mapping, MISSING)
+                if content is not MISSING:
+                    return content
         return self._get_lru_cached_value_from_list(rule, source_field_value)
 
     def _resolve_value_from_list(

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -24,7 +24,7 @@ Processor Configuration
 """
 
 from copy import deepcopy
-from functools import _lru_cache_wrapper, cached_property, lru_cache
+from functools import cached_property, lru_cache
 from typing import Callable, cast
 
 from attrs import define, field, validators
@@ -42,6 +42,7 @@ from logprep.util.helper import (
     add_fields_to,
     get_dotted_field_value,
 )
+from logprep.util.typing import is_lru_cached
 
 
 class GenericResolver(FieldManager):
@@ -125,10 +126,7 @@ class GenericResolver(FieldManager):
     @cached_property
     def _get_lru_cached_value_from_list(
         self,
-    ) -> (
-        Callable[[GenericResolverRule, str], FieldValue | Missing]
-        | _lru_cache_wrapper[FieldValue | Missing]
-    ):
+    ) -> Callable[[GenericResolverRule, str], FieldValue | Missing]:
         """Returns lru cashed method to retrieve values from list if configured"""
         if self.max_cache_entries <= 0:
             return self._resolve_value_from_list
@@ -200,7 +198,7 @@ class GenericResolver(FieldManager):
         return MISSING
 
     def _update_cache_metrics(self) -> None:
-        if not isinstance(self._get_lru_cached_value_from_list, _lru_cache_wrapper):
+        if not is_lru_cached(self._get_lru_cached_value_from_list):
             return
         self._cache_metrics_skip_count += 1
         if self._cache_metrics_skip_count < self.cache_metrics_interval:
@@ -213,6 +211,6 @@ class GenericResolver(FieldManager):
         self.metrics.num_cache_entries += cache_info.currsize
         self.metrics.cache_load += cache_info.currsize / self.max_cache_entries
 
-    def setup(self):
+    def setup(self) -> None:
         super().setup()
         self._cache_metrics_skip_count = 0

--- a/logprep/processor/generic_resolver/rule.py
+++ b/logprep/processor/generic_resolver/rule.py
@@ -100,8 +100,8 @@ Resolved dictionaries can be merged into existing dictionaries. In the following
         .*Hello.*: {"Greeting": "Hello"}
 
 In the following example :code:`to_resolve` will be checked by the
-regex pattern :code:`\d*(?P<mapping>[a-z]+)\d*` and the list in :code:`path/to/resolve_mapping.yml`
-will be used to add new fields.
+regex pattern :code:`\\d*(?P<mapping>[a-z]+)\\d*` and the list in
+:code:`path/to/resolve_mapping.yml` will be used to add new fields.
 :code:`"resolved": "resolved foo"` will be added to the event if the value
 in :code:`to_resolve` begins with number, ends with numbers and contains foo.
 Furthermore, :code:`"resolved": "resolved bar"` will be added to the event

--- a/logprep/processor/generic_resolver/rule.py
+++ b/logprep/processor/generic_resolver/rule.py
@@ -170,7 +170,9 @@ class GenericResolverRule(FieldManagerRule):
                 key_validator=validators.instance_of(str),
                 mapping_validator=validators.instance_of(dict),
             ),
-            converter=convert_ordered_mapping_or_keep_mapping,
+            converter=lambda x: convert_ordered_mapping_or_keep_mapping(
+                x
+            ),  # pylint: disable=unnecessary-lambda
             factory=dict,
         )
         """lookup mapping in form of

--- a/logprep/processor/generic_resolver/rule.py
+++ b/logprep/processor/generic_resolver/rule.py
@@ -166,9 +166,7 @@ class GenericResolverRule(FieldManagerRule):
         """Mapping in form of :code:`{SOURCE_FIELD: DESTINATION_FIELD}`"""
         resolve_list: dict[str, FieldValue] = field(
             validator=validators.deep_mapping(
-                value_validator=validators.instance_of(
-                    dict | list | str | int | float | bool | None
-                ),
+                value_validator=validators.instance_of(dict | list | str | int | float | bool),
                 key_validator=validators.instance_of(str),
                 mapping_validator=validators.instance_of(dict),
             ),
@@ -177,17 +175,15 @@ class GenericResolverRule(FieldManagerRule):
         )
         """lookup mapping in form of
         :code:`{REGEX_PATTERN_0: ADDED_VALUE_0, ..., REGEX_PATTERN_N: ADDED_VALUE_N}`"""
-        resolve_from_file: dict[typing.Literal["path"] | typing.Literal["pattern"], str | int] = (
-            field(
-                validator=[
-                    validators.instance_of(dict),
-                    validators.deep_mapping(
-                        key_validator=validators.in_(["path", "pattern"]),
-                        value_validator=validators.instance_of((str, int)),
-                    ),
-                ],
-                factory=dict,
-            )
+        resolve_from_file: dict[typing.Literal["path"] | typing.Literal["pattern"], str] = field(
+            validator=[
+                validators.instance_of(dict),
+                validators.deep_mapping(
+                    key_validator=validators.in_(["path", "pattern"]),
+                    value_validator=validators.instance_of(str),
+                ),
+            ],
+            factory=dict,
         )
         """Mapping with a `path` key to a YML file (for string format see :ref:`getters`)
         with a resolve list and a `pattern` key with
@@ -282,7 +278,7 @@ class GenericResolverRule(FieldManagerRule):
     @property
     def resolve_from_file(
         self,
-    ) -> dict[typing.Literal["path"] | typing.Literal["pattern"], str | int]:
+    ) -> dict[typing.Literal["path"] | typing.Literal["pattern"], str]:
         """Returns the resolve file"""
         return self.config.resolve_from_file
 

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -42,6 +42,10 @@ FieldValue: TypeAlias = Union[
     dict[str, "FieldValue"], list["FieldValue"], str, int, float, bool, None
 ]
 
+NonNoneFieldValue: TypeAlias = Union[
+    dict[str, "FieldValue"], list["FieldValue"], str, int, float, bool
+]
+
 
 def color_print_line(back: str | AnsiBack | None, fore: str | AnsiBack | None, message: str):
     """Print string with colors and reset the color afterwards."""

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -42,10 +42,6 @@ FieldValue: TypeAlias = Union[
     dict[str, "FieldValue"], list["FieldValue"], str, int, float, bool, None
 ]
 
-NonNoneFieldValue: TypeAlias = Union[
-    dict[str, "FieldValue"], list["FieldValue"], str, int, float, bool
-]
-
 
 def color_print_line(back: str | AnsiBack | None, fore: str | AnsiBack | None, message: str):
     """Print string with colors and reset the color afterwards."""

--- a/logprep/util/typing.py
+++ b/logprep/util/typing.py
@@ -3,7 +3,8 @@ This module contains typing related helper functions
 that are shared by different modules.
 """
 
-from typing import Any, TypeGuard, TypeVar
+from functools import _lru_cache_wrapper
+from typing import Any, Callable, TypeGuard, TypeVar
 
 T = TypeVar("T")
 
@@ -24,3 +25,20 @@ def is_list_of(val: list[Any], class_type: type[T]) -> TypeGuard[list[T]]:
         The type information that `val` is of this list type
     """
     return all(isinstance(obj, class_type) for obj in val)
+
+
+def is_lru_cached(val: Callable) -> TypeGuard[_lru_cache_wrapper]:
+    """Checks the given callable for being a cache wrapper
+    (and thus having a :code:`cache_info` attribute)
+
+    Parameters
+    ----------
+    val : Callable
+        The object to check
+
+    Returns
+    -------
+    TypeGuard[_lru_cache_wrapper]
+        The type information that :code:`val` a cache wrapper
+    """
+    return isinstance(val, _lru_cache_wrapper)

--- a/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
@@ -121,9 +121,10 @@ class TestGenericResolver(BaseProcessorTestCase):
 
         document = {"to_resolve": "something HELLO1"}
 
-        self.object.process(document)
+        log_event = LogEvent(document, original=b"")
+        self.object.process(log_event)
 
-        assert document == expected
+        assert log_event.data == expected
 
     def test_resolve_with_dict_value(self):
         rule = {
@@ -140,9 +141,10 @@ class TestGenericResolver(BaseProcessorTestCase):
 
         document = {"to_resolve": "something HELLO1"}
 
-        self.object.process(document)
+        log_event = LogEvent(document, original=b"")
+        self.object.process(log_event)
 
-        assert document == expected
+        assert log_event.data == expected
 
     @pytest.mark.parametrize(["resolve_value"], resolve_value_variants)
     def test_resolve_not_dotted_field_no_conflict_different_values_match(self, resolve_value):

--- a/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import responses
 
 from logprep.factory import Factory
@@ -37,6 +38,90 @@ class TestGenericResolver(BaseProcessorTestCase):
         rule = {"filter": "anything", "generic_resolver": {"field_mapping": {}}}
         self._load_rule(rule)
         assert isinstance(self.object, GenericResolver)
+
+    @pytest.mark.parametrize(
+        ["resolve_value"],
+        [
+            pytest.param(
+                0,
+                id="int_0_falsy",
+            ),
+            pytest.param(
+                42,
+                id="int_42",
+            ),
+            pytest.param(
+                -1,
+                id="int_neg_1",
+            ),
+            pytest.param(
+                -42,
+                id="int_neg_42",
+            ),
+            pytest.param(
+                -42,
+                id="int_neg_42",
+            ),
+            pytest.param(
+                0.0,
+                id="float_0",
+            ),
+            pytest.param(
+                42.1337,
+                id="float_greater_0",
+            ),
+            pytest.param(
+                -42.1337,
+                id="float_lower_0",
+            ),
+            pytest.param(
+                True,
+                id="bool_true",
+            ),
+            pytest.param(
+                False,
+                id="bool_false",
+            ),
+            pytest.param(
+                [],
+                id="list_empty_falsy",
+            ),
+            pytest.param(
+                [1, 2, "string", 0.5],
+                id="list_mixed_types",
+            ),
+            pytest.param(
+                {},
+                id="dict_empty_falsy",
+            ),
+            pytest.param(
+                {"key": "value"},
+                id="dict_simple",
+            ),
+            pytest.param(
+                None,
+                id="None",
+            ),
+        ],
+    )
+    def test_resolve_not_dotted_field_no_conflict_different_values_match(self, resolve_value):
+        rule = {
+            "filter": "to_resolve",
+            "generic_resolver": {
+                "field_mapping": {"to_resolve": "resolved"},
+                "resolve_list": {".*HELLO\\d": resolve_value},
+            },
+        }
+
+        self._load_rule(rule)
+
+        expected = {"to_resolve": "something HELLO1", "resolved": resolve_value}
+        document = {"to_resolve": "something HELLO1"}
+
+        log_event = LogEvent(document, original=b"")
+        self.object.process(log_event)
+
+        assert log_event.data == expected
 
     def test_resolve_not_dotted_field_no_conflict_match(self):
         rule = {

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -97,6 +97,10 @@ class TestGenericResolver(BaseProcessorTestCase):
                 {"key": "value"},
                 id="dict_simple",
             ),
+            pytest.param(
+                None,
+                id="None",
+            ),
         ],
     )
     def test_resolve_not_dotted_field_no_conflict_different_values_match(self, resolve_value):

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -18,6 +18,73 @@ from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import HttpGetter
 from tests.unit.processor.base import BaseProcessorTestCase
 
+resolve_value_variants = [
+    pytest.param(
+        0,
+        id="int_0_falsy",
+    ),
+    pytest.param(
+        42,
+        id="int_42",
+    ),
+    pytest.param(
+        -1,
+        id="int_neg_1",
+    ),
+    pytest.param(
+        -42,
+        id="int_neg_42",
+    ),
+    pytest.param(
+        -42,
+        id="int_neg_42",
+    ),
+    pytest.param(
+        0.0,
+        id="float_0",
+    ),
+    pytest.param(
+        42.1337,
+        id="float_greater_0",
+    ),
+    pytest.param(
+        -42.1337,
+        id="float_lower_0",
+    ),
+    pytest.param(
+        True,
+        id="bool_true",
+    ),
+    pytest.param(
+        False,
+        id="bool_false",
+    ),
+    pytest.param(
+        [],
+        id="list_empty_falsy",
+    ),
+    pytest.param(
+        [1, 2, "string", 0.5, [1, 2, 3], {"key": "value"}],
+        id="list_mixed_types",
+    ),
+    pytest.param(
+        {},
+        id="dict_empty_falsy",
+    ),
+    pytest.param(
+        {"key": "value"},
+        id="dict_simple",
+    ),
+    pytest.param(
+        {"key": {"str": "value", "int": 0, "float": 0.1, "bool": True, "list": [1, 2]}},
+        id="dict_nested",
+    ),
+    pytest.param(
+        None,
+        id="None",
+    ),
+]
+
 
 class TestGenericResolver(BaseProcessorTestCase):
     CONFIG = {
@@ -38,71 +105,7 @@ class TestGenericResolver(BaseProcessorTestCase):
         self._load_rule(rule)
         assert isinstance(self.object, GenericResolver)
 
-    @pytest.mark.parametrize(
-        ["resolve_value"],
-        [
-            pytest.param(
-                0,
-                id="int_0_falsy",
-            ),
-            pytest.param(
-                42,
-                id="int_42",
-            ),
-            pytest.param(
-                -1,
-                id="int_neg_1",
-            ),
-            pytest.param(
-                -42,
-                id="int_neg_42",
-            ),
-            pytest.param(
-                -42,
-                id="int_neg_42",
-            ),
-            pytest.param(
-                0.0,
-                id="float_0",
-            ),
-            pytest.param(
-                42.1337,
-                id="float_greater_0",
-            ),
-            pytest.param(
-                -42.1337,
-                id="float_lower_0",
-            ),
-            pytest.param(
-                True,
-                id="bool_true",
-            ),
-            pytest.param(
-                False,
-                id="bool_false",
-            ),
-            pytest.param(
-                [],
-                id="list_empty_falsy",
-            ),
-            pytest.param(
-                [1, 2, "string", 0.5],
-                id="list_mixed_types",
-            ),
-            pytest.param(
-                {},
-                id="dict_empty_falsy",
-            ),
-            pytest.param(
-                {"key": "value"},
-                id="dict_simple",
-            ),
-            pytest.param(
-                None,
-                id="None",
-            ),
-        ],
-    )
+    @pytest.mark.parametrize(["resolve_value"], resolve_value_variants)
     def test_resolve_not_dotted_field_no_conflict_different_values_match(self, resolve_value):
         rule = {
             "filter": "to_resolve",
@@ -116,6 +119,35 @@ class TestGenericResolver(BaseProcessorTestCase):
 
         expected = {"to_resolve": "something HELLO1", "resolved": resolve_value}
         document = {"to_resolve": "something HELLO1"}
+
+        self.object.process(document)
+
+        assert document == expected
+
+    @pytest.mark.parametrize(["resolve_value"], resolve_value_variants)
+    def test_resolve_not_dotted_field_no_conflict_different_values_match_from_file(
+        self, resolve_value, tmp_path
+    ):
+        resolve_file_path = tmp_path / "rule.json"
+
+        rule = {
+            "filter": "to_resolve",
+            "generic_resolver": {
+                "field_mapping": {"to_resolve": "resolved"},
+                "resolve_from_file": {
+                    "path": str(resolve_file_path),
+                    "pattern": r"(?P<mapping>.+)",
+                },
+            },
+        }
+        resolve_dict = {"abc": resolve_value}
+        expected = {"to_resolve": "abc", "resolved": resolve_value}
+        document = {"to_resolve": "abc"}
+
+        with open(resolve_file_path, mode="w+", encoding="utf8") as stream:
+            stream.write(json.dumps(resolve_dict))
+
+        self._load_rule(rule)
 
         self.object.process(document)
 


### PR DESCRIPTION
## Description

* fix handling of falsy resolved values (these were skipped before)
* support all `FieldValue` types including `None`
* improve static typing

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* added failing tests to verify the bug and including the whole range of value types
* code changes make the tests pass green

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--933.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->