### PR TITLE
test: add test cases to cover decoder and timestamper processing of empty messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
 
 ### Improvements
+* add test cases for `decoder` and `timestamper` behavior when handling empty messages
 
 ### Bugfix
 

--- a/tests/unit/processor/decoder/test_decoder.py
+++ b/tests/unit/processor/decoder/test_decoder.py
@@ -337,6 +337,19 @@ test_cases = [
             "filter": "message",
             "decoder": {
                 "mapping": {"message": "parsed"},
+                "source_format": "syslog_rfc3164",
+                "overwrite_target": True,
+            },
+        },
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        id="parse empty message for syslog rfc 3164 without error",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "decoder": {
+                "mapping": {"message": "parsed"},
                 "source_format": "syslog_rfc3164_local",
                 "overwrite_target": True,
             },
@@ -353,6 +366,19 @@ test_cases = [
             },
         },
         id="parse syslog rfc 3164 local",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "decoder": {
+                "mapping": {"message": "parsed"},
+                "source_format": "syslog_rfc3164_local",
+                "overwrite_target": True,
+            },
+        },
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        id="parse empty message for syslog rfc 3164 local without error",
     ),
     pytest.param(
         {
@@ -380,6 +406,19 @@ test_cases = [
             },
         },
         id="parse syslog rfc 5424",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "decoder": {
+                "mapping": {"message": "parsed"},
+                "source_format": "syslog_rfc5424",
+                "overwrite_target": True,
+            },
+        },
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        {"message": "", "@timestamp": "2026-04-01T10:46:00.682181235Z"},
+        id="parse empty message for syslog rfc 5424 without error",
     ),
     pytest.param(
         {

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -273,6 +273,26 @@ test_cases = [  # testcase, rule, event, expected
 
 failure_test_cases = [
     (
+        "parsing timestamp fails on empty message",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "",
+        },
+        {
+            "message": "",
+            "tags": ["_timestamper_failure"],
+        },
+        r"Could not parse timestamp.*event=\{'message': ''\}",
+    ),
+    (
         "normalization from timestamp with non matching patterns",
         {
             "filter": "winlog.event_id: 123456789",


### PR DESCRIPTION
## Description

* Added test cases to cover the behavior of the `decoder` and `timestamper` processors when handling empty messages.

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--973.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->