### PR TITLE
Fix unhandled luceneerror

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
                 "examples/exampledata/config/pipeline.yml"
             ],
             "env": {
-                "PROMETHEUS_MULTIPROC_DIR": "tmp/logprep"
+                "PROMETHEUS_MULTIPROC_DIR": "/tmp/logprep"
             },
             "justMyCode": false
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugfix
 * properly handle trailing newlines in lucene filters
+* properly handle lucene filters ending unexpectedly
 
 
 ## 19.0.0

--- a/examples/exampledata/config/pipeline.yml
+++ b/examples/exampledata/config/pipeline.yml
@@ -34,7 +34,7 @@ pipeline:
       type: dropper
       rules:
         - examples/exampledata/rules/dropper/rules
-        - filter: "test_dropper OR"
+        - filter: "test_dropper"
           dropper:
             drop:
               - drop_me

--- a/examples/exampledata/config/pipeline.yml
+++ b/examples/exampledata/config/pipeline.yml
@@ -34,7 +34,7 @@ pipeline:
       type: dropper
       rules:
         - examples/exampledata/rules/dropper/rules
-        - filter: "test_dropper"
+        - filter: "test_dropper OR"
           dropper:
             drop:
               - drop_me

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -110,7 +110,7 @@ from luqum.tree import (
     SearchField,
     Word,
 )
