### PR TITLE
feat: extract list from json field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * list_comparison, network_comparison: continue processing with failure tags after HTTP list get or refresh errors
 
 ### Features
+* allows extracting a JSON subtree from HTTPGetter content via a configurable content_field for list and network comparisons.
 
 ### Improvements
 * remove pre-releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * list_comparison, network_comparison: continue processing with failure tags after HTTP list get or refresh errors
 
 ### Features
-* allows extracting a JSON subtree from HTTPGetter content via a configurable content_field for list and network comparisons.
+* allow list and network comparisons to extract list values from configurable JSON fields via `content_field`.
+* add basic `FileGetter` content type support for `.txt`, `.json`, and `.yml` files.
 
 ### Improvements
 * remove pre-releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 * list_comparison, network_comparison: continue processing with failure tags after HTTP list get or refresh errors
 
 ### Features
-* allow list and network comparisons to extract list values from configurable JSON fields via `content_field`.
-* add basic `FileGetter` content type support for `.txt`, `.json`, and `.yml` files.
+* allow list and network comparisons to extract list values from configurable JSON fields via `content_field`
+* add basic `FileGetter` content type support for `.txt`, `.json`, and `.yml` files
 
 ### Improvements
 * remove pre-releases

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -100,7 +100,7 @@ class Getter(ABC):
             case "text/plain" | None:
                 return content
             case _:
-                logger.warning("Unexpected content type.")
+                logger.info("Unexpected content type: %s", content_type)
                 return content
 
     @staticmethod
@@ -169,7 +169,10 @@ class Getter(ABC):
         if isinstance(content, dict) and content_field is not None:
             content = content[content_field]
         elif content_field is not None:
-            raise ValueError("Expected mapping type, like json for content.")
+            raise ValueError(
+                "Expected mapping type, like json object when content_field is set, got %s.",
+                type(content),
+            )
 
         if isinstance(content, str):
             content = self._parse_newline_separated_list(content)

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -161,10 +161,15 @@ class Getter(ABC):
         """Helper which tries to convert content to list"""
         return content.splitlines()
 
-    def get_list(self) -> list:
+    def get_list(self, content_field: str | None = None) -> list:
         """Gets list and fails otherwise"""
 
         content = self._resolve_content_by_content_type()
+
+        if isinstance(content, dict) and content_field is not None:
+            content = content[content_field]
+        elif content_field is not None:
+            raise ValueError("Expected mapping type, like json for content.")
 
         if isinstance(content, str):
             content = self._parse_newline_separated_list(content)

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -43,7 +43,6 @@ target field :code:`List_comparison.example`.
 
 import os.path
 from string import Template
-from typing import List, Optional
 
 from attrs import define, field, validators
 
@@ -61,7 +60,7 @@ class ListComparisonRule(FieldManagerRule):
     class Config(FieldManagerRule.Config):
         """RuleConfig for ListComparisonRule"""
 
