### PR TITLE
dev: json support httpgetter

### DIFF
--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -5,8 +5,9 @@ import os
 import re
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from email.headerregistry import ContentTypeHeader
 from string import Template
-from typing import Dict, List, Union
+from typing import Dict, List, TypeAlias, Union
 
 from attrs import define, field, validators
 from ruamel.yaml import YAML, YAMLError
@@ -21,6 +22,11 @@ BLOCKLIST_VARIABLE_NAMES = [
 
 VALID_PREFIXES = ["LOGPREP_", "CI_", "GITHUB_", "PYTEST_"]
 
+# TODO: get config informations for related processor and pass it to the _get method:
+CONTENT_JSON_KEY = "content"
+
+ContentType: TypeAlias = str
+
 
 @define(kw_only=True)
 class Getter(ABC):
@@ -30,13 +36,13 @@ class Getter(ABC):
         """Template class for uppercase only template variables"""
 
         pattern = r"""
-        \$(?:
-            (?P<escaped>\$\$\$)|
-            (?P<named>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)|
-            {(?P<braced>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)}|
-            (?P<invalid>)
-        )
-        """
+            \$(?:
+                (?P<escaped>\$\$\$)|
+                (?P<named>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)|
+                {(?P<braced>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)}|
+                (?P<invalid>)
+            )
+            """  # type: ignore[assignment]
         flags = re.VERBOSE
 
     protocol: str = field(validator=validators.instance_of(str))
@@ -54,10 +60,36 @@ class Getter(ABC):
     )
     """used variables in content but not set in environment"""
 
-    def get(self) -> str:
+    content_type: ContentType | None = None
+    """content/mime type of the underlying content, defaults to None"""
+
+    def get(self) -> str | list:
         """calls the get_raw method, decodes the bytes to string and
         enriches by environment variables.
         """
+
+        match self.content_type:
+            case "application/json":
+                json_content: dict | list = self.get_json()
+
+                if isinstance(json_content, list):
+                    return json_content
+                elif isinstance(json_content, dict):
+                    content = json_content.get(CONTENT_JSON_KEY)
+
+                    if content is None:
+                        raise ValueError(f"Content key not found: '{CONTENT_JSON_KEY}'")
+
+                    return content
+                else:
+                    raise ValueError(f"Expected json dict in Getter content")
+
+            case "text/plain":
+                return self._substitute_raw_content().splitlines()
+            case _:
+                return self._substitute_raw_content()
+
+    def _substitute_raw_content(self):
         content = self.get_raw().decode("utf8")
         template = self.EnvTemplate(content)
         kwargs = self._get_kwargs(template, content)
@@ -81,7 +113,7 @@ class Getter(ABC):
 
     def get_yaml(self) -> Union[Dict, List]:
         """gets and parses the raw content to yaml"""
-        raw = self.get()
+        raw = self._substitute_raw_content()
         parsed_yaml = list(yaml.load_all(raw))
         if not parsed_yaml:
             return {}
@@ -91,7 +123,7 @@ class Getter(ABC):
 
     def get_json(self) -> Union[Dict, List]:
         """gets and parses the raw content to json"""
-        return json.loads(self.get())
+        return json.loads(self._substitute_raw_content())
 
     def get_collection(self) -> Union[Dict, List]:
         """Gets and parses the raw content to yaml or json if yaml fails"""
@@ -117,7 +149,7 @@ class Getter(ABC):
     def get_jsonl(self) -> List:
         """Gets and parses the raw content to jsonl"""
         parsed_events = []
-        for json_string in self.get().splitlines():
+        for json_string in self._substitute_raw_content().splitlines():
             if json_string.strip() != "":
                 event = json.loads(json_string)
                 parsed_events.append(event)

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -5,9 +5,8 @@ import os
 import re
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from email.headerregistry import ContentTypeHeader
 from string import Template
-from typing import Dict, List, TypeAlias, Union
+from typing import TypeAlias
 
 from attrs import define, field, validators
 from ruamel.yaml import YAML, YAMLError
@@ -21,9 +20,6 @@ BLOCKLIST_VARIABLE_NAMES = [
 ]
 
 VALID_PREFIXES = ["LOGPREP_", "CI_", "GITHUB_", "PYTEST_"]
-
-# TODO: get config informations for related processor and pass it to the _get method:
-CONTENT_JSON_KEY = "content"
 
 ContentType: TypeAlias = str
 
@@ -60,36 +56,13 @@ class Getter(ABC):
     )
     """used variables in content but not set in environment"""
 
-    content_type: ContentType | None = None
-    """content/mime type of the underlying content, defaults to None"""
-
-    def get(self) -> str | list:
+    def get(self) -> dict | list | str:
         """calls the get_raw method, decodes the bytes to string and
         enriches by environment variables.
         """
+        return self._substitute_raw_content()
 
-        match self.content_type:
-            case "application/json":
-                json_content: dict | list = self.get_json()
-
-                if isinstance(json_content, list):
-                    return json_content
-                elif isinstance(json_content, dict):
-                    content = json_content.get(CONTENT_JSON_KEY)
-
-                    if content is None:
-                        raise ValueError(f"Content key not found: '{CONTENT_JSON_KEY}'")
-
-                    return content
-                else:
-                    raise ValueError(f"Expected json dict in Getter content")
-
-            case "text/plain":
-                return self._substitute_raw_content().splitlines()
-            case _:
-                return self._substitute_raw_content()
-
-    def _substitute_raw_content(self):
+    def _substitute_raw_content(self) -> str:
         content = self.get_raw().decode("utf8")
         template = self.EnvTemplate(content)
         kwargs = self._get_kwargs(template, content)
@@ -111,21 +84,29 @@ class Getter(ABC):
         used_braced_env_vars = map(lambda x: x[2], found_variables)
         return (item for item in {*used_named_env_vars, *used_braced_env_vars} if item)
 
-    def get_yaml(self) -> Union[Dict, List]:
+    def get_yaml(self) -> dict | list:
         """gets and parses the raw content to yaml"""
-        raw = self._substitute_raw_content()
-        parsed_yaml = list(yaml.load_all(raw))
+        content = self._substitute_raw_content()
+        return self.parse_yaml(content)
+
+    def parse_yaml(self, content: str) -> dict | list:
+        parsed_yaml = list(yaml.load_all(content))
         if not parsed_yaml:
             return {}
         if len(parsed_yaml) > 1:
             return parsed_yaml
         return parsed_yaml.pop()
 
-    def get_json(self) -> Union[Dict, List]:
+    def get_json(self) -> dict | list:
         """gets and parses the raw content to json"""
-        return json.loads(self._substitute_raw_content())
+        content = self._substitute_raw_content()
+        return self.parse_json(content)
 
-    def get_collection(self) -> Union[Dict, List]:
+    def parse_json(self, content: str) -> dict | list:
+        """parses the content to json"""
+        return json.loads(content)
+
+    def get_collection(self) -> dict | list:
         """Gets and parses the raw content to yaml or json if yaml fails"""
         try:
             return self.get_yaml()
@@ -139,21 +120,22 @@ class Getter(ABC):
             raise ValueError("Value is not a dictionary")
         return result
 
-    def get_list(self) -> list:
-        """Gets list and fails otherwise"""
-        result = self.get_collection()
-        if not isinstance(result, list):
-            raise ValueError("Value is not a list")
-        return result
+    def parse_list(self, content: str) -> list:
+        """parses the content to list"""
+        return content.splitlines()
 
-    def get_jsonl(self) -> List:
+    def get_jsonl(self) -> list:
         """Gets and parses the raw content to jsonl"""
         parsed_events = []
-        for json_string in self._substitute_raw_content().splitlines():
-            if json_string.strip() != "":
-                event = json.loads(json_string)
+        for content in self.parse_list(self._substitute_raw_content()):
+            if content.strip() != "":
+                event = self.parse_json(content)
                 parsed_events.append(event)
         return parsed_events
+
+    def parse_jsonl(self, content: str) -> list:
+        """parses the content to jsonl"""
+        return json.loads(content)
 
     @abstractmethod
     def get_raw(self) -> bytes:

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -125,8 +125,13 @@ class ListComparisonRule(FieldManagerRule):
             http_getter.add_callback(self._update_compare_sets_via_http, http_getter, list_path)
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
-        compare_elements: list[str] = http_getter.get()
-        self._compare_sets.update({list_path: set(compare_elements)})
+        compare_elements = http_getter.get()
+
+        if isinstance(compare_elements, str):
+            compare_elements = http_getter.parse_list(compare_elements)
+
+        file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
+        self._compare_sets.update({list_path: set(file_elem_tuples)})
 
     def _init_list_comparison_from_local_file(self, list_search_base_path: str) -> None:
         absolute_list_paths = [
@@ -141,12 +146,14 @@ class ListComparisonRule(FieldManagerRule):
         ]
         list_paths = [*absolute_list_paths, *converted_absolute_list_paths]
         for list_path in list_paths:
-            content: str | list = GetterFactory.from_string(list_path).get()
+            content: str | list | dict = GetterFactory.from_string(list_path).get()
 
             if isinstance(content, str):
                 compare_elements = content.splitlines()
-            else:
+            elif isinstance(content, list):
                 compare_elements = content
+            else:
+                raise TypeError(f"The content must be a string or a list")
 
             file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
             filename = os.path.basename(list_path)

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -125,7 +125,7 @@ class ListComparisonRule(FieldManagerRule):
             http_getter.add_callback(self._update_compare_sets_via_http, http_getter, list_path)
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
-        compare_elements: list[str] = http_getter.get_list()
+        compare_elements: list[str] = http_getter.get()
         self._compare_sets.update({list_path: set(compare_elements)})
 
     def _init_list_comparison_from_local_file(self, list_search_base_path: str) -> None:
@@ -141,8 +141,13 @@ class ListComparisonRule(FieldManagerRule):
         ]
         list_paths = [*absolute_list_paths, *converted_absolute_list_paths]
         for list_path in list_paths:
-            content = GetterFactory.from_string(list_path).get()
-            compare_elements = content.splitlines()
+            content: str | list = GetterFactory.from_string(list_path).get()
+
+            if isinstance(content, str):
+                compare_elements = content.splitlines()
+            else:
+                compare_elements = content
+
             file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
             filename = os.path.basename(list_path)
             self._compare_sets.update({filename: set(file_elem_tuples)})

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -126,10 +126,7 @@ class ListComparisonRule(FieldManagerRule):
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
         compare_elements: list[str] = http_getter.get_list()
-        file_elem_tuples = (
-            elem for elem in compare_elements if not elem.startswith("#")
-        )  # TODO: 13304
-        self._compare_sets.update({list_path: set(file_elem_tuples)})
+        self._compare_sets.update({list_path: set(compare_elements)})
 
     def _init_list_comparison_from_local_file(self, list_search_base_path: str) -> None:
         absolute_list_paths = [

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -43,7 +43,7 @@ target field :code:`List_comparison.example`.
 
 import os.path
 from string import Template
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from attrs import define, field, validators
 
@@ -146,10 +146,11 @@ class ListComparisonRule(FieldManagerRule):
         ]
         list_paths = [*absolute_list_paths, *converted_absolute_list_paths]
         for list_path in list_paths:
-            content: str | list | dict = GetterFactory.from_string(list_path).get()
+            getter = GetterFactory.from_string(list_path)
+            content: str | list | dict = getter.get()
 
             if isinstance(content, str):
-                compare_elements = content.splitlines()
+                compare_elements = getter.parse_list(cast(str, content))
             elif isinstance(content, list):
                 compare_elements = content
             else:

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -88,7 +88,12 @@ class ListComparisonRule(FieldManagerRule):
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
 
-    def __init__(self, filter_rule: FilterExpression, config: dict, processor_name: str):
+    def __init__(
+        self,
+        filter_rule: FilterExpression,
+        config: "ListComparisonRule.Config",
+        processor_name: str,
+    ):
         super().__init__(filter_rule, config, processor_name)
         self._config: ListComparisonRule.Config = self._config
         self._compare_sets = {}
@@ -120,8 +125,10 @@ class ListComparisonRule(FieldManagerRule):
             http_getter.add_callback(self._update_compare_sets_via_http, http_getter, list_path)
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
-        compare_elements = http_getter.get().splitlines()
-        file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
+        compare_elements: list[str] = http_getter.get_list()
+        file_elem_tuples = (
+            elem for elem in compare_elements if not elem.startswith("#")
+        )  # TODO: 13304
         self._compare_sets.update({list_path: set(file_elem_tuples)})
 
     def _init_list_comparison_from_local_file(self, list_search_base_path: str) -> None:

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -11,12 +11,12 @@ from functools import cached_property
 from importlib.metadata import version
 from pathlib import Path
 from string import Template
-from typing import Tuple, ClassVar
+from typing import ClassVar, Tuple
 from urllib.parse import urlparse
 
 import requests
-from requests import Response
 from attrs import define, field, validators
+from requests import Response
 from schedule import Scheduler
 
 from logprep.abc.exceptions import LogprepException
@@ -26,7 +26,10 @@ from logprep.util.credentials import (
     CredentialsEnvNotFoundError,
     CredentialsFactory,
 )
-from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE, ENV_NAME_LOGPREP_GETTER_CONFIG
+from logprep.util.defaults import (
+    ENV_NAME_LOGPREP_CREDENTIALS_FILE,
+    ENV_NAME_LOGPREP_GETTER_CONFIG,
+)
 
 
 class GetterNotFoundError(LogprepException):
@@ -392,6 +395,7 @@ class HttpGetter(RefreshableGetter):
 
     def _get_from_target(self) -> tuple[bytes | None, bool]:
         response = self._do_request()
+        self._headers["Content-Type"] = response.headers["Content-Type"]
         was_modified = response.status_code != 304
         return response.content, was_modified
 
@@ -409,7 +413,7 @@ class HttpGetter(RefreshableGetter):
         except requests.exceptions.HTTPError as error:
             self._handle_http_error(error)
         if "etag" in resp.headers:
-            self.hash = resp.headers.get("etag")
+            self.hash = resp.headers["etag"]
         return resp
 
     def _get_requests_session(self) -> requests.Session:
@@ -434,6 +438,46 @@ class HttpGetter(RefreshableGetter):
                 f"'{ENV_NAME_LOGPREP_CREDENTIALS_FILE}'"
             )
         ) from error
+
+    def get_list(self) -> list[str]:
+        """Get the content as list based on header information.
+
+        This method calls the target URL to retrieve the initial header
+        information and initialize the cache state.
+
+        For the content type `application/json`, it defaults to using the
+        `content` key. This can also be configured via `content_json_key`
+        in the corresponding `list_comparison` or `network_comparison`
+        processor configuration.
+
+        See the configuration examples of these processors for details.
+        """
+
+        self._update_cache()
+
+        # TODO: get config informations for related processor and pass it to the _get method:
+        content_json_key = "content"
+
+        return self._get(content_json_key=content_json_key)
+
+    def _get(self, content_json_key: str) -> list[str]:
+        match ct := self._headers.get("Content-Type"):
+            case "application/json":
+                json_content = self.get_json()
+
+                if isinstance(json_content, dict):
+                    content = json_content.get(content_json_key)
+                    if content is None:
+                        raise RefreshableGetterError(f"Content key not found: '{content_json_key}'")
+                else:
+                    raise RefreshableGetterError(f"Expected json dict in HttpGetter content")
+
+            case "text/plain":
+                content = self.get().splitlines()
+            case _:
+                raise RefreshableGetterError(f"Not supported content type: '{ct}'")
+
+        return content
 
 
 def refresh_getters():

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -15,13 +15,12 @@ from typing import ClassVar, Tuple
 from urllib.parse import urlparse
 
 import requests
-from aiohttp.web_fileresponse import content_type
 from attrs import define, field, validators
 from requests import Response
 from schedule import Scheduler
 
 from logprep.abc.exceptions import LogprepException
-from logprep.abc.getter import Getter
+from logprep.abc.getter import ContentType, Getter
 from logprep.util.credentials import (
     Credentials,
     CredentialsEnvNotFoundError,
@@ -31,8 +30,6 @@ from logprep.util.defaults import (
     ENV_NAME_LOGPREP_CREDENTIALS_FILE,
     ENV_NAME_LOGPREP_GETTER_CONFIG,
 )
-
-ContentType = str
 
 
 class GetterNotFoundError(LogprepException):
@@ -261,7 +258,7 @@ class RefreshableGetter(Getter, ABC):
             return
         self.shared.refreshing = True
         try:
-            was_modified, _ = self._update_cache()
+            was_modified = self._update_cache()
         except RefreshableGetterError as error:
             self._log_cache_warning(error)
             was_modified = False
@@ -272,14 +269,16 @@ class RefreshableGetter(Getter, ABC):
             callback["function"](*callback["args"], **callback["kwargs"])
         self.shared.refreshing = False
 
-    def _update_cache(self) -> tuple[bool, ContentType]:
+    def _update_cache(self) -> bool:
         """Update the cache of the current http getter"""
         content, was_modified, content_type = self._get_from_target()
+        self.content_type = content_type
+
         if was_modified and content is not None:
             self.cache = content
         if self.cache is None:
             raise ValueError(f"{type(self).__name__} cache is empty")
-        return was_modified, content_type
+        return was_modified
 
     @abstractmethod
     def _get_from_target(self) -> tuple[bytes | None, bool, ContentType]:
@@ -442,48 +441,16 @@ class HttpGetter(RefreshableGetter):
             )
         ) from error
 
-    def get_list(self) -> list[str]:
-        """Get the content as list based on header information.
+    def get(self) -> list[str]:
+        """Get the content as list based on header information."""
 
-        This method calls the target URL to retrieve the initial header
-        information and initialize the cache state.
+        self._update_cache()
+        content = super().get()
 
-        For the content type `application/json`, it defaults to using the
-        `content` key. This can also be configured via `content_json_key`
-        in the corresponding `list_comparison` or `network_comparison`
-        processor configuration.
+        if isinstance(content, str):
+            return [content]
 
-        See the configuration examples of these processors for details.
-        """
-
-        _, content_type = self._update_cache()
-
-        # TODO: get config informations for related processor and pass it to the _get method:
-        content_json_key = "content"
-
-        return self._get(content_type=content_type, content_json_key=content_json_key)
-
-    def _get(self, content_type: ContentType, content_json_key: str) -> list[str]:
-        match content_type:
-            case "application/json":
-                json_content: dict | list = self.get_json()
-
-                if isinstance(json_content, list):
-                    return json_content
-                elif isinstance(json_content, dict):
-                    content = json_content.get(content_json_key)
-
-                    if content is None:
-                        raise RefreshableGetterError(f"Content key not found: '{content_json_key}'")
-
-                    return content
-                else:
-                    raise RefreshableGetterError(f"Expected json dict in HttpGetter content")
-
-            case "text/plain":
-                return self.get().splitlines()
-            case _:
-                raise RefreshableGetterError(f"Not supported content type: '{content_type}'")
+        return content
 
 
 def refresh_getters():

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -15,6 +15,7 @@ from typing import ClassVar, Tuple
 from urllib.parse import urlparse
 
 import requests
+from aiohttp.web_fileresponse import content_type
 from attrs import define, field, validators
 from requests import Response
 from schedule import Scheduler
@@ -30,6 +31,8 @@ from logprep.util.defaults import (
     ENV_NAME_LOGPREP_CREDENTIALS_FILE,
     ENV_NAME_LOGPREP_GETTER_CONFIG,
 )
+
+ContentType = str
 
 
 class GetterNotFoundError(LogprepException):
@@ -258,7 +261,7 @@ class RefreshableGetter(Getter, ABC):
             return
         self.shared.refreshing = True
         try:
-            was_modified = self._update_cache()
+            was_modified, _ = self._update_cache()
         except RefreshableGetterError as error:
             self._log_cache_warning(error)
             was_modified = False
@@ -269,17 +272,17 @@ class RefreshableGetter(Getter, ABC):
             callback["function"](*callback["args"], **callback["kwargs"])
         self.shared.refreshing = False
 
-    def _update_cache(self) -> bool:
+    def _update_cache(self) -> tuple[bool, ContentType]:
         """Update the cache of the current http getter"""
-        content, was_modified = self._get_from_target()
+        content, was_modified, content_type = self._get_from_target()
         if was_modified and content is not None:
             self.cache = content
         if self.cache is None:
             raise ValueError(f"{type(self).__name__} cache is empty")
-        return was_modified
+        return was_modified, content_type
 
     @abstractmethod
-    def _get_from_target(self) -> tuple[bytes | None, bool]:
+    def _get_from_target(self) -> tuple[bytes | None, bool, ContentType]:
         """Get value from target and return if it changed or not since it was last obtained"""
 
     def _handle_cache_error(self, error: RefreshableGetterError | ValueError):
@@ -393,11 +396,11 @@ class HttpGetter(RefreshableGetter):
             creds = CredentialsFactory.from_target(self.uri)
         return creds if creds else Credentials()
 
-    def _get_from_target(self) -> tuple[bytes | None, bool]:
+    def _get_from_target(self) -> tuple[bytes | None, bool, ContentType]:
         response = self._do_request()
-        self._headers["Content-Type"] = response.headers["Content-Type"]
+        content_type = response.headers["Content-Type"]
         was_modified = response.status_code != 304
-        return response.content, was_modified
+        return response.content, was_modified, content_type
 
     def _do_request(self) -> Response:
         """Gets the content from a http server via a URI"""
@@ -453,15 +456,15 @@ class HttpGetter(RefreshableGetter):
         See the configuration examples of these processors for details.
         """
 
-        self._update_cache()
+        _, content_type = self._update_cache()
 
         # TODO: get config informations for related processor and pass it to the _get method:
         content_json_key = "content"
 
-        return self._get(content_json_key=content_json_key)
+        return self._get(content_type=content_type, content_json_key=content_json_key)
 
-    def _get(self, content_json_key: str) -> list[str]:
-        match ct := self._headers.get("Content-Type"):
+    def _get(self, content_type: ContentType, content_json_key: str) -> list[str]:
+        match content_type:
             case "application/json":
                 json_content = self.get_json()
 
@@ -475,7 +478,7 @@ class HttpGetter(RefreshableGetter):
             case "text/plain":
                 content = self.get().splitlines()
             case _:
-                raise RefreshableGetterError(f"Not supported content type: '{ct}'")
+                raise RefreshableGetterError(f"Not supported content type: '{content_type}'")
 
         return content
 

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -153,7 +153,7 @@ class RefreshableGetter(Getter, ABC):
         self._shared[self.target] = value
 
     @property
-    def scheduler(self) -> Scheduler:
+    def scheduler(self) -> Scheduler | None:
         """Returns the scheduler for the current target"""
         return self.shared.scheduler
 

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -11,7 +11,7 @@ from functools import cached_property
 from importlib.metadata import version
 from pathlib import Path
 from string import Template
-from typing import ClassVar, Tuple
+from typing import ClassVar, Tuple, cast
 from urllib.parse import urlparse
 
 import requests
@@ -30,6 +30,9 @@ from logprep.util.defaults import (
     ENV_NAME_LOGPREP_CREDENTIALS_FILE,
     ENV_NAME_LOGPREP_GETTER_CONFIG,
 )
+
+# TODO: get config informations for related processor
+CONTENT_JSON_KEY = "content"
 
 
 class GetterNotFoundError(LogprepException):
@@ -101,6 +104,9 @@ class DataSharedPerTarget:
     cache: bytes | None = None
     """Value of the resource when it was last obtained"""
 
+    content_type: ContentType | None = None
+    """Content type of the resource when it was last obtained"""
+
     scheduler: Scheduler | None = None
     """Scheduler used to trigger getter refreshes"""
 
@@ -158,6 +164,16 @@ class RefreshableGetter(Getter, ABC):
     def scheduler(self, value: Scheduler) -> None:
         """sets the scheduler for the target"""
         self.shared.scheduler = value
+
+    @property
+    def content_type(self) -> ContentType | None:
+        """Returns the content_type for the current target"""
+        return self.shared.content_type
+
+    @content_type.setter
+    def content_type(self, value: ContentType | None) -> None:
+        """sets the content_type for the target"""
+        self.shared.content_type = value
 
     @property
     def cache(self) -> bytes | None:
@@ -271,17 +287,17 @@ class RefreshableGetter(Getter, ABC):
 
     def _update_cache(self) -> bool:
         """Update the cache of the current http getter"""
-        content, was_modified, content_type = self._get_from_target()
-        self.content_type = content_type
+        content, content_type, was_modified = self._get_from_target()
 
         if was_modified and content is not None:
             self.cache = content
+            self.content_type = content_type
         if self.cache is None:
             raise ValueError(f"{type(self).__name__} cache is empty")
         return was_modified
 
     @abstractmethod
-    def _get_from_target(self) -> tuple[bytes | None, bool, ContentType]:
+    def _get_from_target(self) -> tuple[bytes | None, ContentType | None, bool]:
         """Get value from target and return if it changed or not since it was last obtained"""
 
     def _handle_cache_error(self, error: RefreshableGetterError | ValueError):
@@ -289,6 +305,7 @@ class RefreshableGetter(Getter, ABC):
         if self._default_return_value is None:
             raise error
         self.cache = self._default_return_value
+        self.content_type = None
 
     def _log_cache_warning(self, error: Exception):
         self._logger.warning(
@@ -322,6 +339,34 @@ class RefreshableGetter(Getter, ABC):
         for shared_target_data in cls._shared.values():
             if shared_target_data.scheduler:
                 shared_target_data.scheduler.run_pending()
+
+    def get(self) -> dict | list | str:
+        """Get the content as list based on header information."""
+
+        content = super().get()
+
+        match self.content_type:
+            case "application/json":
+                json_content = self.parse_json(cast(str, content))
+
+                if isinstance(json_content, list):
+                    return json_content
+                elif isinstance(json_content, dict):
+                    content = cast(list, json_content.get(CONTENT_JSON_KEY))
+
+                    if content is None:
+                        raise ValueError(f"Content key not found: '{CONTENT_JSON_KEY}'")
+                    if not isinstance(content, list):
+                        raise ValueError(f"Content is not a list.")
+
+                    return content
+                else:
+                    raise ValueError(f"Expected json dict in Getter content")
+
+            case "text/plain":
+                return self.parse_list(cast(str, content))
+            case _:
+                return content
 
 
 @define(kw_only=True)
@@ -395,11 +440,11 @@ class HttpGetter(RefreshableGetter):
             creds = CredentialsFactory.from_target(self.uri)
         return creds if creds else Credentials()
 
-    def _get_from_target(self) -> tuple[bytes | None, bool, ContentType]:
+    def _get_from_target(self) -> tuple[bytes | None, ContentType | None, bool]:
         response = self._do_request()
-        content_type = response.headers["Content-Type"]
+        content_type = response.headers.get("Content-Type")
         was_modified = response.status_code != 304
-        return response.content, was_modified, content_type
+        return response.content, content_type, was_modified
 
     def _do_request(self) -> Response:
         """Gets the content from a http server via a URI"""
@@ -440,17 +485,6 @@ class HttpGetter(RefreshableGetter):
                 f"'{ENV_NAME_LOGPREP_CREDENTIALS_FILE}'"
             )
         ) from error