-
+from logprep.abc.exceptions import LogprepException
 from logprep.filter.expression.filter_expression import (
     Always,
     And,
@@ -133,7 +133,7 @@ from logprep.util.helper import field_list_to_dotted_field, get_dotted_field_lis
 logger = logging.getLogger("LuceneFilter")
 
 
-class LuceneFilterError(Exception):
+class LuceneFilterError(LogprepException):
     """Base class for LuceneFilter related exceptions."""
 
 

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -194,12 +194,13 @@ from __future__ import annotations  # Fixes mypy reporting wrong lines
 import json
 import logging
 import os
+import typing
 from copy import deepcopy
 from importlib.metadata import version
 from itertools import chain
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Any, cast, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
 from attrs import asdict, define, field, fields, validators
 from requests import RequestException
 from ruamel.yaml import YAML
@@ -256,7 +257,7 @@ class InvalidConfigurationErrors(InvalidConfigurationError):
 
     errors: List[InvalidConfigurationError]
 
-    def __init__(self, errors: Sequence[Exception]) -> None:
+    def __init__(self, errors: List[Exception]) -> None:
         unique_errors = []
         for error in errors:
             if not isinstance(error, InvalidConfigurationError):
@@ -1027,8 +1028,8 @@ class Configuration:
         for processor_config in self.pipeline:
             processor = None
             try:
-                processor_component = Factory.create(deepcopy(processor_config))
-                processor = cast(Processor, processor_component)
+                processor = Factory.create(deepcopy(processor_config))
+                processor = typing.cast(processor)
                 processor.setup()
                 self._verify_rules(processor)
             except (

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -190,7 +190,6 @@ The following config file will be valid by setting the given environment variabl
                 group.id: test"
 """
 
-from __future__ import annotations  # Fixes mypy reporting wrong lines
 import json
 import logging
 import os

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -1030,6 +1030,7 @@ class Configuration:
         for processor_config in self.pipeline:
             processor = None
             try:
+                processor = Factory.create(deepcopy(processor_config))
                 if isinstance(processor, Processor):
                     processor.setup()
                     self._verify_rules(processor)

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -200,7 +200,7 @@ from importlib.metadata import version
 from itertools import chain
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, Sequence
 from attrs import asdict, define, field, fields, validators
 from requests import RequestException
 from ruamel.yaml import YAML
@@ -255,9 +255,9 @@ yaml = MyYAML(pure=True)
 class InvalidConfigurationErrors(InvalidConfigurationError):
     """Raise for multiple Configuration related exceptions."""
 
-    errors: List[InvalidConfigurationError]
+    errors: list[InvalidConfigurationError]
 
-    def __init__(self, errors: List[Exception]) -> None:
+    def __init__(self, errors: list[Exception]) -> None:
         unique_errors = []
         for error in errors:
             if not isinstance(error, InvalidConfigurationError):
@@ -480,7 +480,7 @@ class Configuration:
     can be printed via :code:`logprep run --version config/pipeline.yml`.
     This has no effect on the execution of logprep but is used as hook for reloading
     the configuration. Defaults to :code:`unset`."""
-    config_refresh_interval: Optional[int] = field(
+    config_refresh_interval: int | None = field(
         validator=validators.instance_of((int, type(None))), default=None, eq=False
     )
     """Configures the interval in seconds on which logprep should try to reload the configuration.
@@ -643,7 +643,7 @@ class Configuration:
         eq=False,
     )
 
-    _configs: Tuple["Configuration", ...] = field(
+    _configs: tuple["Configuration", ...] = field(
         validator=validators.instance_of(tuple), factory=tuple, repr=False, eq=False
     )
 
@@ -780,8 +780,8 @@ class Configuration:
         """
         if not config_paths:
             config_paths = [DEFAULT_CONFIG_LOCATION]
-        errors = []
-        configs: List[Configuration] = []
+        errors: list[Exception] = []
+        configs: list[Configuration] = []
         for config_path in config_paths:
             try:
                 config = Configuration.from_source(config_path)
@@ -861,7 +861,7 @@ class Configuration:
         InvalidConfigurationErrors
             If the configuration is invalid.
         """
-        errors: List[Exception] = []
+        errors: list[Exception] = []
         try:
             new_config = Configuration.from_sources(self.config_paths)
             if new_config.config_refresh_interval is None:
@@ -951,7 +951,7 @@ class Configuration:
     def _build_merged_pipeline(self) -> None:
         pipelines = (config.pipeline for config in self._configs if config.pipeline)
         pipeline = list(chain(*pipelines))
-        errors = []
+        errors: list[Exception] = []
         pipeline_with_loaded_rules = []
         for processor_definition in pipeline:
             try:
@@ -1029,7 +1029,7 @@ class Configuration:
             processor = None
             try:
                 processor = Factory.create(deepcopy(processor_config))
-                processor = typing.cast(processor)
+                processor = typing.cast(Processor, processor)
                 processor.setup()
                 self._verify_rules(processor)
             except (

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -639,7 +639,7 @@ class Configuration:
     _metrics: "Configuration.Metrics" = field(init=False, repr=False, eq=False)
 
     _getter: Getter = field(
-        validator=validators.instance_of(Getter),
+        validator=validators.instance_of(Getter),  # type: ignore
         default=GetterFactory.from_string(DEFAULT_CONFIG_LOCATION),
         repr=False,
         eq=False,
@@ -1030,8 +1030,7 @@ class Configuration:
         for processor_config in self.pipeline:
             processor = None
             try:
-                processor = Factory.create(deepcopy(processor_config))
-                if processor is not None:
+                if isinstance(processor, Processor):
                     processor.setup()
                     self._verify_rules(processor)
             except (

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -193,6 +193,7 @@ The following config file will be valid by setting the given environment variabl
 import json
 import logging
 import os
+from __future__ import annotations  # Fixes mypy reporting wrong lines
 from copy import deepcopy
 from importlib.metadata import version
 from itertools import chain
@@ -256,9 +257,11 @@ class InvalidConfigurationErrors(InvalidConfigurationError):
 
     errors: List[InvalidConfigurationError]
 
-    def __init__(self, errors: List[Exception]) -> None:
+    def __init__(self, errors: List) -> None:
         unique_errors = []
         for error in errors:
+            if not isinstance(error, Exception):
+                raise TypeError(f'Error {error} is not of expected type "Exception"')
             if not isinstance(error, InvalidConfigurationError):
                 error = InvalidConfigurationError(*error.args)
                 if error not in unique_errors:
@@ -1028,8 +1031,9 @@ class Configuration:
             processor = None
             try:
                 processor = Factory.create(deepcopy(processor_config))
-                processor.setup()
-                self._verify_rules(processor)
+                if processor is not None:
+                    processor.setup()
+                    self._verify_rules(processor)
             except (
                 FactoryError,
                 TypeError,

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -190,10 +190,10 @@ The following config file will be valid by setting the given environment variabl
                 group.id: test"
 """
 
+from __future__ import annotations  # Fixes mypy reporting wrong lines
 import json
 import logging
 import os
-from __future__ import annotations  # Fixes mypy reporting wrong lines
 from copy import deepcopy
 from importlib.metadata import version
 from itertools import chain

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -212,6 +212,7 @@ from logprep.abc.getter import Getter
 from logprep.abc.processor import Processor
 from logprep.factory import Factory
 from logprep.factory_error import FactoryError, InvalidConfigurationError
+from logprep.filter.lucene_filter import LuceneFilterError
 from logprep.metrics.metrics import CounterMetric, GaugeMetric
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.util import http
@@ -961,6 +962,7 @@ class Configuration:
                 ValueError,
                 InvalidRuleDefinitionError,
                 RefreshableGetterError,
+                LuceneFilterError,
             ) as error:
                 errors.append(error)
         if errors:
@@ -1034,6 +1036,7 @@ class Configuration:
                 ValueError,
                 InvalidRuleDefinitionError,
                 RefreshableGetterError,
+                LuceneFilterError,
             ) as error:
                 errors.append(error)
             except FileNotFoundError as error:

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -199,8 +199,7 @@ from importlib.metadata import version
 from itertools import chain
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Sequence, Tuple
-
+from typing import Any, cast, Iterable, List, Optional, Sequence, Tuple
 from attrs import asdict, define, field, fields, validators
 from requests import RequestException
 from ruamel.yaml import YAML
@@ -257,11 +256,9 @@ class InvalidConfigurationErrors(InvalidConfigurationError):
 
     errors: List[InvalidConfigurationError]
 
-    def __init__(self, errors: List) -> None:
+    def __init__(self, errors: Sequence[Exception]) -> None:
         unique_errors = []
         for error in errors:
-            if not isinstance(error, Exception):
-                raise TypeError(f'Error {error} is not of expected type "Exception"')
             if not isinstance(error, InvalidConfigurationError):
                 error = InvalidConfigurationError(*error.args)
                 if error not in unique_errors:
@@ -1030,10 +1027,10 @@ class Configuration:
         for processor_config in self.pipeline:
             processor = None
             try:
-                processor = Factory.create(deepcopy(processor_config))
-                if isinstance(processor, Processor):
-                    processor.setup()
-                    self._verify_rules(processor)
+                processor_component = Factory.create(deepcopy(processor_config))
+                processor = cast(Processor, processor_component)
+                processor.setup()
+                self._verify_rules(processor)
             except (
                 FactoryError,
                 TypeError,

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -507,15 +507,16 @@ pipeline:
                       - drop_me
                   description: "..."
         """,
+            "unexpected end of expression",
             id="lucene filter definition ends unexpectedly",
         ),
     ]
 
-    @pytest.mark.parametrize("test_config", invalid_config_test_cases)
-    def test_from_sources_error_handling(self, tmp_path, test_config):
+    @pytest.mark.parametrize("test_config, expected_msg", invalid_config_test_cases)
+    def test_from_sources_error_handling(self, tmp_path, test_config, expected_msg):
         test_config_path = tmp_path / "failure-from_sources.yml"
         test_config_path.write_text(test_config)
-        with pytest.raises(InvalidConfigurationError, match="unexpected end of expression"):
+        with pytest.raises(InvalidConfigurationError, match=expected_msg):
             Configuration.from_sources((str(test_config_path),))
 
     patch = mock.patch(

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -481,10 +481,9 @@ pipeline:
         else:
             Configuration.from_sources([str(test_config_path)])
 
-
     invalid_config_test_cases = [
         pytest.param(
-        """
+            """
         version: test_version
         process_count: 2
         timeout: 0.1
@@ -508,19 +507,16 @@ pipeline:
                       - drop_me
                   description: "..."
         """,
-        id="lucene filter definition ends unexpectedly"
+            id="lucene filter definition ends unexpectedly",
         ),
     ]