-        list_file_paths: List[str] = field(
+        list_file_paths: list[str] = field(
             validator=validators.deep_iterable(member_validator=validators.instance_of(str))
         )
         """List of files. For string format see :ref:`getters`.
@@ -143,7 +142,7 @@ class ListComparisonRule(FieldManagerRule):
             return self._config.list_search_base_path
         return list_search_base_path
 
-    def init_list_comparison(self, list_search_base_path: Optional[str] = None):
+    def init_list_comparison(self, list_search_base_path: str | None = None):
         """init method for list_comparison lists"""
         list_search_base_path = self._get_list_search_base_path(list_search_base_path)
         if list_search_base_path.startswith("http"):

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -87,6 +87,12 @@ class ListComparisonRule(FieldManagerRule):
         will be filled by this processor. """
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
+        content_field: str | None = field(
+            validator=validators.optional(validators.instance_of(str)),
+            converter=lambda value: None if value == "" else value,
+            default=None,
+        )
+        """Content field will be used to access the subkey."""
 
     def __init__(
         self,
@@ -119,18 +125,17 @@ class ListComparisonRule(FieldManagerRule):
                 {**os.environ, **{"LOGPREP_LIST": list_path}}
             )
             http_getter = GetterFactory.from_string(list_search_base_path_resolved)
-
             if not isinstance(http_getter, HttpGetter):
                 raise TypeError(f"The target {list_search_base_path_resolved} must be a url")
-
-            http_getter.add_callback(self._update_compare_sets_via_http, http_getter, list_path)
             self._update_compare_sets_via_http(http_getter, list_path)
+            http_getter.add_callback(self._update_compare_sets_via_http, http_getter, list_path)
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
         try:
-            content = http_getter.get_list()
-            file_elements = (elem for elem in content if not elem.startswith("#"))
-            self._compare_sets.update({list_path: set(file_elements)})
+            content_field = self._config.content_field
+            content = http_getter.get_list(content_field=content_field)
+            file_elem_tuples = (elem for elem in content if not elem.startswith("#"))
+            self._compare_sets.update({list_path: set(file_elem_tuples)})
         except Exception as ex:
             self.mark_failed(error=ex)
         else:

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -141,6 +141,7 @@ class ListComparisonRule(FieldManagerRule):
             self.clear_failed()
 
     def _init_list_comparison_from_local_file(self, list_search_base_path: str) -> None:
+        content_field = self._config.content_field
         absolute_list_paths = [
             list_path for list_path in self._config.list_file_paths if list_path.startswith("/")
         ]
@@ -153,7 +154,9 @@ class ListComparisonRule(FieldManagerRule):
         ]
         list_paths = [*absolute_list_paths, *converted_absolute_list_paths]
         for list_path in list_paths:
-            compare_elements = GetterFactory.from_string(list_path).get_list()
+            compare_elements = GetterFactory.from_string(list_path).get_list(
+                content_field=content_field
+            )
             file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
             filename = os.path.basename(list_path)
             self._compare_sets.update({filename: set(file_elem_tuples)})

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -92,6 +92,39 @@ class ListComparisonRule(FieldManagerRule):
             converter=lambda value: None if value == "" else value,
             default=None,
         )
+        """
+        Optional JSON key used to extract the list values from loaded content.
+
+        Example:
+            Given the following JSON content:
+
+            .. code-block:: json
+
+               {
+                   "content": ["Jane", "Julia"]
+               }
+
+            Set ``content_field`` to ``"content"`` to use the value of this key
+            as the comparison list.
+
+        Note:
+            Setting ``content_field`` requires mapping-like JSON content. Non-JSON
+            content, or JSON content that does not resolve to a mapping, fails with an
+            error.
+
+            An empty ``content_field`` is treated as unset, so the list is expected at
+            the root of the JSON content.
+
+            Examples:
+                ``content_field: ""``
+                    Is converted to ``None`` and reads the list from the JSON root.
+
+                ``content_field: null``
+                    Is treated as ``None`` and reads the list from the JSON root.
+
+                ``content_field: "content"``
+                    Reads the list from the ``"content"`` key of the JSON object.
+        """
 
     def __init__(
         self,

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -166,8 +166,8 @@ class ListComparisonRule(FieldManagerRule):
         try:
             content_field = self._config.content_field
             content = http_getter.get_list(content_field=content_field)
-            file_elem_tuples = (elem for elem in content if not elem.startswith("#"))
-            self._compare_sets.update({list_path: set(file_elem_tuples)})
+            file_elements = (elem for elem in content if not elem.startswith("#"))
+            self._compare_sets.update({list_path: set(file_elements)})
         except Exception as ex:
             self.mark_failed(error=ex)
         else:
@@ -190,9 +190,9 @@ class ListComparisonRule(FieldManagerRule):
             compare_elements = GetterFactory.from_string(list_path).get_list(
                 content_field=content_field
             )
-            file_elem_tuples = (elem for elem in compare_elements if not elem.startswith("#"))
+            file_elements = (elem for elem in compare_elements if not elem.startswith("#"))
             filename = os.path.basename(list_path)
-            self._compare_sets.update({filename: set(file_elem_tuples)})
+            self._compare_sets.update({filename: set(file_elements)})
 
     @property
     def compare_sets(self) -> dict:  # pylint: disable=missing-docstring

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -163,8 +163,7 @@ class ListComparisonRule(FieldManagerRule):
 
     def _update_compare_sets_via_http(self, http_getter: HttpGetter, list_path: str) -> None:
         try:
-            content_field = self._config.content_field
-            content = http_getter.get_list(content_field=content_field)
+            content = http_getter.get_list(content_field=self._config.content_field)
             file_elements = (elem for elem in content if not elem.startswith("#"))
             self._compare_sets.update({list_path: set(file_elements)})
         except Exception as ex:

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -92,7 +92,6 @@ class ListComparisonRule(FieldManagerRule):
             converter=lambda value: None if value == "" else value,
             default=None,
         )