-
-    def get(self) -> list[str]:
-        """Get the content as list based on header information."""
-
-        self._update_cache()
-        content = super().get()
-
-        if isinstance(content, str):
-            return [content]
-
-        return content
 
 
 def refresh_getters():

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -466,21 +466,24 @@ class HttpGetter(RefreshableGetter):
     def _get(self, content_type: ContentType, content_json_key: str) -> list[str]:
         match content_type:
             case "application/json":
-                json_content = self.get_json()
+                json_content: dict | list = self.get_json()
 
-                if isinstance(json_content, dict):
+                if isinstance(json_content, list):
+                    return json_content
+                elif isinstance(json_content, dict):
                     content = json_content.get(content_json_key)
+
                     if content is None:
                         raise RefreshableGetterError(f"Content key not found: '{content_json_key}'")
+
+                    return content
                 else:
                     raise RefreshableGetterError(f"Expected json dict in HttpGetter content")
 
             case "text/plain":
-                content = self.get().splitlines()
+                return self.get().splitlines()
             case _:
                 raise RefreshableGetterError(f"Not supported content type: '{content_type}'")
-
-        return content
 
 
 def refresh_getters():

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -515,6 +515,6 @@ Heinz
         processor.process(document)
 
         assert document == expected_document
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
         assert rule.compare_sets[list_name] == expected_result

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -288,7 +288,38 @@ Hans
         assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
 
     @responses.activate