-    @pytest.mark.parametrize(
-            "test_config",
-            invalid_config_test_cases
-        )
+
+    @pytest.mark.parametrize("test_config", invalid_config_test_cases)
     def test_from_sources_error_handling(self, tmp_path, test_config):
         test_config_path = tmp_path / "failure-from_sources.yml"
         test_config_path.write_text(test_config)
         with pytest.raises(InvalidConfigurationError, match="unexpected end of expression"):
             Configuration.from_sources((str(test_config_path),))
-
 
     patch = mock.patch(
         "os.environ",

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -515,8 +515,8 @@ pipeline:
             "test_config",
             invalid_config_test_cases
         )
-    def test_invalid_config_error_handling(self, tmp_path, test_config):
-        test_config_path = tmp_path / "failure-unexpected_end.yml"
+    def test_from_sources_error_handling(self, tmp_path, test_config):
+        test_config_path = tmp_path / "failure-from_sources.yml"
         test_config_path.write_text(test_config)
         with pytest.raises(InvalidConfigurationError, match="unexpected end of expression"):
             Configuration.from_sources((str(test_config_path),))

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -482,50 +482,44 @@ pipeline:
             Configuration.from_sources([str(test_config_path)])
 
 
+    invalid_config_test_cases = [
+        pytest.param(
+        """
+        version: test_version
+        process_count: 2
+        timeout: 0.1
+        logger:
+            level: DEBUG
+        input:
+            dummy:
+                type: dummy_input
+                documents: []
+        output:
+            dummy:
+                type: dummy_output
+        pipeline:
+          - dropper:
+              type: dropper
+              rules:
+                - examples/exampledata/rules/dropper/rules
+                - filter: "test_dropper OR"
+                  dropper:
+                    drop:
+                      - drop_me
+                  description: "..."
+        """,
+        id="lucene filter definition ends unexpectedly"
+        ),
+    ]
     @pytest.mark.parametrize(
-        "test_case, test_config, error_type",
-        [
-            ("dropper filter with AND/OR at the end",
-                {
-                    "pipeline": [{
-                            "dropper":{
-                                "type": "dropper",
-                                "rules":[
-                                    #"examples/exampledata/rules/dropper/rules",
-                                    {
-                                        "filter": "test_dropper OR",
-                                    }
-                                ],
-                            }
-                        }
-                    ],
-                },
-                InvalidConfigurationError,
-            ),
-        ]
-    )
-
-    def test_catch_as_invalidconfigurationerror(self, tmp_path, test_case, test_config, error_type):
-        test_config_path = tmp_path / "failure-config.yml"
-        test_config = Configuration(**test_config)
-        if not test_config.input:
-            test_config.input = {"dummy": {"type": "dummy_input", "documents": []}}
-        if not test_config.output:
-            test_config.output = {"dummy": {"type": "dummy_output"}}
-        test_config_path.write_text(test_config.as_yaml())
-        try:
+            "test_config",
+            invalid_config_test_cases
+        )
+    def test_invalid_config_error_handling(self, tmp_path, test_config):
+        test_config_path = tmp_path / "failure-unexpected_end.yml"
+        test_config_path.write_text(test_config)
+        with pytest.raises(InvalidConfigurationError, match="unexpected end of expression"):
             Configuration.from_sources((str(test_config_path),))