-        """Content field will be used to access the subkey."""
 
     def __init__(
         self,

--- a/logprep/processor/network_comparison/rule.py
+++ b/logprep/processor/network_comparison/rule.py
@@ -44,7 +44,7 @@ target field :code:`network_comparison.example`.
 """
 
 from ipaddress import ip_network
-from typing import Optional, List
+from typing import List, Optional
 
 from attrs import define, field, validators
 
@@ -88,6 +88,12 @@ class NetworkComparisonRule(ListComparisonRule):
         will be filled by this processor. """
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
+        content_field: str | None = field(
+            validator=validators.optional(validators.instance_of(str)),
+            converter=lambda value: None if value == "" else value,
+            default=None,
+        )
+        """Content field will be used to access the subkey."""
 
     def init_list_comparison(self, list_search_base_path: Optional[str] = None) -> None:
         """init method for list_comparison lists"""

--- a/logprep/processor/network_comparison/rule.py
+++ b/logprep/processor/network_comparison/rule.py
@@ -44,7 +44,6 @@ target field :code:`network_comparison.example`.
 """
 
 from ipaddress import ip_network
-from typing import List, Optional
 
 from attrs import define, field, validators
 
@@ -62,7 +61,7 @@ class NetworkComparisonRule(ListComparisonRule):
     class Config(FieldManagerRule.Config):
         """RuleConfig for NetworkComparisonRule"""
 
-        list_file_paths: List[str] = field(
+        list_file_paths: list[str] = field(
             validator=validators.deep_iterable(member_validator=validators.instance_of(str))
         )
         """List of files. For string format see :ref:`getters`.
@@ -127,7 +126,7 @@ class NetworkComparisonRule(ListComparisonRule):
                     Reads the list from the ``"content"`` key of the JSON object.
         """
 
-    def init_list_comparison(self, list_search_base_path: Optional[str] = None) -> None:
+    def init_list_comparison(self, list_search_base_path: str | None = None) -> None:
         """init method for list_comparison lists"""
         super().init_list_comparison(list_search_base_path)
         self._convert_compare_sets_to_networks()

--- a/logprep/processor/network_comparison/rule.py
+++ b/logprep/processor/network_comparison/rule.py
@@ -93,7 +93,7 @@ class NetworkComparisonRule(ListComparisonRule):
             converter=lambda value: None if value == "" else value,
             default=None,
         )
-        """Content field will be used to access the subkey."""
+        """Optional key used to extract the list from json HTTP content."""
 
     def init_list_comparison(self, list_search_base_path: Optional[str] = None) -> None:
         """init method for list_comparison lists"""

--- a/logprep/processor/network_comparison/rule.py
+++ b/logprep/processor/network_comparison/rule.py
@@ -93,7 +93,39 @@ class NetworkComparisonRule(ListComparisonRule):
             converter=lambda value: None if value == "" else value,
             default=None,
         )
-        """Optional key used to extract the list from json HTTP content."""
+        """
+        Optional JSON key used to extract the list values from loaded content.
+
+        Example:
+            Given the following JSON content:
+
+            .. code-block:: json
+
+               {
+                   "content": ["Jane", "Julia"]
+               }
+
+            Set ``content_field`` to ``"content"`` to use the value of this key
+            as the comparison list.
+
+        Note:
+            Setting ``content_field`` requires mapping-like JSON content. Non-JSON
+            content, or JSON content that does not resolve to a mapping, fails with an
+            error.
+
+            An empty ``content_field`` is treated as unset, so the list is expected at
+            the root of the JSON content.
+
+            Examples:
+                ``content_field: ""``
+                    Is converted to ``None`` and reads the list from the JSON root.
+
+                ``content_field: null``
+                    Is treated as ``None`` and reads the list from the JSON root.
+
+                ``content_field: "content"``
+                    Reads the list from the ``"content"`` key of the JSON object.
+        """
 
     def init_list_comparison(self, list_search_base_path: Optional[str] = None) -> None:
         """init method for list_comparison lists"""

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import cached_property
 from importlib.metadata import version
-from lib2to3.btm_utils import reduce_tree
 from pathlib import Path
 from string import Template
 from typing import ClassVar

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -9,12 +9,14 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import cached_property
 from importlib.metadata import version
+from lib2to3.btm_utils import reduce_tree
 from pathlib import Path
 from string import Template
 from typing import ClassVar
 from urllib.parse import urlparse
 
 import requests
+from aiohttp.web_fileresponse import content_type
 from attrs import define, field, validators
 from requests import Response
 from schedule import Scheduler
@@ -354,7 +356,18 @@ class FileGetter(Getter):
         content type, which defaults currently to None."""
 
         path = Path(self.target)
-        return path.read_bytes(), None
+
+        content_bytes = path.read_bytes()
+
+        match path.suffix:
+            case ".txt":
+                return content_bytes, "text/plain"
+            case ".json":
+                return content_bytes, "application/json"
+            case ".yml":
+                return content_bytes, "text/yaml"
+            case _:
+                raise ValueError(f"FileGetter: Not supported file type '{path.suffix}'")
 
 
 @define(kw_only=True)

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -367,7 +367,7 @@ class FileGetter(Getter):
             case ".yml":
                 return content_bytes, "text/yaml"
             case _:
-                raise ValueError(f"FileGetter: Not supported file type '{path.suffix}'")
+                return content_bytes, None
 
 
 @define(kw_only=True)

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -15,7 +15,6 @@ from typing import ClassVar
 from urllib.parse import urlparse
 
 import requests
-from aiohttp.web_fileresponse import content_type
 from attrs import define, field, validators
 from requests import Response
 from schedule import Scheduler
@@ -364,7 +363,7 @@ class FileGetter(Getter):
             case ".json":
                 return raw_content, "application/json"
             case ".yml":
-                return raw_content, "text/yaml"
+                return raw_content, "application/yaml"
             case _:
                 return raw_content, None
 

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -356,17 +356,17 @@ class FileGetter(Getter):
 
         path = Path(self.target)
 
-        content_bytes = path.read_bytes()
+        raw_content = path.read_bytes()
 
         match path.suffix:
             case ".txt":
-                return content_bytes, "text/plain"
+                return raw_content, "text/plain"
             case ".json":
-                return content_bytes, "application/json"
+                return raw_content, "application/json"
             case ".yml":
-                return content_bytes, "text/yaml"
+                return raw_content, "text/yaml"
             case _:
-                return content_bytes, None
+                return raw_content, None
 
 
 @define(kw_only=True)

--- a/tests/acceptance/util.py
+++ b/tests/acceptance/util.py
@@ -368,7 +368,7 @@ def get_full_pipeline(exclude=None):
 
 
 def convert_to_http_config(config: Configuration, endpoint) -> Configuration:
-    config_path = Path(tempfile.gettempdir() + "/config.json")
+    config_path = Path(tempfile.gettempdir() + "/config.yml")
     config_path.write_text(config.as_yaml(), encoding="utf-8")
     config = Configuration.from_sources([str(config_path)])
     http_fields = [

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -415,72 +415,37 @@ Heinz
     @pytest.mark.parametrize(
         ("json_content", "content_field"),
         [
-            pytest.param(["Franz", "Heinz", "Hans"], ""),
-            pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
-            pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
-        ],
-    )
-    @responses.activate
-    def test_list_comparison_loads_json_list(self, json_content, content_field):
-        responses.add(
-            responses.GET,
-            "http://localhost:8080/v2/valuestore/test_4",
-            json.dumps(json_content),
-            content_type="application/json",
-        )
-        rule_dict = {
-            "filter": "user",
-            "list_comparison": {
-                "source_fields": ["user"],
-                "target_field": "user_results",
-                "list_file_paths": ["bad_users.list"],
-                "content_field": content_field,
-            },
-            "description": "",
-        }
-        config = {
-            "type": "ng_list_comparison",
-            "rules": [],
-            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
-        }
-
-        HttpGetter._shared.clear()
-
-        processor = Factory.create({"custom_lister": config})
-        rule = processor.rule_class.create_from_dict(rule_dict)
-        processor._rule_tree.add_rule(rule)
-        processor.setup()
-        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
-
-    @pytest.mark.parametrize(
-        ("json_content", "content_field"),
-        [
             pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, None),
             pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, None),
         ],
     )
