### PR TITLE
chore: make k8s deployment strategy configurable; default to RollingUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming Changes
 ### Breaking
+* chart: change default deployment strategy to RollingUpdate
 
 ### Features
 
@@ -7,6 +8,7 @@
 * upgrade transitive dependencies
 * fix #904 by upgrading opensearch-py to 3.2.0
 * fix urllib vulnerabilities CVE-2026-44431 & CVE-2026-44432
+* make deployment strategy configurable
 
 ### Bugfix
 

--- a/charts/logprep/Chart.yaml
+++ b/charts/logprep/Chart.yaml
@@ -2,14 +2,12 @@ apiVersion: v2
 name: logprep
 description: Logprep helm chart
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "15.1.0"
-
+version: "16.0.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "15.1.0"
+appVersion: "16.0.0"

--- a/charts/logprep/templates/deployment.yaml
+++ b/charts/logprep/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
-    type: Recreate
+    type: {{ .Values.deploymentStrategy }}
   selector:
     matchLabels:
       {{- include "logprep.selectorLabels" . | nindent 6 }}

--- a/charts/logprep/values.yaml
+++ b/charts/logprep/values.yaml
@@ -1,5 +1,10 @@
 # The replica count
 replicas: 1
+# The Kubernetes deployment strategy
+deploymentStrategy: "RollingUpdate"
+# The termination grace period for the pod
+# Defaults to 300 seconds to ensure that queues are drained before the pod is terminated
+terminationGracePeriodSeconds: 300
 # The image repository and tag
 # An image pull secret can be specified in the secrets section
 image:
@@ -176,6 +181,3 @@ configurations:
 #       admin
 #       admin2
 artifacts: []
-# The termination grace period for the pod
-# Defaults to 300 seconds to ensure that queues are drained before the pod is terminated
-terminationGracePeriodSeconds: 300


### PR DESCRIPTION
## Description

* make k8s deployment strategy configurable
* default to RollingUpdate (instead of Recreate)

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* not yet

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--967.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->