### PR TITLE
fix: support special chars in key names & empty values for `decoder` logfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * fix urllib vulnerabilities CVE-2026-44431 & CVE-2026-44432
 
 ### Bugfix
-
+* fix `decoder` to support special characters in logfmt keys
+* fix `decoder` to support empty values in logfmt items
 
 ## 19.1.0
 ### Breaking

--- a/logprep/processor/decoder/decoders.py
+++ b/logprep/processor/decoder/decoders.py
@@ -156,11 +156,18 @@ REGEX_SYSLOG_RFC5424 = (
 )
 
 
-REGEX_LOGFMT_TOKEN = re.compile(r'([a-zA-Z0-9]+)=("[^"]+"|\S+)')
+REGEX_LOGFMT_TOKEN = re.compile(r'([\w*?.|#@/-]+)=("[^"]*"|\S*)')
 
 
 def parse_logfmt(log_line: str) -> dict[str, str]:
-    """Parses logfmt format"""
+    """
+    Parses logfmt format.
+    Intentionally allows a wide range of key names (even non-identifiers).
+
+    Limitations:
+    - Does not support escaped or nested quotes in values
+    - Does only parse attributes and ignores the inline message
+    """
     tokens = REGEX_LOGFMT_TOKEN.findall(log_line)
     return {key: value.strip('"') for key, value in tokens}
 

--- a/tests/unit/processor/decoder/test_decoder.py
+++ b/tests/unit/processor/decoder/test_decoder.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from logprep.processor.base.exceptions import ProcessingError, ProcessingWarning
+from logprep.processor.decoder.decoders import parse_logfmt
 from logprep.util.typing import is_list_of
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -430,6 +431,36 @@ test_cases = [
             "filter": "message",
             "decoder": {
                 "mapping": {"message": "parsed"},
+                "source_format": "logfmt",
+                "overwrite_target": True,
+            },
+        },
+        {
+            "message": "time=2012-11-01T22:08:41+00:00 app.name=loki level=WARN debug="
+            ' total_duration=125 message-content="this is a log line"'
+            ' extra="user.bonus-info_v2=foo"',
+        },
+        {
+            "message": "time=2012-11-01T22:08:41+00:00 app.name=loki level=WARN debug="
+            ' total_duration=125 message-content="this is a log line"'
+            ' extra="user.bonus-info_v2=foo"',
+            "parsed": {
+                "app.name": "loki",
+                "total_duration": "125",
+                "extra": "user.bonus-info_v2=foo",
+                "level": "WARN",
+                "message-content": "this is a log line",
+                "time": "2012-11-01T22:08:41+00:00",
+                "debug": "",
+            },
+        },
+        id="parse logfmt with dots, underscores and hyphens",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "decoder": {
+                "mapping": {"message": "parsed"},
                 "source_format": "cri",
                 "overwrite_target": True,
             },
@@ -773,3 +804,28 @@ class TestDecoder(BaseProcessorTestCase):
                 event = self.object._decoder.decode(log_input)
                 self.object.process(event)
                 assert json.dumps(event["parsed"]) == expected_output
+
+    @pytest.mark.parametrize(
+        "log_line, expected",
+        [
+            pytest.param("k=123", {"k": "123"}, id="single character key"),
+            pytest.param("=1 \t=2 \n=3 \x1b=4", {}, id="empty key not supported"),
+            pytest.param("k=1 =435", {"k": "1"}, id="item before empty key"),
+            pytest.param("k=", {"k": ""}, id="empty value"),
+            pytest.param("k1= k2=2", {"k1": "", "k2": "2"}, id="item after empty value"),
+            pytest.param(
+                "key1=value1 key2=value2", {"key1": "value1", "key2": "value2"}, id="multiple keys"
+            ),
+        ],
+    )
+    def test_parse_logfmt(self, log_line, expected: dict):
+        assert expected == parse_logfmt(log_line)
+
+    @pytest.mark.parametrize("char", [pytest.param(c, id=f"{c} in key name") for c in "*?.|#@/-"])
+    def test_parse_logfmt_special_characters(self, char):
+        assert {
+            f"{char}": "1",
+            f"k{char}k": "2",
+            f"{char}k": "3",
+            f"k{char}": "4",
+        } == parse_logfmt(f"{char}=1 k{char}k=2 {char}k=3 k{char}=4")


### PR DESCRIPTION
## Description

* support special characters in logfmt key names (see https://docs.appsignal.com/logging/formatting/logfmt.html for reference)
* support empty values

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--964.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->