-    @responses.activate
-    def test_list_comparison_fail_on_json_list_load(self, json_content, content_field):
-        responses.add(
-            responses.GET,
-            "http://localhost:8080/v2/valuestore/test_4",
-            json.dumps(json_content),
-            content_type="application/json",
-        )
+    def test_list_comparison_fail_on_json_list_load_from_file(
+        self, json_content, content_field, tmp_path
+    ):
+        file_content = json.dumps(json_content)
+        file_name = "file.json"
+        file_root_path = tmp_path
+        file_path = file_root_path / file_name
+
+        with open(file_path, "w") as f:
+            f.write(file_content)
+
         rule_dict = {
             "filter": "user",
             "list_comparison": {
                 "source_fields": ["user"],
                 "target_field": "user_results",
-                "list_file_paths": ["bad_users.list"],
+                "list_file_paths": [file_name],
                 "content_field": content_field,
             },
             "description": "",
         }
         config = {
-            "type": "ng_list_comparison",
+            "type": "list_comparison",
             "rules": [],
-            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+            "list_search_base_path": str(file_root_path),
         }
 
         HttpGetter._shared.clear()

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -13,12 +13,7 @@ from logprep.factory import Factory
 from logprep.ng.event.log_event import LogEvent
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import (
-    GetterFactory,
-    HttpGetter,
-    RefreshableGetterError,
-    refresh_getters,
-)
+from logprep.util.getter import HttpGetter, RefreshableGetterError, refresh_getters
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 
@@ -416,6 +411,86 @@ Heinz
         processor.setup()
         processor.process(log_event)
         assert document == expected, testcase
