### PR TITLE
feat: allow multiple credentials for input connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ requirements.*
 /scripts/
 .dmypy.json
 tmp
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 ### Breaking
 
 ### Features
+* make it possible to assign multiple credentials to a single endpoint
 
 ### Improvements
+* improve http endpoint security by fully checking basic auth hashes, and doing that in a time constant manner to not expose secrets
 
 ### Bugfix
 

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -276,25 +276,21 @@ class HttpEndpoint(ABC):
         self.collect_meta = collect_meta
 
         self.metafield_name = metafield_name
-        self.credentials = credentials
         self.metrics = metrics
         self.basicauth_b64: list[str] = []
 
-        if self.credentials and isinstance(self.credentials, list):
-            for cred in self.credentials:
+        self.credentials = None
+
+        if credentials:
+            credentials = [credentials] if isinstance(credentials, Credentials) else credentials
+            for cred in credentials:
                 if isinstance(cred, BasicAuthCredentials):
                     self.basicauth_b64.append(
                         b64encode(f"{cred.username}:{cred.password}".encode("utf-8")).decode(
                             "utf-8"
                         )
                     )
-        elif self.credentials:
-            if isinstance(self.credentials, BasicAuthCredentials):
-                self.basicauth_b64.append(
-                    b64encode(
-                        f"{self.credentials.username}:{self.credentials.password}".encode("utf-8")
-                    ).decode("utf-8")
-                )
+            self.credentials = credentials
 
     def collect_metrics(self):
         """Increment number of requests"""
@@ -481,7 +477,7 @@ class HttpInput(Input):
         """
 
         message_backlog_size: int = field(
-            validator=validators.instance_of(int), default=15000, converter=lambda x: int(x)
+            validator=validators.instance_of(int), default=15000, converter=int
         )
         """Configures maximum size of input message queue for this connector. When limit is reached
         the server will answer with 429 Too Many Requests. For reasonable throughput this shouldn't

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -29,6 +29,7 @@ An example config file would look like:
           /firstendpoint: json
           /second*: plaintext
           /(third|fourth)/endpoint: jsonl
+          /endpoint_with_multiple_credentials: json
 
 The endpoint config supports regex and wildcard patterns:
   * :code:`/second*`: matches everything after asterisk
@@ -56,6 +57,11 @@ add basic authentication for a specific endpoint. The format of this file would 
         /second*:
           username: user
           password: secret_password
+        /endpoint_with_multiple_credentials:
+          - username: user
+            password: secret_password
+          - username: user2
+            password_file: examples/exampledata/config/user_password.txt
 
 You can choose between a plain secret with the key :code:`password` or a filebased secret
 with the key :code:`password_file`.

--- a/logprep/ng/connector/http/input.py
+++ b/logprep/ng/connector/http/input.py
@@ -29,6 +29,7 @@ An example config file would look like:
           /firstendpoint: json
           /second*: plaintext
           /(third|fourth)/endpoint: jsonl
+          /endpoint_with_multiple_credentials: json
 
 The endpoint config supports regex and wildcard patterns:
   * :code:`/second*`: matches everything after asterisk
@@ -56,6 +57,11 @@ add basic authentication for a specific endpoint. The format of this file would 
         /second*:
           username: user
           password: secret_password
+        /endpoint_with_multiple_credentials:
+          - username: user
+            password: secret_password
+          - username: user2
+            password_file: examples/exampledata/config/user_password.txt
 
 You can choose between a plain secret with the key :code:`password` or a filebased secret
 with the key :code:`password_file`.

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -188,6 +188,7 @@ class CredentialsFactory:
         if endpoint_credentials is None:
             return None
         credential_mapping: dict | None = endpoint_credentials.get(target_endpoint)
+
         credentials = cls.from_dict(credential_mapping)
         return credentials
 

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -264,7 +264,7 @@ class CredentialsFactory:
             if isinstance(cred, Credentials):
                 creds.append(cred)
 
-        return creds
+        return creds if len(creds) > 0 else None
 
     @classmethod
     def from_dict(cls, credential_mapping: dict | None) -> "Credentials | None":
@@ -407,8 +407,8 @@ class AccessToken:
 
     token: str = field(validator=validators.instance_of(str), repr=False)
     """token used for authentication against the target"""
