### PR TITLE
fix: adapt release build workflow to nix

### DIFF
--- a/.github/workflows/publish-latest-dev-release-to-github.yml
+++ b/.github/workflows/publish-latest-dev-release-to-github.yml
@@ -10,20 +10,19 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
-      - name: Initialize Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # https://github.com/actions/setup-python/releases/tag/v6.2.0
-        with:
-          python-version: "3.11"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+      - name: Set up Nix
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # https://github.com/cachix/install-nix-action/releases/tag/v31.10.4
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse --archs x86_64
-      - name: Build binary wheel and a source tarball
-        run: pipx run build --sdist
-      - name: copy artifacts to dist folder
-        run: cp ./wheelhouse/* ./dist/
+        run: |
+          mkdir -p dist
+          nix build .#dist.python311 -o dist_sl
+          # hard copy contents to avoid issues with symlinks (which Nix creates by default)
+          cp -rL dist_sl/* dist
+      - name: Upload Artifact for next job
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
+        with:
+          name: logprep-build
+          path: dist
       - uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # https://github.com/marvinpinto/action-automatic-releases/releases/tag/v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-latest-dev-release-to-github.yml
+++ b/.github/workflows/publish-latest-dev-release-to-github.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Set up Nix
         uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # https://github.com/cachix/install-nix-action/releases/tag/v31.10.4
-      - name: Build wheels
+      - name: Build package
         run: |
           mkdir -p dist
           nix build .#dist.python311 -o dist_sl

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -3,14 +3,14 @@ on:
   release:
     types: [published]
 jobs:
-  build-wheel-and-tarball:
+  build-package:
     runs-on: ubuntu-24.04
     name: Build Logprep
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Set up Nix
         uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # https://github.com/cachix/install-nix-action/releases/tag/v31.10.4
-      - name: Build wheels
+      - name: Build package
         run: |
           mkdir -p dist
           nix build .#dist.python311 -o dist_sl
@@ -29,7 +29,7 @@ jobs:
       url: https://pypi.org/p/logprep
     permissions:
       id-token: write
-    needs: build-wheel-and-tarball
+    needs: build-package
     steps:
       - name: Download artifact from previous job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # https://github.com/actions/download-artifact/releases/tag/v8.0.1


### PR DESCRIPTION
## Description

Fix broken pre release pipeline

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* List of (preferably easy reproducible) tests including OS

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--960.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->