+
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            pytest.param(["Franz", "Heinz", "Hans"], ""),
+            pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
+            pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_loads_json_list(self, json_content, content_field):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps(json_content),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+                "content_field": content_field,
+            },
+            "description": "",
+        }
+        config = {
+            "type": "ng_list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+        assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
+
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_fail_on_json_list_load(self, json_content, content_field):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps(json_content),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+                "content_field": content_field,
+            },
+            "description": "",
+        }
+        config = {
+            "type": "ng_list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+
+        with pytest.raises(ValueError, match="Content is not a list"):
+            processor.setup()
 
     @responses.activate
     def test_list_comparison_process_adds_failure_tag_if_http_list_returns_500(

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -389,11 +389,11 @@ Hans
     @pytest.mark.parametrize(
         ("json_content", "content_field"),
         [
-            # pytest.param(["Franz", "Heinz", "Hans"], ""),
-            # pytest.param(["Franz", "Heinz", "Hans"], None),
-            # pytest.param(
-            #    ["Franz", "Heinz", "Hans"], NOT_SET, id="no_content_field_entry_in_config"
-            # ),
+            pytest.param(["Franz", "Heinz", "Hans"], ""),
+            pytest.param(["Franz", "Heinz", "Hans"], None),
+            pytest.param(
+                ["Franz", "Heinz", "Hans"], NOT_SET, id="no_content_field_entry_in_config"
+            ),
             pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
             pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
         ],

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -347,48 +347,6 @@ Hans
     @pytest.mark.parametrize(
         ("json_content", "content_field"),
         [
-            pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
-            pytest.param({None: ["Franz", "Heinz", "Hans"]}, None),
-            pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
-            pytest.param({"": ["Franz", "Heinz", "Hans"]}, None),
-        ],
-    )
-    @responses.activate
-    def test_list_comparison_fail_on_json_list_load_from_http(self, json_content, content_field):
-        responses.add(
-            responses.GET,
-            "http://localhost:8080/v2/valuestore/test_4",
-            json.dumps(json_content),
-            content_type="application/json",
-        )
-        rule_dict = {
-            "filter": "user",
-            "list_comparison": {
-                "source_fields": ["user"],
-                "target_field": "user_results",
-                "list_file_paths": ["bad_users.list"],
-                "content_field": content_field,
-            },
-            "description": "",
-        }
-        config = {
-            "type": "list_comparison",
-            "rules": [],
-            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
-        }
-
-        HttpGetter._shared.clear()
-
-        processor = Factory.create({"custom_lister": config})
-        rule = processor.rule_class.create_from_dict(rule_dict)
-        processor._rule_tree.add_rule(rule)
-
-        with pytest.raises(ValueError, match="Content is not a list"):
-            processor.setup()
-
-    @pytest.mark.parametrize(
-        ("json_content", "content_field"),
-        [
             pytest.param(["Franz", "Heinz", "Hans"], ""),
             pytest.param(["Franz", "Heinz", "Hans"], None),
             pytest.param(

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -21,6 +21,9 @@ from logprep.util.getter import (
 )
 from tests.unit.processor.base import BaseProcessorTestCase
 
+NOT_SET = object()
+"""A sentinel object to indicate that a value has not been provided."""
+
 
 class TestListComparison(BaseProcessorTestCase):
     CONFIG = {
@@ -298,6 +301,10 @@ Hans
         ("json_content", "content_field"),
         [
             pytest.param(["Franz", "Heinz", "Hans"], ""),
+            pytest.param(["Franz", "Heinz", "Hans"], None),
+            pytest.param(
+                ["Franz", "Heinz", "Hans"], NOT_SET, id="no_content_field_entry_in_config"
+            ),
             pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
             pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
         ],
@@ -316,10 +323,13 @@ Hans
                 "source_fields": ["user"],
                 "target_field": "user_results",
                 "list_file_paths": ["bad_users.list"],
-                "content_field": content_field,
             },
             "description": "",
         }
+
+        if content_field is not NOT_SET:
+            rule_dict["list_comparison"] |= {"content_field": content_field}
+
         config = {
             "type": "list_comparison",
             "rules": [],
@@ -338,7 +348,9 @@ Hans
         ("json_content", "content_field"),
         [
             pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, None),
             pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, None),
         ],
     )
     @responses.activate

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -310,7 +310,7 @@ Hans
         ],
     )
     @responses.activate
-    def test_list_comparison_loads_json_list(self, json_content, content_field):
+    def test_list_comparison_loads_json_list_from_http(self, json_content, content_field):
         responses.add(
             responses.GET,
             "http://localhost:8080/v2/valuestore/test_4",
@@ -354,7 +354,7 @@ Hans
         ],
     )
     @responses.activate