-    expiry_time: datetime | None = field(
-        validator=validators.instance_of((datetime, type(None))), init=False
+    expiry_time: datetime = field(
+        validator=validators.instance_of(datetime), init=False, default=datetime.now()
     )
     """time when token is expired"""
     refresh_token: str | None = field(
@@ -431,7 +431,7 @@ class AccessToken:
     @property
     def is_expired(self) -> bool:
         """Checks if the token is already expired."""
-        if self.expires_in == 0 or not self.expiry_time:
+        if self.expires_in == 0:
             return False
         return datetime.now() > self.expiry_time
 
@@ -676,7 +676,7 @@ class OAuth2ClientFlowCredentials(Credentials):
 
         """
         session = super().get_session()
-        if "Authorization" in session.headers and (not self._token or self._token.is_expired):
+        if "Authorization" in session.headers and (self._token and not self._token.is_expired):
             session.close()
             session = Session()
         if self._no_authorization_header(session):

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -163,7 +163,7 @@ class CredentialsFactory:
         return credentials
 
     @classmethod
-    def from_endpoint(cls, target_endpoint: str) -> "Credentials | None":
+    def from_endpoint(cls, target_endpoint: str) -> "list[Credentials] | Credentials | None":
         """Factory method to create a credentials object based on the credentials stored in the
         environment variable :code:`LOGPREP_CREDENTIALS_FILE`.
         Based on these credentials the expected authentication method is chosen and represented
@@ -187,9 +187,14 @@ class CredentialsFactory:
         endpoint_credentials = credentials_file.input.get("endpoints")
         if endpoint_credentials is None:
             return None
-        credential_mapping: dict | None = endpoint_credentials.get(target_endpoint)
+        credential_mapping: list | dict | None = endpoint_credentials.get(target_endpoint)
 
-        credentials = cls.from_dict(credential_mapping)
+        credentials: list[Credentials] | Credentials | None = None
+        if isinstance(credential_mapping, dict):
+            credentials = cls.from_dict(credential_mapping)
+        elif isinstance(credential_mapping, list):
+            credentials = cls.from_list(credential_mapping)
+
         return credentials
 
     @staticmethod
@@ -250,6 +255,16 @@ class CredentialsFactory:
         for credential_type in secret_content:
             credential_mapping.pop(f"{credential_type}_file")
         credential_mapping.update(secret_content)
+
+    @classmethod
+    def from_list(cls, credential_mapping: list[dict | None]) -> "list[Credentials] | None":
+        creds: list[Credentials] = []
+        for credential in credential_mapping:
+            cred = cls.from_dict(credential)
+            if isinstance(cred, Credentials):
+                creds.append(cred)
+
+        return creds
 
     @classmethod
     def from_dict(cls, credential_mapping: dict | None) -> "Credentials | None":
@@ -392,11 +407,11 @@ class AccessToken:
 
     token: str = field(validator=validators.instance_of(str), repr=False)
     """token used for authentication against the target"""
-    expiry_time: datetime = field(
+    expiry_time: datetime | None = field(
         validator=validators.instance_of((datetime, type(None))), init=False
     )
     """time when token is expired"""
-    refresh_token: str = field(
+    refresh_token: str | None = field(
         validator=validators.instance_of((str, type(None))), default=None, repr=False
     )
     """is used incase the token is expired"""
@@ -416,7 +431,7 @@ class AccessToken:
     @property
     def is_expired(self) -> bool:
         """Checks if the token is already expired."""
-        if self.expires_in == 0:
+        if self.expires_in == 0 or not self.expiry_time:
             return False
         return datetime.now() > self.expiry_time
 
@@ -427,7 +442,9 @@ class Credentials:
 
     _logger = logging.getLogger("Credentials")
 
-    _session: Session = field(validator=validators.instance_of((Session, type(None))), default=None)
+    _session: Session | None = field(
+        validator=validators.instance_of((Session, type(None))), default=None
+    )
 
     def get_session(self):
         """returns session with retry configuration"""
@@ -549,14 +566,14 @@ class OAuth2PasswordFlowCredentials(Credentials):
     """the username for the token request"""
     timeout: int = field(validator=validators.instance_of(int), default=1)
     """The timeout for the token request. Defaults to 1 second."""
-    client_id: str = field(validator=validators.instance_of((str, type(None))), default=None)
+    client_id: str | None = field(validator=validators.instance_of((str, type(None))), default=None)
     """The client id for the token request. This is used to identify the client. (Optional)"""
-    client_secret: str = field(
+    client_secret: str | None = field(
         validator=validators.instance_of((str, type(None))), default=None, repr=False
     )
     """The client secret for the token request.
     This is used to authenticate the client. (Optional)"""
-    _token: AccessToken = field(
+    _token: AccessToken | None = field(
         validator=validators.instance_of((AccessToken, type(None))),
         init=False,
         repr=False,
@@ -573,7 +590,7 @@ class OAuth2PasswordFlowCredentials(Credentials):
             }
             session.headers["Authorization"] = f"Bearer {self._get_token(payload)}"
 
-        if self._token.is_expired and self._token.refresh_token is not None:
+        if self._token and self._token.is_expired and self._token.refresh_token is not None:
             session = Session()
             payload = {
                 "grant_type": "refresh_token",
@@ -639,7 +656,7 @@ class OAuth2ClientFlowCredentials(Credentials):
     """The client secret for the token request. This is used to authenticate the client."""
     timeout: int = field(validator=validators.instance_of(int), default=1)
     """The timeout for the token request. Defaults to 1 second."""
-    _token: AccessToken = field(
+    _token: AccessToken | None = field(
         validator=validators.instance_of((AccessToken, type(None))), init=False, repr=False
     )
 
@@ -659,7 +676,7 @@ class OAuth2ClientFlowCredentials(Credentials):
 
         """
         session = super().get_session()
-        if "Authorization" in session.headers and self._token.is_expired:
+        if "Authorization" in session.headers and (not self._token or self._token.is_expired):
             session.close()
             session = Session()
         if self._no_authorization_header(session):
@@ -710,7 +727,7 @@ class MTLSCredentials(Credentials):
     """path to the client key"""
     cert: str = field(validator=validators.instance_of(str))
     """path to the client certificate"""
-    ca_cert: str = field(validator=validators.instance_of((str, type(None))), default=None)
+    ca_cert: str | None = field(validator=validators.instance_of((str, type(None))), default=None)
     """path to a certification authority certificate"""
 
     def get_session(self):

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -676,7 +676,7 @@ class OAuth2ClientFlowCredentials(Credentials):
 
         """
         session = super().get_session()
-        if "Authorization" in session.headers and (self._token and not self._token.is_expired):
+        if "Authorization" in session.headers and (not self._token or self._token.is_expired):
             session.close()
             session = Session()
         if self._no_authorization_header(session):

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -591,13 +591,11 @@ class OAuth2PasswordFlowCredentials(Credentials):
             session.headers["Authorization"] = f"Bearer {self._get_token(payload)}"
 
         if self._token and self._token.is_expired and self._token.refresh_token is not None:
-            session = Session()
             payload = {
                 "grant_type": "refresh_token",
                 "refresh_token": self._token.refresh_token,
             }
             session.headers["Authorization"] = f"Bearer {self._get_token(payload)}"
-        self._session = session
         return session
 
     def _get_token(self, payload: dict[str, str]) -> AccessToken:
@@ -677,11 +675,10 @@ class OAuth2ClientFlowCredentials(Credentials):
         """
         session = super().get_session()
         if "Authorization" in session.headers and (not self._token or self._token.is_expired):
-            session.close()
-            session = Session()
+            session.headers["Authorization"] = f"Bearer {self._get_token()}"
         if self._no_authorization_header(session):
             session.headers["Authorization"] = f"Bearer {self._get_token()}"
-        self._session = session
+
         return session
 
     def _get_token(self) -> AccessToken:

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -503,9 +503,11 @@ class TestHttpConnector(BaseInputTestCase):
         data = {"message": "my log message"}
         with mock.patch.dict("os.environ", mock_env):
             new_connector = Factory.create({"test connector": self.CONFIG})
+            assert isinstance(new_connector, HttpInput)
             new_connector.pipeline_index = 1
             new_connector.setup()
             headers = {"Authorization": _basic_auth_str("user", "file_password")}
+            assert new_connector.app
             client = testing.TestClient(new_connector.app, headers=headers)
             resp = client.post("/auth-json-file", body=json.dumps(data))
             assert resp.status_code == 200

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -46,7 +46,7 @@ input:
       - username: user
         password: password
       - username: user2
-        password: password2
+        password_file: {secret_file_path}
 
 """)
 
@@ -556,7 +556,7 @@ class TestHttpConnector(BaseInputTestCase):
             new_connector.pipeline_index = 1
             new_connector.setup()
             assert new_connector.app
-            headers = {"Authorization": _basic_auth_str("user2", "password2")}
+            headers = {"Authorization": _basic_auth_str("user2", "secret_password")}
             client = testing.TestClient(new_connector.app, headers=headers)
             resp = client.post("/auth-json-two-creds", body=json.dumps(data))
             assert resp.status_code == 200

--- a/tests/unit/ng/connector/test_http_input.py
+++ b/tests/unit/ng/connector/test_http_input.py
@@ -45,6 +45,11 @@ input:
     /.*/[A-Z]{{2}}/json$:
       username: user
       password: password
+    /auth-json-two-creds:
+      - username: user
+        password: password
+      - username: user2
+        password: password2
 """)
 
     return str(credential_file_path)
@@ -69,6 +74,7 @@ class TestHttpConnector(BaseInputTestCase):
             "/auth-json-secret": "json",
             "/auth-json-file": "json",
             "/[A-Za-z0-9]*/[A-Z]{2}/json$": "json",
+            "/auth-json-two-creds": "json",
         },
     }
 
@@ -392,6 +398,43 @@ class TestHttpConnector(BaseInputTestCase):
             client = testing.TestClient(new_connector.app, headers=headers)
             resp = client.post("/auth-json-file", body=json.dumps(data))
             assert resp.status_code == 200
+
+    def test_endpoint_returns_200_on_correct_authorization_for_subpath_and_both_credentials(
+        self, credentials_file_path
+    ):
+        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        data = {"message": "my log message"}
+        with mock.patch.dict("os.environ", mock_env):
+            new_connector = Factory.create({"test connector": self.CONFIG})
+            assert isinstance(new_connector, HttpInput)
+            new_connector.pipeline_index = 1
+            new_connector.setup()
+            assert new_connector.app
+            headers = {"Authorization": _basic_auth_str("user2", "password2")}
+            client = testing.TestClient(new_connector.app, headers=headers)
+            resp = client.post("/auth-json-two-creds", body=json.dumps(data))
+            assert resp.status_code == 200
+
+            headers = {"Authorization": _basic_auth_str("user", "password")}
+            client = testing.TestClient(new_connector.app, headers=headers)
+            resp = client.post("/auth-json-two-creds", body=json.dumps(data))
+            assert resp.status_code == 200
+
+    def test_endpoint_returns_401_on_wrong_authorization_with_second_credential(
+        self, credentials_file_path
+    ):
+        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        data = {"message": "my log message"}
+        with mock.patch.dict("os.environ", mock_env):
+            new_connector = Factory.create({"test connector": self.CONFIG})
+            assert isinstance(new_connector, HttpInput)
+            new_connector.pipeline_index = 1
+            new_connector.setup()
+            assert new_connector.app
+            headers = {"Authorization": _basic_auth_str("wrong", "credentials")}
+            client = testing.TestClient(new_connector.app, headers=headers)
+            resp = client.post("/auth-json-two-creds", body=json.dumps(data))
+            assert resp.status_code == 401
 
     def test_endpoint_returns_200_on_correct_authorization_with_password_within_credentials_file(
         self, credentials_file_path

--- a/tests/unit/ng/connector/test_http_input.py
+++ b/tests/unit/ng/connector/test_http_input.py
@@ -49,7 +49,7 @@ input:
       - username: user
         password: password
       - username: user2
-        password: password2
+        password_file: {secret_file_path}
 """)
 
     return str(credential_file_path)
@@ -410,7 +410,7 @@ class TestHttpConnector(BaseInputTestCase):
             new_connector.pipeline_index = 1
             new_connector.setup()
             assert new_connector.app
-            headers = {"Authorization": _basic_auth_str("user2", "password2")}
+            headers = {"Authorization": _basic_auth_str("user2", "secret_password")}
             client = testing.TestClient(new_connector.app, headers=headers)
             resp = client.post("/auth-json-two-creds", body=json.dumps(data))
             assert resp.status_code == 200

--- a/tests/unit/util/test_credentials.py
+++ b/tests/unit/util/test_credentials.py
@@ -388,7 +388,9 @@ class TestOAuth2PasswordFlowCredentials:
         )
         test._token.expiry_time = mock_expiry_time  # expire the token
         new_session = test.get_session()
-        assert new_session is not session, "new session should be returned for every refresh"
+        assert (
+            new_session.headers["Authorization"] == "Bearer very new token"
+        ), "new session should be returned for every refresh"
 
     @responses.activate
     def test_get_session_does_not_refresh_token_if_not_expired(self):
@@ -588,7 +590,6 @@ class TestOAuth2ClientFlowCredentials:
         test._token.expiry_time = mock_expiry_time  # expire the token
         # end prepare mock
         session = test.get_session()
-        assert test._session is session
         assert session.headers.get("Authorization") == "Bearer new toooken", "new should be used"
         # next refresh with new refresh token
         responses.add(
@@ -614,8 +615,9 @@ class TestOAuth2ClientFlowCredentials:
         )
         test._token.expiry_time = mock_expiry_time  # expire the token
         new_session = test.get_session()
-        assert new_session is not session, "new session should be returned for every refresh"
-        assert test._session is new_session, "new session should be used here"
+        assert (
+            new_session.headers.get("Authorization") == "Bearer very new token"
+        ), "new session should be returned for every refresh"
 
     @pytest.mark.parametrize(
         "error_reason",


### PR DESCRIPTION
## Description
make it possible to assign multiple credentials to a single endpoint

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

Run pytests

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--938.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->