-        except InvalidConfigurationErrors as e:
-            print(e)
-#        if error_type:
-#            with pytest.raises(InvalidConfigurationError) as raised:
-#                Configuration.from_source(str(test_config_path))
-#            assert raised.value.errors == error_type, test_case
-#        else:
-#            Configuration.from_sources([str(test_config_path)])
-
-
-
 
 
     patch = mock.patch(

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -53,11 +53,11 @@ class TestConfiguration:
             ("config_refresh_interval", type(None), None),
             ("process_count", int, 1),
             ("timeout", float, 5.0),
-            ("logger", LoggerConfig, LoggerConfig(**{"level": "INFO"})),
+            ("logger", LoggerConfig, LoggerConfig(level="INFO")),
             ("pipeline", list, []),
             ("input", dict, {}),
             ("output", dict, {}),
-            ("metrics", MetricsConfig, MetricsConfig(**{"enabled": False, "port": 8000})),
+            ("metrics", MetricsConfig, MetricsConfig(enabled=False, port=8000)),
         ],
     )
     def test_configuration_init(self, attribute, attribute_type, default):

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -16,6 +16,7 @@ from attrs import asdict
 from requests.exceptions import HTTPError
 from ruamel.yaml.scanner import ScannerError
 
+from logprep.filter.lucene_filter import LuceneFilterError
 from logprep.util.configuration import (
     Configuration,
     InvalidConfigurationError,
@@ -479,6 +480,53 @@ pipeline:
             assert len(raised.value.errors) == error_count, test_case
         else:
             Configuration.from_sources([str(test_config_path)])
+
+
+    @pytest.mark.parametrize(
+        "test_case, test_config, error_type",
+        [
+            ("dropper filter with AND/OR at the end",
+                {
+                    "pipeline": [{
+                            "dropper":{
+                                "type": "dropper",
+                                "rules":[
+                                    #"examples/exampledata/rules/dropper/rules",
+                                    {
+                                        "filter": "test_dropper OR",
+                                    }
+                                ],
+                            }
+                        }
+                    ],
+                },
+                InvalidConfigurationError,
+            ),
+        ]
+    )
+
+    def test_catch_as_invalidconfigurationerror(self, tmp_path, test_case, test_config, error_type):
+        test_config_path = tmp_path / "failure-config.yml"
+        test_config = Configuration(**test_config)
+        if not test_config.input:
+            test_config.input = {"dummy": {"type": "dummy_input", "documents": []}}
+        if not test_config.output:
+            test_config.output = {"dummy": {"type": "dummy_output"}}
+        test_config_path.write_text(test_config.as_yaml())
+        try:
+            Configuration.from_sources((str(test_config_path),))
+        except InvalidConfigurationErrors as e:
+            print(e)
+#        if error_type:
+#            with pytest.raises(InvalidConfigurationError) as raised:
+#                Configuration.from_source(str(test_config_path))
+#            assert raised.value.errors == error_type, test_case
+#        else:
+#            Configuration.from_sources([str(test_config_path)])
+
+
+
+
 
     patch = mock.patch(
         "os.environ",
@@ -1463,11 +1511,13 @@ class TestInvalidConfigurationErrors:
                     InvalidConfigurationError("test"),
                     TypeError("typeerror"),
                     ValueError("valueerror"),
+                    LuceneFilterError("lucenefiltererror"),
                 ],
                 [
                     InvalidConfigurationError("test"),
                     InvalidConfigurationError("typeerror"),
                     InvalidConfigurationError("valueerror"),
+                    InvalidConfigurationError("lucenefiltererror"),
                 ],
             ),
         ],


### PR DESCRIPTION
## Description

Fixed unhandled error for filter definitions / rules ending unexpectedly. 
Added tests for those changes, fixed some tests that caused mypy errors.

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* List of (preferably easy reproducible) tests including OS

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--957.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->