-    def test_list_comparison_fail_on_json_list_load(self, json_content, content_field):
+    def test_list_comparison_fail_on_json_list_load_from_http(self, json_content, content_field):
         responses.add(
             responses.GET,
             "http://localhost:8080/v2/valuestore/test_4",
@@ -375,6 +375,99 @@ Hans
             "type": "list_comparison",
             "rules": [],
             "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+
+        with pytest.raises(ValueError, match="Content is not a list"):
+            processor.setup()
+
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            # pytest.param(["Franz", "Heinz", "Hans"], ""),
+            # pytest.param(["Franz", "Heinz", "Hans"], None),
+            # pytest.param(
+            #    ["Franz", "Heinz", "Hans"], NOT_SET, id="no_content_field_entry_in_config"
+            # ),
+            pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
+            pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
+        ],
+    )
+    def test_list_comparison_loads_json_list_from_file(self, json_content, content_field, tmp_path):
+        file_content = json.dumps(json_content)
+        file_name = "file.json"
+        file_root_path = tmp_path
+        file_path = file_root_path / file_name
+
+        with open(file_path, "w") as f:
+            f.write(file_content)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [file_name],
+            },
+            "description": "",
+        }
+
+        if content_field is not NOT_SET:
+            rule_dict["list_comparison"] |= {"content_field": content_field}
+
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": str(file_root_path),
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+        assert processor.rules[0].compare_sets == {"file.json": {"Franz", "Heinz", "Hans"}}
+
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, None),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, None),
+        ],
+    )
+    def test_list_comparison_fail_on_json_list_load_from_file(
+        self, json_content, content_field, tmp_path
+    ):
+        file_content = json.dumps(json_content)
+        file_name = "file.json"
+        file_root_path = tmp_path
+        file_path = file_root_path / file_name
+
+        with open(file_path, "w") as f:
+            f.write(file_content)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [file_name],
+                "content_field": content_field,
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": str(file_root_path),
         }
 
         HttpGetter._shared.clear()

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -294,12 +294,20 @@ Hans
         processor.setup()
         assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
 
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            pytest.param(["Franz", "Heinz", "Hans"], ""),
+            pytest.param({"content": ["Franz", "Heinz", "Hans"]}, "content"),
+            pytest.param({"_": ["Franz", "Heinz", "Hans"]}, "_"),
+        ],
+    )
     @responses.activate
