### PR TITLE
test: add test case for moving nested fields in field manager

### DIFF
--- a/tests/unit/processor/field_manager/test_field_manager.py
+++ b/tests/unit/processor/field_manager/test_field_manager.py
@@ -575,6 +575,81 @@ test_cases = [  # testcase, rule, event, expected
         {"host": "example.com"},
         {"host": {"name": "example.com"}},
     ),
+    (
+        "move trees",
+        {
+            "filter": "kubernetes.labels",
+            "field_manager": {
+                "mapping": {
+                    "kubernetes.labels": "orchestrator.resources.labels",
+                },
+                "overwrite_target": False,
+                "delete_source_fields": True,
+            },
+        },
+        {
+            "time": "2025-12-11T13:08:38.152495266Z",
+            "logtag": "F",
+            "message": "2025-12-11T13:08:38.152Z [INFO]  storage.raft: snapshot complete up to: index=1234567890",
+            "tags": "intdev,",
+            "kubernetes": {
+                "labels": {
+                    "app.kubernetes.io/name": "vault",
+                    "apps.kubernetes.io/pod-index": "2",
+                    "controller-revision-hash": "vault-123456789",
+                    "statefulset.kubernetes.io/pod-name": "vault-2",
+                    "vault-active": "false",
+                    "vault-initialized": "true",
+                    "vault-perf-standby": "true",
+                    "vault-sealed": "false",
+                    "vault-version": "1.17.5-ent",
+                    "vault_cr": "vault",
+                },
+                "annotations": {
+                    "common/annotation": "true",
+                    "prometheus.io/path": "/metrics",
+                    "prometheus.io/port": "9102",
+                    "prometheus.io/scrape": "true",
+                    "type/instance": "vault",
+                    "vault.banzaicloud.io/tls-expiration-date": "2026-08-29T11:39:20Z",
+                    "vault.banzaicloud.io/vault-config": "aaaaaaaaaabbbbbbbbbbcccccccccc9620589d2a8603aa9e599d45677b67389a",
+                },
+            },
+        },
+        {
+            "time": "2025-12-11T13:08:38.152495266Z",
+            "logtag": "F",
+            "message": "2025-12-11T13:08:38.152Z [INFO]  storage.raft: snapshot complete up to: index=1234567890",
+            "tags": "intdev,",
+            "kubernetes": {
+                "annotations": {
+                    "common/annotation": "true",
+                    "prometheus.io/path": "/metrics",
+                    "prometheus.io/port": "9102",
+                    "prometheus.io/scrape": "true",
+                    "type/instance": "vault",
+                    "vault.banzaicloud.io/tls-expiration-date": "2026-08-29T11:39:20Z",
+                    "vault.banzaicloud.io/vault-config": "aaaaaaaaaabbbbbbbbbbcccccccccc9620589d2a8603aa9e599d45677b67389a",
+                }
+            },
+            "orchestrator": {
+                "resources": {
+                    "labels": {
+                        "app.kubernetes.io/name": "vault",
+                        "apps.kubernetes.io/pod-index": "2",
+                        "controller-revision-hash": "vault-123456789",
+                        "statefulset.kubernetes.io/pod-name": "vault-2",
+                        "vault-active": "false",
+                        "vault-initialized": "true",
+                        "vault-perf-standby": "true",
+                        "vault-sealed": "false",
+                        "vault-version": "1.17.5-ent",
+                        "vault_cr": "vault",
+                    }
+                }
+            },
+        },
+    ),
 ]
 
 failure_test_cases = [

--- a/tests/unit/processor/field_manager/test_field_manager.py
+++ b/tests/unit/processor/field_manager/test_field_manager.py
@@ -576,7 +576,7 @@ test_cases = [  # testcase, rule, event, expected
         {"host": {"name": "example.com"}},
     ),
     (
-        "move trees",
+        "move tree",
         {
             "filter": "kubernetes.labels",
             "field_manager": {
@@ -588,48 +588,23 @@ test_cases = [  # testcase, rule, event, expected
             },
         },
         {
-            "time": "2025-12-11T13:08:38.152495266Z",
-            "logtag": "F",
-            "message": "2025-12-11T13:08:38.152Z [INFO]  storage.raft: snapshot complete up to: index=1234567890",
-            "tags": "intdev,",
+            "keep": "this unchanged",
             "kubernetes": {
                 "labels": {
                     "app.kubernetes.io/name": "vault",
                     "apps.kubernetes.io/pod-index": "2",
                     "controller-revision-hash": "vault-123456789",
-                    "statefulset.kubernetes.io/pod-name": "vault-2",
-                    "vault-active": "false",
-                    "vault-initialized": "true",
-                    "vault-perf-standby": "true",
-                    "vault-sealed": "false",
-                    "vault-version": "1.17.5-ent",
-                    "vault_cr": "vault",
                 },
                 "annotations": {
                     "common/annotation": "true",
-                    "prometheus.io/path": "/metrics",
-                    "prometheus.io/port": "9102",
-                    "prometheus.io/scrape": "true",
-                    "type/instance": "vault",
-                    "vault.banzaicloud.io/tls-expiration-date": "2026-08-29T11:39:20Z",
-                    "vault.banzaicloud.io/vault-config": "aaaaaaaaaabbbbbbbbbbcccccccccc9620589d2a8603aa9e599d45677b67389a",
                 },
             },
         },
         {
-            "time": "2025-12-11T13:08:38.152495266Z",
-            "logtag": "F",
-            "message": "2025-12-11T13:08:38.152Z [INFO]  storage.raft: snapshot complete up to: index=1234567890",
-            "tags": "intdev,",
+            "keep": "this unchanged",
             "kubernetes": {
                 "annotations": {
                     "common/annotation": "true",
-                    "prometheus.io/path": "/metrics",
-                    "prometheus.io/port": "9102",
-                    "prometheus.io/scrape": "true",
-                    "type/instance": "vault",
-                    "vault.banzaicloud.io/tls-expiration-date": "2026-08-29T11:39:20Z",
-                    "vault.banzaicloud.io/vault-config": "aaaaaaaaaabbbbbbbbbbcccccccccc9620589d2a8603aa9e599d45677b67389a",
                 }
             },
             "orchestrator": {
@@ -638,13 +613,6 @@ test_cases = [  # testcase, rule, event, expected
                         "app.kubernetes.io/name": "vault",
                         "apps.kubernetes.io/pod-index": "2",
                         "controller-revision-hash": "vault-123456789",
-                        "statefulset.kubernetes.io/pod-name": "vault-2",
-                        "vault-active": "false",
-                        "vault-initialized": "true",
-                        "vault-perf-standby": "true",
-                        "vault-sealed": "false",
-                        "vault-version": "1.17.5-ent",
-                        "vault_cr": "vault",
                     }
                 }
             },


### PR DESCRIPTION
## Description

* add a test case for moving trees in field manager

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* ran pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--956.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->