-    def test_list_comparison_content_json_array(self):
+    def test_list_comparison_preserves_loaded_json_list(self):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps(["Franz", "Heinz", "Hans"]),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
+
+    @responses.activate
+    def test_list_comparison_wraps_loaded_json_dict_in_array(self):
         responses.add(
             responses.GET,
             "http://localhost:8080/v2/valuestore/test_4",

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -318,38 +318,6 @@ Hans
         processor.setup()
         assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
 
-    @pytest.skip(reason="logprep does not support objects in json result yet.")
-    @responses.activate
-    def test_list_comparison_content_json_object(self):
-        responses.add(
-            responses.GET,
-            "http://localhost:8080/v2/valuestore/test_4",
-            json.dumps({"content": {"name_1": "Franz", "name_2": "Heinz", "name_3": "Hans"}}),
-            content_type="application/json",
-        )
-        rule_dict = {
-            "filter": "user",
-            "list_comparison": {
-                "source_fields": ["user"],
-                "target_field": "user_results",
-                "list_file_paths": ["bad_users.list"],
-            },
-            "description": "",
-        }
-        config = {
-            "type": "list_comparison",
-            "rules": [],
-            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
-        }
-
-        HttpGetter._shared.clear()
-
-        processor = Factory.create({"custom_lister": config})
-        rule = processor.rule_class.create_from_dict(rule_dict)
-        processor._rule_tree.add_rule(rule)
-        processor.setup()
-        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
-
     @responses.activate
     def test_list_comparison_loads_rule_using_http_and_updates_with_callback(self, tmp_path):
         target = "localhost/tests/testdata/bad_users.list?ref=bla"

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -288,6 +288,69 @@ Hans
         assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
 
     @responses.activate
+    def test_list_comparison_content_json_array(self):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps({"content": ["Franz", "Heinz", "Hans"]}),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
+
+    @pytest.skip(reason="logprep does not support objects in json result yet.")
+    @responses.activate
+    def test_list_comparison_content_json_object(self):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps({"content": {"name_1": "Franz", "name_2": "Heinz", "name_3": "Hans"}}),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
+
+    @responses.activate
     def test_list_comparison_loads_rule_using_http_and_updates_with_callback(self, tmp_path):
         target = "localhost/tests/testdata/bad_users.list?ref=bla"
         url = f"http://{target}"
@@ -453,6 +516,6 @@ Heinz
         processor.process(document)
 
         assert document == expected_document
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert responses.calls[0].request.url == url
         assert rule.compare_sets[list_name] == expected_result

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1310,7 +1310,7 @@ class TestHttpGetter:
         http_getter._refresh()
         assert re.search(r"Not updating .+ cache with URI .+", caplog.text)
 
-    @mock.patch("logprep.util.getter.HttpGetter._get_from_target", return_value=(b"", False))
+    @mock.patch("logprep.util.getter.HttpGetter._get_from_target", return_value=(b"", False, None))
     def test_update_cache_raises_error_if_empty(self, _):
         http_getter: HttpGetter = GetterFactory.from_string("http://something")
         http_getter.cache = None

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1310,7 +1310,7 @@ class TestHttpGetter:
         http_getter._refresh()
         assert re.search(r"Not updating .+ cache with URI .+", caplog.text)
 
-    @mock.patch("logprep.util.getter.HttpGetter._get_from_target", return_value=(b"", False, None))
+    @mock.patch("logprep.util.getter.HttpGetter._get_from_target", return_value=(b"", None, False))
     def test_update_cache_raises_error_if_empty(self, _):
         http_getter: HttpGetter = GetterFactory.from_string("http://something")
         http_getter.cache = None

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1335,17 +1335,6 @@ class TestHttpGetter:
         http_getter: HttpGetter = GetterFactory.from_string("http://something")
         assert http_getter.get_dict() == {"something": "foo"}
 
-    @mock.patch("logprep.abc.getter.Getter.get_collection", return_value="not a list")
-    def test_get_list_raises_exception_if_result_not_list(self, _):
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
-        with pytest.raises(ValueError, match="Value is not a list"):
-            http_getter.get_list()
-
-    @mock.patch("logprep.abc.getter.Getter.get_collection", return_value=["something"])
-    def test_get_list_returns_if_result_is_list(self, _):
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
-        assert http_getter.get_list() == ["something"]
-
     def test_handle_http_error_401_raises_refreshable_getter_error(self):
         response = MagicMock()
         response.status_code = 123


### PR DESCRIPTION
## Description

* Added json support for HttpGetter

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* Added tests to verify json list support

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--958.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->