-    def test_list_comparison_loads_json_list(self):
+    def test_list_comparison_loads_json_list(self, json_content, content_field):
         responses.add(
             responses.GET,
             "http://localhost:8080/v2/valuestore/test_4",
-            json.dumps(["Franz", "Heinz", "Hans"]),
+            json.dumps(json_content),
             content_type="application/json",
         )
         rule_dict = {
@@ -308,6 +316,7 @@ Hans
                 "source_fields": ["user"],
                 "target_field": "user_results",
                 "list_file_paths": ["bad_users.list"],
+                "content_field": content_field,
             },
             "description": "",
         }
@@ -324,6 +333,46 @@ Hans
         processor._rule_tree.add_rule(rule)
         processor.setup()
         assert processor.rules[0].compare_sets == {"bad_users.list": {"Franz", "Heinz", "Hans"}}
+
+    @pytest.mark.parametrize(
+        ("json_content", "content_field"),
+        [
+            pytest.param({None: ["Franz", "Heinz", "Hans"]}, ""),
+            pytest.param({"": ["Franz", "Heinz", "Hans"]}, ""),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_fail_on_json_list_load(self, json_content, content_field):
+        responses.add(
+            responses.GET,
+            "http://localhost:8080/v2/valuestore/test_4",
+            json.dumps(json_content),
+            content_type="application/json",
+        )
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+                "content_field": content_field,
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+
+        with pytest.raises(ValueError, match="Content is not a list"):
+            processor.setup()
 
     @responses.activate
     def test_list_comparison_loads_rule_using_http_and_updates_with_callback(self, tmp_path):

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -218,8 +218,15 @@ class TestFileGetter:
             assert content == b"my content"
 
     @pytest.mark.parametrize(
-        "method_name, input_content, expected_output",
+        ("method_name", "input_content", "expected_output"),
         [
+            (
+                "get_list",
+                b"""list_element_1
+list_element_2
+""",
+                ["list_element_1", "list_element_2"],
+            ),
             (
                 "get_yaml",
                 b"""---

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -222,9 +222,7 @@ class TestFileGetter:
         [
             (
                 "get_list",
-                b"""list_element_1
-list_element_2
-""",
+                b"list_element_1\nlist_element_2",
                 ["list_element_1", "list_element_2"],
             ),
             (


### PR DESCRIPTION
## Description

Adds support for extracting list values from configurable JSON fields.

`list_comparison` and `network_comparison` rules can now use the optional `content_field` setting to load list data from a specific JSON key instead of requiring the JSON content itself to be a top-level list.

Existing plain list handling remains unchanged when `content_field` is omitted, empty, or `null`.

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--970.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->