### PR TITLE
feat: support ranges in Lucene filters and field groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Breaking
 
 ### Features
+* add support for inclusive numeric Lucene range filters using square brackets.
+* add support for integer and floating-point ranges in regular fields and field groups.
+* add validation for reversed, non-numeric, non-finite, and unsupported exclusive ranges.
 * add `deduplicator` processor that removes duplicates from lists
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 ### Breaking
 
 ### Features
-* add support for validated integer, floating-point, and lexicographic string Lucene range filters in regular fields and field groups.
-* add support for quoted string range boundaries, allowing values with Lucene special characters such as ISO-8601 timestamps with timezone offsets.
+* add Lucene range support for integer, floating-point, and lexicographic string values, including quoted ISO-8601 timestamps with timezone offsets.
 * add `deduplicator` processor that removes duplicates from lists
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 ### Breaking
 
 ### Features
-* add support for inclusive numeric Lucene range filters using square brackets.
-* add support for integer and floating-point ranges in regular fields and field groups.
-* add validation for reversed, non-numeric, non-finite, and unsupported exclusive ranges.
+
+* add support for validated integer, floating-point, and lexicographic string Lucene range filters in regular fields and field groups.
 * add `deduplicator` processor that removes duplicates from lists
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ### Breaking
 
 ### Features
-
 * add support for validated integer, floating-point, and lexicographic string Lucene range filters in regular fields and field groups.
+* add support for quoted string range boundaries, allowing values with Lucene special characters such as ISO-8601 timestamps with timezone offsets.
 * add `deduplicator` processor that removes duplicates from lists
 
 ### Improvements

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -3,9 +3,11 @@
 import re
 from abc import ABC, abstractmethod
 from itertools import chain, zip_longest
-from typing import Any, Sequence
+from typing import Any, Generic, Sequence, TypeVar
 
 from logprep.util.helper import field_list_to_dotted_field
+
+RangeBoundary = TypeVar("RangeBoundary", int, float, str)
 
 
 class FilterExpressionError(Exception):
@@ -289,37 +291,88 @@ class FloatFilterExpression(KeyValueBasedFilterExpression):
         return value == self._expected_value
 
 
-class RangeBasedFilterExpression(KeyBasedFilterExpression):
+class RangeBasedFilterExpression(KeyBasedFilterExpression, Generic[RangeBoundary]):
     """Base class of filter expressions that match for a range of values."""
 
-    def __init__(self, key: Sequence[str], lower_bound: float, upper_bound: float):
+    def __init__(
+        self,
+        key: Sequence[str],
+        lower_bound: RangeBoundary,
+        upper_bound: RangeBoundary,
+        include_lower_bound: bool = True,
+        include_upper_bound: bool = True,
+    ):
         super().__init__(key)
-        self._lower_bound = lower_bound
-        self._upper_bound = upper_bound
+        self._lower_bound: RangeBoundary = lower_bound
+        self._upper_bound: RangeBoundary = upper_bound
+        self._include_lower_bound = include_lower_bound
+        self._include_upper_bound = include_upper_bound
 
     def __repr__(self) -> str:
-        return f"{self.key_as_dotted_string}:[{self._lower_bound} TO {self._upper_bound}]"
+        opening_bracket = "[" if self._include_lower_bound else "{"
+        closing_bracket = "]" if self._include_upper_bound else "}"
+
+        return (
+            f"{self.key_as_dotted_string}:"
+            f"{opening_bracket}{self._lower_bound} TO {self._upper_bound}"
+            f"{closing_bracket}"
+        )
+
+    def _matches_lower_bound(self, value: RangeBoundary) -> bool:
+        if self._include_lower_bound:
+            return value >= self._lower_bound
+        return value > self._lower_bound
+
+    def _matches_upper_bound(self, value: RangeBoundary) -> bool:
+        if self._include_upper_bound:
+            return value <= self._upper_bound
+        return value < self._upper_bound
+
+    def _matches_range(self, value: RangeBoundary) -> bool:
+        return self._matches_lower_bound(value) and self._matches_upper_bound(value)
 
     def does_match(self, document: dict):
         raise NotImplementedError
 
 
-class IntegerRangeFilterExpression(RangeBasedFilterExpression):
+class IntegerRangeFilterExpression(RangeBasedFilterExpression[int]):
     """Range based filter expression that matches for integers."""
 
     def does_match(self, document: dict) -> bool:
         value = self._get_value(self.key, document)
 
-        return self._lower_bound <= value <= self._upper_bound
+        if not isinstance(value, int) or isinstance(value, bool):
+            return False
+
+        return self._matches_range(value)
 
 
-class FloatRangeFilterExpression(RangeBasedFilterExpression):
+class FloatRangeFilterExpression(RangeBasedFilterExpression[float]):
     """Range based filter expression that matches for floats."""
 
     def does_match(self, document: dict) -> bool:
         value = self._get_value(self.key, document)
 
-        return self._lower_bound <= value <= self._upper_bound
+        if not isinstance(value, float) or isinstance(value, bool):
+            return False
+
+        return self._matches_range(value)
+
+
+class StringRangeFilterExpression(RangeBasedFilterExpression[str]):
+    """Range based filter expression that matches for strings.
+
+    String ranges are compared lexicographically.
+    """
+
+    def does_match(self, document: dict) -> bool:
+        value = self._get_value(self.key, document)
+
+        # Avoid comparing strings with other value types, which would raise a TypeError.
+        if not isinstance(value, str):
+            return False
+
+        return self._matches_range(value)
 
 
 class RegExFilterExpression(KeyValueBasedFilterExpression):

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -61,9 +61,13 @@ This example is not complete, since rules are specific to processors and require
 Range-Filter
 ------------
 
-It is possible to use inclusive range expressions to match numeric values.
-The lower and upper boundaries are included and must be specified using square
-brackets. Both integer and floating-point boundaries are supported.
+It is possible to use range expressions to match integer, floating-point, and
+string values. Square brackets include a boundary, while curly brackets exclude
+a boundary. String ranges are compared lexicographically.
+
+The lower and upper boundaries of a range must have the same type. Mixed ranges
+such as integer-to-float, integer-to-string, or float-to-string are not
+supported.
 
 
 ..  code-block:: yaml
@@ -76,6 +80,39 @@ brackets. Both integer and floating-point boundaries are supported.
 The example matches log messages in which the value of :code:`age` is greater
 than or equal to :code:`18` and less than or equal to :code:`65`.
 
+Exclusive boundaries are also supported:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'age:{18 TO 65}'
+
+
+The example matches log messages in which the value of :code:`age` is greater
+than :code:`18` and less than :code:`65`.
+
+Floating-point ranges are supported as well:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'temperature:[18.5 TO 25.0]'
+
+
+String ranges are compared lexicographically:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'status:[alpha TO stable]'
+
+
 Range expressions can also be used within field groups:
 
 
@@ -86,9 +123,8 @@ Range expressions can also be used within field groups:
     filter: 'temperature:([18.5 TO 25.0])'
 
 
-Only closed numeric ranges using square brackets are currently supported.
-Exclusive ranges using curly brackets, open boundaries using :code:`*`, and
-non-numeric boundaries are not supported.
+Open boundaries using :code:`*`, non-finite numeric boundaries, and mixed
+boundary types are not supported.
 
 RegEx-Filter
 ------------

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -159,9 +159,11 @@ from logprep.filter.expression.filter_expression import Not as NotExpression
 from logprep.filter.expression.filter_expression import (
     Null,
     Or,
+    RangeBoundary,
     RegExFilterExpression,
     SigmaFilterExpression,
     StringFilterExpression,
+    StringRangeFilterExpression,
 )
 from logprep.util.helper import field_list_to_dotted_field, get_dotted_field_list
 
@@ -338,52 +340,159 @@ class LuceneTransformer:
         expression = str(expr)
         lower_token, upper_token = expr.children
 
-        if not expression.startswith("[") or not expression.endswith("]"):
-            raise LuceneFilterError(
-                f'The expression "{expression}" is invalid. '
-                "Only inclusive ranges using square brackets are supported."
-            )
+        include_lower_bound = expression.startswith("[")
+        include_upper_bound = expression.endswith("]")
+
+        if not expression.startswith(("[", "{")) or not expression.endswith(("]", "}")):
+            raise LuceneFilterError(f'The expression "{expression}" is invalid!')
 
         lower_value = self._get_range_boundary_value(lower_token)
         upper_value = self._get_range_boundary_value(upper_token)
 
+        for range_parser in (
+            self._parse_integer_range,
+            self._parse_float_range,
+            self._parse_string_range,
+        ):
+            range_filter_expression = range_parser(
+                key,
+                lower_value,
+                upper_value,
+                include_lower_bound,
+                include_upper_bound,
+                expr,
+            )
+
+            if range_filter_expression is not None:
+                return range_filter_expression
+
+        raise LuceneFilterError(f'The expression "{expression}" is invalid!')
+
+    @staticmethod
+    def _parse_integer_range(
+        key: Sequence[str],
+        lower_value: str,
+        upper_value: str,
+        include_lower_bound: bool,
+        include_upper_bound: bool,
+        expr: Range,
+    ) -> IntegerRangeFilterExpression | None:
+        """Create an integer range expression if both boundaries are integers."""
         try:
             lower_bound = int(lower_value)
             upper_bound = int(upper_value)
         except ValueError:
-            pass
-        else:
-            self._validate_range_boundaries(lower_bound, upper_bound, expr)
+            return None
 
-            return IntegerRangeFilterExpression(
-                key,
-                lower_bound,
-                upper_bound,
-            )
+        LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
+
+        return IntegerRangeFilterExpression(
+            key,
+            lower_bound,
+            upper_bound,
+            include_lower_bound,
+            include_upper_bound,
+        )
+
+    @staticmethod
+    def _parse_float_range(
+        key: Sequence[str],
+        lower_value: str,
+        upper_value: str,
+        include_lower_bound: bool,
+        include_upper_bound: bool,
+        expr: Range,
+    ) -> FloatRangeFilterExpression | None:
+        """Create a float range expression if both boundaries are finite floats."""
+        if LuceneTransformer._is_integer_range_boundary(
+            lower_value
+        ) or LuceneTransformer._is_integer_range_boundary(upper_value):
+            return None
 
         try:
-            lower_bound_float = float(lower_value)
-            upper_bound_float = float(upper_value)
-        except ValueError as error:
-            raise LuceneFilterError(f'The expression "{expression}" is invalid!') from error
+            lower_bound = float(lower_value)
+            upper_bound = float(upper_value)
+        except ValueError:
+            return None
 
-        if not math.isfinite(lower_bound_float) or not math.isfinite(upper_bound_float):
+        expression = str(expr)
+
+        if not math.isfinite(lower_bound) or not math.isfinite(upper_bound):
             raise LuceneFilterError(
                 f'The expression "{expression}" is invalid. '
                 "Range boundaries must be finite numbers."
             )
 
-        self._validate_range_boundaries(
-            lower_bound_float,
-            upper_bound_float,
-            expr,
-        )
+        LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
 
         return FloatRangeFilterExpression(
             key,
-            lower_bound_float,
-            upper_bound_float,
+            lower_bound,
+            upper_bound,
+            include_lower_bound,
+            include_upper_bound,
         )
+
+    @staticmethod
+    def _parse_string_range(
+        key: Sequence[str],
+        lower_value: str,
+        upper_value: str,
+        include_lower_bound: bool,
+        include_upper_bound: bool,
+        expr: Range,
+    ) -> StringRangeFilterExpression:
+        """Create a lexicographic string range expression for non-numeric boundaries."""
+        if lower_value == "*" or upper_value == "*":
+            raise LuceneFilterError(f'The expression "{expr}" is invalid!')
+
+        if LuceneTransformer._is_numeric_range_boundary(
+            lower_value
+        ) or LuceneTransformer._is_numeric_range_boundary(upper_value):
+            raise LuceneFilterError(f'The expression "{expr}" is invalid!')
+
+        LuceneTransformer._validate_range_boundaries(lower_value, upper_value, expr)
+
+        return StringRangeFilterExpression(
+            key,
+            lower_value,
+            upper_value,
+            include_lower_bound,
+            include_upper_bound,
+        )
+
+    @staticmethod
+    def _is_numeric_range_boundary(value: str) -> bool:
+        """Return whether a range boundary can be interpreted as a finite number."""
+        try:
+            numeric_value = float(value)
+        except ValueError:
+            return False
+
+        return math.isfinite(numeric_value)
+
+    @staticmethod
+    def _is_integer_range_boundary(value: str) -> bool:
+        """Return whether a range boundary can be interpreted as an integer."""
+        try:
+            int(value)
+        except ValueError:
+            return False
+
+        return True
+
+    @staticmethod
+    def _is_float_range_boundary(value: str) -> bool:
+        """Return whether a range boundary can be interpreted as a finite float."""
+        if LuceneTransformer._is_integer_range_boundary(value):
+            return False
+
+        try:
+            numeric_value = float(value)
+        except ValueError:
+            return False
+
+        return math.isfinite(numeric_value)
 
     @staticmethod
     def _get_range_boundary_value(token: luqum.tree) -> str:
@@ -398,7 +507,7 @@ class LuceneTransformer:
         if isinstance(token, Word):
             return token.value
 
-        if isinstance(token, Prohibit):
+        if isinstance(token, Prohibit) and len(token.children) == 1:
             child = token.children[0]
 
             if isinstance(child, Word):
@@ -408,16 +517,20 @@ class LuceneTransformer:
 
     @staticmethod
     def _validate_range_boundaries(
-        lower_bound: int | float,
-        upper_bound: int | float,
+        lower_bound: RangeBoundary,
+        upper_bound: RangeBoundary,
         expr: Range,
     ) -> None:
         """Validate that the range boundaries form an ascending range.
 
-        The range filter expressions expect the lower boundary to be less than
-        or equal to the upper boundary. Without this validation, a reversed range
-        such as ``[10 TO 0]`` would be accepted but could never match any value,
-        which would hide a likely configuration error.
+        Range filter expressions require the lower boundary to be less than or equal
+        to the upper boundary. This is independent of whether the boundaries are
+        inclusive or exclusive.
+
+        Numeric boundaries are compared numerically. String boundaries are compared
+        lexicographically. Without this validation, a reversed range such as
+        ``[10 TO 0]`` or ``[foo TO bar]`` would be accepted but could never match
+        any value, which would hide a likely configuration error.
         """
 
         if lower_bound > upper_bound:

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -130,7 +130,7 @@ The example matches log messages in which the value of :code:`timestamp` is
 lexicographically greater than or equal to :code:`2024-01-01T00:00:00Z` and
 less than or equal to :code:`2024-12-31T23:59:59Z`.
 
-Timestamp values containing Lucene special characters must be quoted. This is
+Range boundaries containing Lucene special characters must be quoted. This is
 required, for example, for ISO-8601 timestamps with timezone offsets:
 
 

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -115,6 +115,32 @@ String ranges are compared lexicographically:
     filter: 'status:[alpha TO stable]'
 
 
+This also allows matching consistently formatted ISO-8601 timestamps as string
+ranges:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'timestamp:[2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z]'
+
+
+The example matches log messages in which the value of :code:`timestamp` is
+lexicographically greater than or equal to :code:`2024-01-01T00:00:00Z` and
+less than or equal to :code:`2024-12-31T23:59:59Z`.
+
+Timestamp values containing Lucene special characters must be quoted. This is
+required, for example, for ISO-8601 timestamps with timezone offsets:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'timestamp:["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]'
+
+
 Range expressions can also be used within field groups:
 
 
@@ -125,8 +151,9 @@ Range expressions can also be used within field groups:
     filter: 'temperature:([18.5 TO 25.0])'
 
 
-Open boundaries using :code:`*`, non-finite numeric boundaries, and mixed
-boundary types are not supported.
+Open boundaries using :code:`*`, non-finite numeric boundaries, mixed boundary
+types, and unquoted boundaries containing Lucene special characters are not
+supported.
 
 RegEx-Filter
 ------------

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -403,17 +403,8 @@ class LuceneTransformer:
         raise LuceneFilterError(f'The expression "{str(tree)}" is invalid!')
 
     def _parse_range(self, key: Sequence[str], expr: Range) -> FilterExpression:
-        expression = str(expr)
-        lower_token, upper_token = expr.children
-
-        include_lower_bound = expression.startswith("[")
-        include_upper_bound = expression.endswith("]")
-
-        if not expression.startswith(("[", "{")) or not expression.endswith(("]", "}")):
-            raise LuceneFilterError(f'The expression "{expression}" is invalid!')
-
-        lower_value = self._get_range_boundary_value(lower_token)
-        upper_value = self._get_range_boundary_value(upper_token)
+        lower_value = self._get_range_boundary_value(expr.low)
+        upper_value = self._get_range_boundary_value(expr.high)
 
         for range_parser in (
             self._parse_integer_range,
@@ -424,15 +415,15 @@ class LuceneTransformer:
                 key,
                 lower_value,
                 upper_value,
-                include_lower_bound,
-                include_upper_bound,
+                expr.include_low,
+                expr.include_high,
                 expr,
             )
 
             if range_filter_expression is not None:
                 return range_filter_expression
 
-        raise LuceneFilterError(f'The expression "{expression}" is invalid!')
+        raise LuceneFilterError(f'The expression "{expr}" is invalid!')
 
     @staticmethod
     def _parse_integer_range(
@@ -469,24 +460,16 @@ class LuceneTransformer:
         include_upper_bound: bool,
         expr: Range,
     ) -> FloatRangeFilterExpression | None:
-        """Create a float range expression if both boundaries are finite floats."""
-        if LuceneTransformer._is_integer_range_boundary(
-            lower_value
-        ) or LuceneTransformer._is_integer_range_boundary(upper_value):
-            return None
-
+        """Create a float range expression if both boundaries are finite numbers."""
         try:
             lower_bound = float(lower_value)
             upper_bound = float(upper_value)
         except ValueError:
             return None
 
-        expression = str(expr)
-
         if not math.isfinite(lower_bound) or not math.isfinite(upper_bound):
             raise LuceneFilterError(
-                f'The expression "{expression}" is invalid. '
-                "Range boundaries must be finite numbers."
+                f'The expression "{expr}" is invalid. ' "Range boundaries must be finite numbers."
             )
 
         LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
@@ -507,15 +490,15 @@ class LuceneTransformer:
         include_lower_bound: bool,
         include_upper_bound: bool,
         expr: Range,
-    ) -> StringRangeFilterExpression:
+    ) -> StringRangeFilterExpression | None:
         """Create a lexicographic string range expression for non-numeric boundaries."""
         if lower_value == "*" or upper_value == "*":
             raise LuceneFilterError(f'The expression "{expr}" is invalid!')
 
-        if LuceneTransformer._is_numeric_range_boundary(
+        if LuceneTransformer._is_finite_numeric_range_boundary(
             lower_value
-        ) or LuceneTransformer._is_numeric_range_boundary(upper_value):
-            raise LuceneFilterError(f'The expression "{expr}" is invalid!')
+        ) or LuceneTransformer._is_finite_numeric_range_boundary(upper_value):
+            return None
 
         LuceneTransformer._validate_range_boundaries(lower_value, upper_value, expr)
 
@@ -528,31 +511,8 @@ class LuceneTransformer:
         )
 
     @staticmethod
-    def _is_numeric_range_boundary(value: str) -> bool:
+    def _is_finite_numeric_range_boundary(value: str) -> bool:
         """Return whether a range boundary can be interpreted as a finite number."""
-        try:
-            numeric_value = float(value)
-        except ValueError:
-            return False
-
-        return math.isfinite(numeric_value)
-
-    @staticmethod
-    def _is_integer_range_boundary(value: str) -> bool:
-        """Return whether a range boundary can be interpreted as an integer."""
-        try:
-            int(value)
-        except ValueError:
-            return False
-
-        return True
-
-    @staticmethod
-    def _is_float_range_boundary(value: str) -> bool:
-        """Return whether a range boundary can be interpreted as a finite float."""
-        if LuceneTransformer._is_integer_range_boundary(value):
-            return False
-
         try:
             numeric_value = float(value)
         except ValueError:

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -1,4 +1,6 @@
 # pylint: disable=anomalous-backslash-in-string
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-return-statements
 r"""
 Filter
 ======
@@ -141,7 +143,8 @@ To be recognized as a regular expression, the filter field has to start with
     filter: 'ip_address: /192\.168\.0\..*/'
 
 
-[Deprecated, but still functional] The field with the regex pattern must be added to the optional field
+[Deprecated, but still functional] The field with the regex pattern
+must be added to the optional field
 :code:`regex_fields` in the rule definition.
 
 In the following example the field :code:`ip_address` is defined as regex field.
@@ -532,16 +535,19 @@ class LuceneTransformer:
 
     @staticmethod
     def _get_range_boundary_value(token: luqum.tree) -> str:
-        """Return a range boundary as a normalized numeric string.
+        """Return a range boundary as a normalized string.
 
         Luqum parses a negative boundary such as ``-10`` as
-        ``Prohibit(Word("10"))`` instead of ``Word("-10")``. This helper is
-        therefore required to normalize both positive and negative boundary
-        nodes into the string representation expected by the numeric parsers.
+        ``Prohibit(Word("10"))`` instead of ``Word("-10")``. Quoted boundaries are
+        parsed as phrases and are required for values containing Lucene special
+        characters, such as ISO-8601 timestamps with timezone offsets.
         """
 
         if isinstance(token, Word):
             return token.value
+
+        if isinstance(token, Phrase):
+            return token.value.strip('"')
 
         if isinstance(token, Prohibit) and len(token.children) == 1:
             child = token.children[0]

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -58,6 +58,38 @@ This example is not complete, since rules are specific to processors and require
 
     { "filter": "event_id: 1 AND NOT ip_address: 192.168.0.1" }
 
+Range-Filter
+------------
+
+It is possible to use inclusive range expressions to match numeric values.
+The lower and upper boundaries are included and must be specified using square
+brackets. Both integer and floating-point boundaries are supported.
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'age:[18 TO 65]'
+
+
+The example matches log messages in which the value of :code:`age` is greater
+than or equal to :code:`18` and less than or equal to :code:`65`.
+
+Range expressions can also be used within field groups:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'temperature:([18.5 TO 25.0])'
+
+
+Only closed numeric ranges using square brackets are currently supported.
+Exclusive ranges using curly brackets, open boundaries using :code:`*`, and
+non-numeric boundaries are not supported.
+
 RegEx-Filter
 ------------
 

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -93,6 +93,7 @@ require additional options.
 """
 
 import logging
+import math
 import re
 from itertools import chain, zip_longest
 from typing import Sequence
@@ -106,16 +107,21 @@ from luqum.tree import (
     Not,
     OrOperation,
     Phrase,
+    Prohibit,
+    Range,
     Regex,
     SearchField,
     Word,
 )
+
 from logprep.abc.exceptions import LogprepException
 from logprep.filter.expression.filter_expression import (
     Always,
     And,
     Exists,
     FilterExpression,
+    FloatRangeFilterExpression,
+    IntegerRangeFilterExpression,
 )
 from logprep.filter.expression.filter_expression import Not as NotExpression
 from logprep.filter.expression.filter_expression import (
@@ -275,6 +281,14 @@ class LuceneTransformer:
             # pylint: enable=no-value-for-parameter
         if isinstance(tree, Group):
             return self._parse_tree(tree.children[0])
+
+        if isinstance(tree, Range):
+            if self._last_search_field is None:
+                raise LuceneFilterError(f'The expression "{str(tree)}" is invalid!')
+
+            key = get_dotted_field_list(self._last_search_field)
+            return self._parse_range(key, tree)
+
         if isinstance(tree, SearchField):
             if isinstance(tree.expr, FieldGroup):
                 self._last_search_field = tree.name
@@ -287,6 +301,97 @@ class LuceneTransformer:
                 return self._create_field_group_expression(tree, self._last_search_field)
             return self._create_value_expression(tree)
         raise LuceneFilterError(f'The expression "{str(tree)}" is invalid!')
+
+    def _parse_range(self, key: Sequence[str], expr: Range) -> FilterExpression:
+        expression = str(expr)
+        lower_token, upper_token = expr.children
+
+        if not expression.startswith("[") or not expression.endswith("]"):
+            raise LuceneFilterError(
+                f'The expression "{expression}" is invalid. '
+                "Only inclusive ranges using square brackets are supported."
+            )
+
+        lower_value = self._get_range_boundary_value(lower_token)
+        upper_value = self._get_range_boundary_value(upper_token)
+
+        try:
+            lower_bound = int(lower_value)
+            upper_bound = int(upper_value)
+        except ValueError:
+            pass
+        else:
+            self._validate_range_boundaries(lower_bound, upper_bound, expr)
+
+            return IntegerRangeFilterExpression(
+                key,
+                lower_bound,
+                upper_bound,
+            )
+
+        try:
+            lower_bound_float = float(lower_value)
+            upper_bound_float = float(upper_value)
+        except ValueError as error:
+            raise LuceneFilterError(f'The expression "{expression}" is invalid!') from error
+
+        if not math.isfinite(lower_bound_float) or not math.isfinite(upper_bound_float):
+            raise LuceneFilterError(
+                f'The expression "{expression}" is invalid. '
+                "Range boundaries must be finite numbers."
+            )
+
+        self._validate_range_boundaries(
+            lower_bound_float,
+            upper_bound_float,
+            expr,
+        )
+
+        return FloatRangeFilterExpression(
+            key,
+            lower_bound_float,
+            upper_bound_float,
+        )
+
+    @staticmethod
+    def _get_range_boundary_value(token: luqum.tree) -> str:
+        """Return a range boundary as a normalized numeric string.
+
+        Luqum parses a negative boundary such as ``-10`` as
+        ``Prohibit(Word("10"))`` instead of ``Word("-10")``. This helper is
+        therefore required to normalize both positive and negative boundary
+        nodes into the string representation expected by the numeric parsers.
+        """
+
+        if isinstance(token, Word):
+            return token.value
+
+        if isinstance(token, Prohibit):
+            child = token.children[0]
+
+            if isinstance(child, Word):
+                return f"-{child.value}"
+
+        raise LuceneFilterError(f'The range boundary "{token}" is invalid!')
+
+    @staticmethod
+    def _validate_range_boundaries(
+        lower_bound: int | float,
+        upper_bound: int | float,
+        expr: Range,
+    ) -> None:
+        """Validate that the range boundaries form an ascending range.
+
+        The range filter expressions expect the lower boundary to be less than
+        or equal to the upper boundary. Without this validation, a reversed range
+        such as ``[10 TO 0]`` would be accepted but could never match any value,
+        which would hide a likely configuration error.
+        """
+
+        if lower_bound > upper_bound:
+            raise LuceneFilterError(
+                "The lower range boundary must not exceed " f'the upper range boundary: "{expr}"'
+            )
 
     def _create_field_group_expression(
         self, tree: luqum.tree, dotted_field: str
@@ -321,22 +426,27 @@ class LuceneTransformer:
         return expressions
 
     def _create_field(self, tree: luqum.tree) -> FilterExpression:
+        key = get_dotted_field_list(tree.name)
+
         if isinstance(tree.expr, (Phrase, Word)):
-            key = get_dotted_field_list(tree.name)
             if tree.expr.value == "null":
                 return Null(key)
 
             value = self._strip_quote_from_string(tree.expr.value)
             value = self._remove_lucene_escaping(value)
             return self._get_filter_expression(key, value)
+
         if isinstance(tree.expr, Regex):
-            key = get_dotted_field_list(tree.name)
             if tree.expr.value == "null":
                 return Null(key)
 
             value = self._strip_quote_from_string(tree.expr.value)
             value = self._remove_lucene_escaping(value)
             return self._get_filter_expression_regex(key, value)
+
+        if isinstance(tree.expr, Range):
+            return self._parse_range(key, tree.expr)
+
         raise LuceneFilterError(f'The expression "{str(tree)}" is invalid!')
 
     @staticmethod

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -256,7 +256,7 @@ class TestIntegerRangeFilterExpression(ValueBasedFilterExpressionTest):
         assert not self.filter.matches({"key1": {"key2": 42 + 1}})
 
     def test_does_not_match_when_value_is_in_range_but_as_float(self):
-        assert self.filter.matches({"key1": {"key2": 24.0}})
+        assert not self.filter.matches({"key1": {"key2": 24.0}})
 
     def test_does_match_when_value_is_in_range(self):
         for i in range(23, 43):

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -8,21 +8,21 @@ from string import ascii_letters, digits
 import pytest
 
 from logprep.filter.expression.filter_expression import (
-    FilterExpression,
-    KeyDoesNotExistError,
-    StringFilterExpression,
-    IntegerFilterExpression,
-    And,
-    Or,
-    Not,
-    RegExFilterExpression,
-    IntegerRangeFilterExpression,
-    FloatRangeFilterExpression,
-    FloatFilterExpression,
     Always,
-    WildcardStringFilterExpression,
-    SigmaFilterExpression,
+    And,
     Exists,
+    FilterExpression,
+    FloatFilterExpression,
+    FloatRangeFilterExpression,
+    IntegerFilterExpression,
+    IntegerRangeFilterExpression,
+    KeyDoesNotExistError,
+    Not,
+    Or,
+    RegExFilterExpression,
+    SigmaFilterExpression,
+    StringFilterExpression,
+    WildcardStringFilterExpression,
 )
 from logprep.filter.lucene_filter import LuceneFilter
 
@@ -583,3 +583,127 @@ class TestLuceneRepresentation:
         assert (
             str(filter_expression) == expected_lucene_filter_query
         ), f"Expected: '{expected_lucene_filter_query}', but got: '{filter_expression}'"
+
+    @pytest.mark.parametrize(
+        ("filter_expression", "field_name", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "age:[0 TO 10] OR age:[20 TO 30]",
+                "age",
+                (0, 5, 10, 20, 25, 30),
+                (-1, 15, 31),
+                id="integer-ranges-with-or",
+            ),
+            pytest.param(
+                "age:[0 TO 10] AND age:[5 TO 15]",
+                "age",
+                (5, 7, 10),
+                (0, 4, 11, 15),
+                id="integer-ranges-with-and",
+            ),
+            pytest.param(
+                "temperature:[18.5 TO 25.0] OR temperature:[33.5 TO 55.0]",
+                "temperature",
+                (18.5, 20.0, 25.0, 33.5, 40.0, 55.0),
+                (18.4, 30.0, 55.1),
+                id="float-ranges-with-or",
+            ),
+            pytest.param(
+                "temperature:[18.5 TO 33.5] AND temperature:[25.0 TO 55.0]",
+                "temperature",
+                (25.0, 30.0, 33.5),
+                (18.5, 24.9, 33.6, 55.0),
+                id="float-ranges-with-and",
+            ),
+            pytest.param(
+                "status:[alpha TO beta] OR status:[stable TO zulu]",
+                "status",
+                ("alpha", "beta", "stable", "zulu"),
+                ("delta", "aaa", "zzzz"),
+                id="string-ranges-with-or",
+            ),
+            pytest.param(
+                "status:[alpha TO stable] AND status:[beta TO zulu]",
+                "status",
+                ("beta", "delta", "stable"),
+                ("alpha", "aaa", "zulu", "zzzz"),
+                id="string-ranges-with-and",
+            ),
+        ),
+    )
+    def test_created_range_filter_supports_combination_of_ranges(
+        self,
+        filter_expression,
+        field_name,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(filter_expression)
+
+        for value in matching_values:
+            assert lucene_filter.matches({field_name: value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({field_name: value})
+
+    @pytest.mark.parametrize(
+        ("filter_expression", "field_name", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "age:([0 TO 10] OR [20 TO 30])",
+                "age",
+                (0, 5, 10, 20, 25, 30),
+                (-1, 15, 31),
+                id="integer-field-group-ranges-with-or",
+            ),
+            pytest.param(
+                "age:([0 TO 10] AND [5 TO 15])",
+                "age",
+                (5, 7, 10),
+                (0, 4, 11, 15),
+                id="integer-field-group-ranges-with-and",
+            ),
+            pytest.param(
+                "temperature:([18.5 TO 25.0] OR [33.5 TO 55.0])",
+                "temperature",
+                (18.5, 20.0, 25.0, 33.5, 40.0, 55.0),
+                (18.4, 30.0, 55.1),
+                id="float-field-group-ranges-with-or",
+            ),
+            pytest.param(
+                "temperature:([18.5 TO 33.5] AND [25.0 TO 55.0])",
+                "temperature",
+                (25.0, 30.0, 33.5),
+                (18.5, 24.9, 33.6, 55.0),
+                id="float-field-group-ranges-with-and",
+            ),
+            pytest.param(
+                "status:([alpha TO beta] OR [stable TO zulu])",
+                "status",
+                ("alpha", "beta", "stable", "zulu"),
+                ("delta", "aaa", "zzzz"),
+                id="string-field-group-ranges-with-or",
+            ),
+            pytest.param(
+                "status:([alpha TO stable] AND [beta TO zulu])",
+                "status",
+                ("beta", "delta", "stable"),
+                ("alpha", "aaa", "zulu", "zzzz"),
+                id="string-field-group-ranges-with-and",
+            ),
+        ),
+    )
+    def test_created_range_filter_supports_combination_of_field_group_ranges(
+        self,
+        filter_expression,
+        field_name,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(filter_expression)
+
+        for value in matching_values:
+            assert lucene_filter.matches({field_name: value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({field_name: value})

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -585,125 +585,310 @@ class TestLuceneRepresentation:
         ), f"Expected: '{expected_lucene_filter_query}', but got: '{filter_expression}'"
 
     @pytest.mark.parametrize(
-        ("filter_expression", "field_name", "matching_values", "non_matching_values"),
+        ("filter_expression", "matching_documents", "non_matching_documents"),
         (
             pytest.param(
                 "age:[0 TO 10] OR age:[20 TO 30]",
-                "age",
-                (0, 5, 10, 20, 25, 30),
-                (-1, 15, 31),
+                (
+                    {"age": 0},
+                    {"age": 5},
+                    {"age": 10},
+                    {"age": 20},
+                    {"age": 25},
+                    {"age": 30},
+                ),
+                (
+                    {"age": -1},
+                    {"age": 15},
+                    {"age": 31},
+                ),
                 id="integer-ranges-with-or",
             ),
             pytest.param(
                 "age:[0 TO 10] AND age:[5 TO 15]",
-                "age",
-                (5, 7, 10),
-                (0, 4, 11, 15),
+                (
+                    {"age": 5},
+                    {"age": 7},
+                    {"age": 10},
+                ),
+                (
+                    {"age": 0},
+                    {"age": 4},
+                    {"age": 11},
+                    {"age": 15},
+                ),
                 id="integer-ranges-with-and",
             ),
             pytest.param(
                 "temperature:[18.5 TO 25.0] OR temperature:[33.5 TO 55.0]",
-                "temperature",
-                (18.5, 20.0, 25.0, 33.5, 40.0, 55.0),
-                (18.4, 30.0, 55.1),
+                (
+                    {"temperature": 18.5},
+                    {"temperature": 20.0},
+                    {"temperature": 25.0},
+                    {"temperature": 33.5},
+                    {"temperature": 40.0},
+                    {"temperature": 55.0},
+                ),
+                (
+                    {"temperature": 18.4},
+                    {"temperature": 30.0},
+                    {"temperature": 55.1},
+                ),
                 id="float-ranges-with-or",
             ),
             pytest.param(
                 "temperature:[18.5 TO 33.5] AND temperature:[25.0 TO 55.0]",
-                "temperature",
-                (25.0, 30.0, 33.5),
-                (18.5, 24.9, 33.6, 55.0),
+                (
+                    {"temperature": 25.0},
+                    {"temperature": 30.0},
+                    {"temperature": 33.5},
+                ),
+                (
+                    {"temperature": 18.5},
+                    {"temperature": 24.9},
+                    {"temperature": 33.6},
+                    {"temperature": 55.0},
+                ),
                 id="float-ranges-with-and",
             ),
             pytest.param(
                 "status:[alpha TO beta] OR status:[stable TO zulu]",
-                "status",
-                ("alpha", "beta", "stable", "zulu"),
-                ("delta", "aaa", "zzzz"),
+                (
+                    {"status": "alpha"},
+                    {"status": "beta"},
+                    {"status": "stable"},
+                    {"status": "zulu"},
+                ),
+                (
+                    {"status": "delta"},
+                    {"status": "aaa"},
+                    {"status": "zzzz"},
+                ),
                 id="string-ranges-with-or",
             ),
             pytest.param(
                 "status:[alpha TO stable] AND status:[beta TO zulu]",
-                "status",
-                ("beta", "delta", "stable"),
-                ("alpha", "aaa", "zulu", "zzzz"),
+                (
+                    {"status": "beta"},
+                    {"status": "delta"},
+                    {"status": "stable"},
+                ),
+                (
+                    {"status": "alpha"},
+                    {"status": "aaa"},
+                    {"status": "zulu"},
+                    {"status": "zzzz"},
+                ),
                 id="string-ranges-with-and",
+            ),
+            pytest.param(
+                "(age:[0 TO 10] OR age:[20 TO 30]) AND status:[active TO stable]",
+                (
+                    {"age": 5, "status": "active"},
+                    {"age": 25, "status": "beta"},
+                    {"age": 30, "status": "stable"},
+                ),
+                (
+                    {"age": 15, "status": "active"},
+                    {"age": 5, "status": "zzz"},
+                    {"age": 25, "status": "aaa"},
+                ),
+                id="parenthesized-non-group-ranges-with-and-to-other-field",
+            ),
+            pytest.param(
+                "(temperature:[18.5 TO 25.0] OR temperature:[33.5 TO 55.0]) "
+                "AND status:[ok TO stable]",
+                (
+                    {"temperature": 20.0, "status": "ok"},
+                    {"temperature": 40.0, "status": "stable"},
+                ),
+                (
+                    {"temperature": 30.0, "status": "ok"},
+                    {"temperature": 20.0, "status": "fail"},
+                    {"temperature": 40.0, "status": "zzz"},
+                ),
+                id="parenthesized-float-ranges-with-string-range-on-other-field",
+            ),
+            pytest.param(
+                "(status:[alpha TO beta] OR status:[stable TO zulu]) AND age:[18 TO 65]",
+                (
+                    {"status": "alpha", "age": 18},
+                    {"status": "stable", "age": 42},
+                    {"status": "zulu", "age": 65},
+                ),
+                (
+                    {"status": "delta", "age": 42},
+                    {"status": "alpha", "age": 17},
+                    {"status": "zulu", "age": 66},
+                ),
+                id="parenthesized-string-ranges-with-integer-range-on-other-field",
             ),
         ),
     )
     def test_created_range_filter_supports_combination_of_ranges(
         self,
         filter_expression,
-        field_name,
-        matching_values,
-        non_matching_values,
+        matching_documents,
+        non_matching_documents,
     ):
         lucene_filter = LuceneFilter.create(filter_expression)
 
-        for value in matching_values:
-            assert lucene_filter.matches({field_name: value})
+        for document in matching_documents:
+            assert lucene_filter.matches(document)
 
-        for value in non_matching_values:
-            assert not lucene_filter.matches({field_name: value})
+        for document in non_matching_documents:
+            assert not lucene_filter.matches(document)
 
     @pytest.mark.parametrize(
-        ("filter_expression", "field_name", "matching_values", "non_matching_values"),
+        ("filter_expression", "matching_documents", "non_matching_documents"),
         (
             pytest.param(
                 "age:([0 TO 10] OR [20 TO 30])",
-                "age",
-                (0, 5, 10, 20, 25, 30),
-                (-1, 15, 31),
+                (
+                    {"age": 0},
+                    {"age": 5},
+                    {"age": 10},
+                    {"age": 20},
+                    {"age": 25},
+                    {"age": 30},
+                ),
+                (
+                    {"age": -1},
+                    {"age": 15},
+                    {"age": 31},
+                ),
                 id="integer-field-group-ranges-with-or",
             ),
             pytest.param(
                 "age:([0 TO 10] AND [5 TO 15])",
-                "age",
-                (5, 7, 10),
-                (0, 4, 11, 15),
+                (
+                    {"age": 5},
+                    {"age": 7},
+                    {"age": 10},
+                ),
+                (
+                    {"age": 0},
+                    {"age": 4},
+                    {"age": 11},
+                    {"age": 15},
+                ),
                 id="integer-field-group-ranges-with-and",
             ),
             pytest.param(
                 "temperature:([18.5 TO 25.0] OR [33.5 TO 55.0])",
-                "temperature",
-                (18.5, 20.0, 25.0, 33.5, 40.0, 55.0),
-                (18.4, 30.0, 55.1),
+                (
+                    {"temperature": 18.5},
+                    {"temperature": 20.0},
+                    {"temperature": 25.0},
+                    {"temperature": 33.5},
+                    {"temperature": 40.0},
+                    {"temperature": 55.0},
+                ),
+                (
+                    {"temperature": 18.4},
+                    {"temperature": 30.0},
+                    {"temperature": 55.1},
+                ),
                 id="float-field-group-ranges-with-or",
             ),
             pytest.param(
                 "temperature:([18.5 TO 33.5] AND [25.0 TO 55.0])",
-                "temperature",
-                (25.0, 30.0, 33.5),
-                (18.5, 24.9, 33.6, 55.0),
+                (
+                    {"temperature": 25.0},
+                    {"temperature": 30.0},
+                    {"temperature": 33.5},
+                ),
+                (
+                    {"temperature": 18.5},
+                    {"temperature": 24.9},
+                    {"temperature": 33.6},
+                    {"temperature": 55.0},
+                ),
                 id="float-field-group-ranges-with-and",
             ),
             pytest.param(
                 "status:([alpha TO beta] OR [stable TO zulu])",
-                "status",
-                ("alpha", "beta", "stable", "zulu"),
-                ("delta", "aaa", "zzzz"),
+                (
+                    {"status": "alpha"},
+                    {"status": "beta"},
+                    {"status": "stable"},
+                    {"status": "zulu"},
+                ),
+                (
+                    {"status": "delta"},
+                    {"status": "aaa"},
+                    {"status": "zzzz"},
+                ),
                 id="string-field-group-ranges-with-or",
             ),
             pytest.param(
                 "status:([alpha TO stable] AND [beta TO zulu])",
-                "status",
-                ("beta", "delta", "stable"),
-                ("alpha", "aaa", "zulu", "zzzz"),
+                (
+                    {"status": "beta"},
+                    {"status": "delta"},
+                    {"status": "stable"},
+                ),
+                (
+                    {"status": "alpha"},
+                    {"status": "aaa"},
+                    {"status": "zulu"},
+                    {"status": "zzzz"},
+                ),
                 id="string-field-group-ranges-with-and",
+            ),
+            pytest.param(
+                "age:([0 TO 10] OR [20 TO 30]) AND status:[active TO stable]",
+                (
+                    {"age": 5, "status": "active"},
+                    {"age": 25, "status": "beta"},
+                    {"age": 30, "status": "stable"},
+                ),
+                (
+                    {"age": 15, "status": "active"},
+                    {"age": 5, "status": "zzz"},
+                    {"age": 25, "status": "aaa"},
+                ),
+                id="integer-field-group-ranges-with-and-to-other-field",
+            ),
+            pytest.param(
+                "temperature:([18.5 TO 25.0] OR [33.5 TO 55.0]) " "AND status:[ok TO stable]",
+                (
+                    {"temperature": 20.0, "status": "ok"},
+                    {"temperature": 40.0, "status": "stable"},
+                ),
+                (
+                    {"temperature": 30.0, "status": "ok"},
+                    {"temperature": 20.0, "status": "fail"},
+                    {"temperature": 40.0, "status": "zzz"},
+                ),
+                id="float-field-group-ranges-with-string-range-on-other-field",
+            ),
+            pytest.param(
+                "status:([alpha TO beta] OR [stable TO zulu]) AND age:[18 TO 65]",
+                (
+                    {"status": "alpha", "age": 18},
+                    {"status": "stable", "age": 42},
+                    {"status": "zulu", "age": 65},
+                ),
+                (
+                    {"status": "delta", "age": 42},
+                    {"status": "alpha", "age": 17},
+                    {"status": "zulu", "age": 66},
+                ),
+                id="string-field-group-ranges-with-integer-range-on-other-field",
             ),
         ),
     )
     def test_created_range_filter_supports_combination_of_field_group_ranges(
         self,
         filter_expression,
-        field_name,
-        matching_values,
-        non_matching_values,
+        matching_documents,
+        non_matching_documents,
     ):
         lucene_filter = LuceneFilter.create(filter_expression)
 
-        for value in matching_values:
-            assert lucene_filter.matches({field_name: value})
+        for document in matching_documents:
+            assert lucene_filter.matches(document)
 
-        for value in non_matching_values:
-            assert not lucene_filter.matches({field_name: value})
+        for document in non_matching_documents:
+            assert not lucene_filter.matches(document)

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -1143,52 +1143,36 @@ class TestLueceneFilter:
             LuceneFilter.create(range_query(range_expression))
 
     @pytest.mark.parametrize(
-        "range_expression",
+        ("range_expression", "matching_values", "non_matching_values"),
         (
             pytest.param(
                 "[0 TO 10.5]",
-                id="integer-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "{0 TO 10.5}",
-                id="exclusive-integer-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "{0 TO 10.5]",
-                id="exclusive-inclusive-integer-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "[0 TO 10.5}",
-                id="inclusive-exclusive-integer-lower-and-float-upper-bound",
+                (0.0, 5.5, 10.5),
+                (-0.1, 10.6),
+                id="integer-lower-float-upper-boundary",
             ),
             pytest.param(
                 "[-10.5 TO 10]",
-                id="float-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "{-10.5 TO 10}",
-                id="exclusive-float-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "{-10.5 TO 10]",
-                id="exclusive-inclusive-float-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "[-10.5 TO 10}",
-                id="inclusive-exclusive-float-lower-and-integer-upper-bound",
+                (-10.5, 0.0, 10.0),
+                (-10.6, 10.1),
+                id="float-lower-integer-upper-boundary",
             ),
         ),
     )
-    def test_create_rejects_mixed_integer_and_float_range_boundaries(
+    def test_created_float_range_filter_supports_mixed_integer_and_float_boundaries(
         self,
         range_query,
         range_expression,
+        matching_values,
+        non_matching_values,
     ):
-        with pytest.raises(
-            LuceneFilterError,
-            match=re.escape(f'The expression "{range_expression}" is invalid!'),
-        ):
-            LuceneFilter.create(range_query(range_expression))
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
 
     @pytest.mark.parametrize(
         "range_expression",
@@ -1362,7 +1346,10 @@ class TestLueceneFilter:
     ):
         with pytest.raises(
             LuceneFilterError,
-            match=re.escape(f'The expression "{range_expression}" is invalid!'),
+            match=re.escape(
+                f'The expression "{range_expression}" is invalid. '
+                "Range boundaries must be finite numbers."
+            ),
         ):
             LuceneFilter.create(range_query(range_expression))
 

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -22,6 +22,25 @@ from logprep.filter.lucene_filter import (
 )
 
 
+@pytest.fixture(
+    params=(
+        pytest.param(
+            "key:{range_expression}",
+            id="search-field-range",
+        ),
+        pytest.param(
+            "key:({range_expression})",
+            id="field-group-range",
+        ),
+    )
+)
+def range_query(request):
+    def create_query(range_expression: str) -> str:
+        return request.param.format(range_expression=range_expression)
+
+    return create_query
+
+
 def esc(count: int) -> str:
     """Returns given amount of escaping characters"""
     return count * "\\"
@@ -577,3 +596,291 @@ class TestLueceneFilter:
             RegExFilterExpression(["regex_key_one"], ".*value_one.*"),
             StringFilterExpression(["regex_key_one"], "/.*value_two.*/"),
         )
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[0 TO 10]",
+                (0, 5, 10),
+                (-1, 11),
+                id="positive-integer-range-including-boundaries",
+            ),
+            pytest.param(
+                "[-10 TO -1]",
+                (-10, -5, -1),
+                (-11, 0),
+                id="negative-integer-range",
+            ),
+            pytest.param(
+                "[-10 TO 10]",
+                (-10, 0, 10),
+                (-11, 11),
+                id="integer-range-across-zero",
+            ),
+            pytest.param(
+                "[0 TO 0]",
+                (0,),
+                (-1, 1),
+                id="single-integer-value-range",
+            ),
+            pytest.param(
+                "[2147483647 TO 2147483648]",
+                (2147483647, 2147483648),
+                (2147483646, 2147483649),
+                id="integer-values-above-32-bit-boundary",
+            ),
+            pytest.param(
+                "[-9223372036854775809 TO -9223372036854775808]",
+                (-9223372036854775809, -9223372036854775808),
+                (-9223372036854775810, -9223372036854775807),
+                id="integer-values-below-64-bit-boundary",
+            ),
+        ),
+    )
+    def test_created_integer_range_filter_matches_values_inside_inclusive_range(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[0.1 TO 8.5]",
+                (0.1, 5, 8.5),
+                (0.099, 8.501),
+                id="positive-float-range-including-boundaries",
+            ),
+            pytest.param(
+                "[-8.5 TO -0.1]",
+                (-8.5, -4.2, -0.1),
+                (-8.501, 0),
+                id="negative-float-range",
+            ),
+            pytest.param(
+                "[-1.5 TO 1.5]",
+                (-1.5, 0, 1.5),
+                (-1.501, 1.501),
+                id="float-range-across-zero",
+            ),
+            pytest.param(
+                "[1.5 TO 1.5]",
+                (1.5,),
+                (1.499, 1.501),
+                id="single-float-value-range",
+            ),
+            pytest.param(
+                "[0 TO 10.5]",
+                (0, 5, 10.5),
+                (-0.1, 10.6),
+                id="integer-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "[-10.5 TO 10]",
+                (-10.5, 0, 10),
+                (-10.6, 10.1),
+                id="float-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "[1e-3 TO 1e3]",
+                (0.001, 1, 1000),
+                (0.0009, 1000.1),
+                id="scientific-notation",
+            ),
+            pytest.param(
+                "[-1.0e3 TO -1.0e-3]",
+                (-1000, -1, -0.001),
+                (-1000.1, 0),
+                id="negative-scientific-notation",
+            ),
+        ),
+    )
+    def test_created_float_range_filter_matches_values_inside_inclusive_range(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[0 TO 10]",
+                id="integer-range",
+            ),
+            pytest.param(
+                "[-1.5 TO 1.5]",
+                id="float-range",
+            ),
+        ),
+    )
+    def test_created_range_filter_does_not_match_missing_field(
+        self,
+        range_query,
+        range_expression,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        assert not lucene_filter.matches({})
+        assert not lucene_filter.matches({"other_key": 5})
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[10 TO 0]",
+                id="reversed-integer-range",
+            ),
+            pytest.param(
+                "[10.5 TO -1.5]",
+                id="reversed-float-range",
+            ),
+        ),
+    )
+    def test_create_rejects_range_with_reversed_boundaries(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(
+                "The lower range boundary must not exceed "
+                f'the upper range boundary: "{range_expression}"'
+            ),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[foo TO bar]",
+                id="string-range",
+            ),
+            pytest.param(
+                "[1 TO bar]",
+                id="numeric-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "[foo TO 10]",
+                id="string-lower-and-numeric-upper-bound",
+            ),
+            pytest.param(
+                "[* TO 10]",
+                id="open-lower-bound",
+            ),
+            pytest.param(
+                "[1 TO *]",
+                id="open-upper-bound",
+            ),
+            pytest.param(
+                "[* TO *]",
+                id="fully-open-range",
+            ),
+        ),
+    )
+    def test_create_rejects_non_numeric_or_open_range(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(f'The expression "{range_expression}" is invalid!'),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[nan TO 10]",
+                id="nan-lower-bound",
+            ),
+            pytest.param(
+                "[0 TO nan]",
+                id="nan-upper-bound",
+            ),
+            pytest.param(
+                "[-inf TO 10]",
+                id="negative-infinity-lower-bound",
+            ),
+            pytest.param(
+                "[0 TO inf]",
+                id="positive-infinity-upper-bound",
+            ),
+        ),
+    )
+    def test_create_rejects_non_finite_float_range_boundaries(
+        self,
+        range_query,
+        range_expression,
+    ):
+        expected_message = (
+            f'The expression "{range_expression}" is invalid. '
+            "Range boundaries must be finite numbers."
+        )
+
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(expected_message),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "{0 TO 10}",
+                id="both-boundaries-exclusive",
+            ),
+            pytest.param(
+                "{0 TO 10]",
+                id="lower-bound-exclusive",
+            ),
+            pytest.param(
+                "[0 TO 10}",
+                id="upper-bound-exclusive",
+            ),
+            pytest.param(
+                "{-10.5 TO 10.5}",
+                id="exclusive-float-range",
+            ),
+        ),
+    )
+    def test_create_rejects_range_with_exclusive_boundary(
+        self,
+        range_query,
+        range_expression,
+    ):
+        expected_message = (
+            f'The expression "{range_expression}" is invalid. '
+            "Only inclusive ranges using square brackets are supported."
+        )
+
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(expected_message),
+        ):
+            LuceneFilter.create(range_query(range_expression))

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -1,5 +1,9 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=protected-access
+# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines
+# pylint: disable=missing-function-docstring
+
 import re
 
 import pytest
@@ -1381,3 +1385,221 @@ class TestLueceneFilter:
         assert lucene_filter.matches({"key": 2.0})
         assert lucene_filter.matches({"key": 10.5})
         assert not lucene_filter.matches({"key": "2.0"})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z]",
+                (
+                    "2024-01-01T00:00:00Z",
+                    "2024-06-15T12:30:00Z",
+                    "2024-12-31T23:59:59Z",
+                ),
+                (
+                    "2023-12-31T23:59:59Z",
+                    "2025-01-01T00:00:00Z",
+                ),
+                id="iso-8601-utc-timestamp-range",
+            ),
+            pytest.param(
+                "[2024-01-01T00:00:00.000Z TO 2024-01-01T00:00:00.999Z]",
+                (
+                    "2024-01-01T00:00:00.000Z",
+                    "2024-01-01T00:00:00.500Z",
+                    "2024-01-01T00:00:00.999Z",
+                ),
+                (
+                    "2023-12-31T23:59:59.999Z",
+                    "2024-01-01T00:00:01.000Z",
+                ),
+                id="iso-8601-millisecond-timestamp-range",
+            ),
+            pytest.param(
+                '["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]',
+                (
+                    "2024-01-01T00:00:00+01:00",
+                    "2024-06-15T12:30:00+01:00",
+                    "2024-12-31T23:59:59+01:00",
+                ),
+                (
+                    "2023-12-31T23:59:59+01:00",
+                    "2025-01-01T00:00:00+01:00",
+                ),
+                id="quoted-iso-8601-offset-timestamp-range",
+            ),
+        ),
+    )
+    def test_created_string_range_filter_matches_iso_8601_timestamps_lexicographically(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z]",
+                (
+                    "2024-01-01T00:00:00Z",
+                    "2024-06-15T12:30:00Z",
+                    "2024-12-31T23:59:59Z",
+                ),
+                (
+                    "2023-12-31T23:59:59Z",
+                    "2025-01-01T00:00:00Z",
+                ),
+                id="iso-8601-inclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "{2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z}",
+                ("2024-06-15T12:30:00Z",),
+                (
+                    "2024-01-01T00:00:00Z",
+                    "2024-12-31T23:59:59Z",
+                ),
+                id="iso-8601-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z]",
+                (
+                    "2024-06-15T12:30:00Z",
+                    "2024-12-31T23:59:59Z",
+                ),
+                (
+                    "2024-01-01T00:00:00Z",
+                    "2025-01-01T00:00:00Z",
+                ),
+                id="iso-8601-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z}",
+                (
+                    "2024-01-01T00:00:00Z",
+                    "2024-06-15T12:30:00Z",
+                ),
+                (
+                    "2023-12-31T23:59:59Z",
+                    "2024-12-31T23:59:59Z",
+                ),
+                id="iso-8601-inclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                '["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]',
+                (
+                    "2024-01-01T00:00:00+01:00",
+                    "2024-06-15T12:30:00+01:00",
+                    "2024-12-31T23:59:59+01:00",
+                ),
+                (
+                    "2023-12-31T23:59:59+01:00",
+                    "2025-01-01T00:00:00+01:00",
+                ),
+                id="quoted-iso-8601-offset-inclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                '{"2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"}',
+                ("2024-06-15T12:30:00+01:00",),
+                (
+                    "2024-01-01T00:00:00+01:00",
+                    "2024-12-31T23:59:59+01:00",
+                ),
+                id="quoted-iso-8601-offset-exclusive-lower-exclusive-upper",
+            ),
+        ),
+    )
+    def test_created_string_range_filter_respects_iso_8601_timestamp_boundary_inclusiveness(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z]",
+                id="reversed-inclusive-iso-8601-timestamp-range",
+            ),
+            pytest.param(
+                "{2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z}",
+                id="reversed-exclusive-iso-8601-timestamp-range",
+            ),
+            pytest.param(
+                "{2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z]",
+                id="reversed-exclusive-inclusive-iso-8601-timestamp-range",
+            ),
+            pytest.param(
+                "[2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z}",
+                id="reversed-inclusive-exclusive-iso-8601-timestamp-range",
+            ),
+            pytest.param(
+                '["2024-12-31T23:59:59+01:00" TO "2024-01-01T00:00:00+01:00"]',
+                id="reversed-quoted-iso-8601-offset-timestamp-range",
+            ),
+        ),
+    )
+    def test_create_rejects_reversed_iso_8601_timestamp_range(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(
+                "The lower range boundary must not exceed "
+                f'the upper range boundary: "{range_expression}"'
+            ),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "[2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00]",
+                id="unquoted-iso-8601-offset-inclusive-range",
+            ),
+            pytest.param(
+                "{2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00}",
+                id="unquoted-iso-8601-offset-exclusive-range",
+            ),
+            pytest.param(
+                "{2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00]",
+                id="unquoted-iso-8601-offset-exclusive-inclusive-range",
+            ),
+            pytest.param(
+                "[2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00}",
+                id="unquoted-iso-8601-offset-inclusive-exclusive-range",
+            ),
+        ),
+    )
+    def test_create_rejects_unquoted_iso_8601_offset_timestamp_range(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match="expression not escaped correctly",
+        ):
+            LuceneFilter.create(range_query(range_expression))

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -589,14 +589,6 @@ class TestLueceneFilter:
             RegExFilterExpression(["regex_key_one"], ".*value_two.*"),
         )
 
-    def test_creates_lucene_compliance_filter_parentheses_or_one_regex(self):
-        lucene_filter = LuceneFilter.create('regex_key_one: (/.*value_one.*/ OR "/.*value_two.*/")')
-
-        assert lucene_filter == Or(
-            RegExFilterExpression(["regex_key_one"], ".*value_one.*"),
-            StringFilterExpression(["regex_key_one"], "/.*value_two.*/"),
-        )
-
     @pytest.mark.parametrize(
         ("range_expression", "matching_values", "non_matching_values"),
         (
@@ -658,7 +650,7 @@ class TestLueceneFilter:
         (
             pytest.param(
                 "[0.1 TO 8.5]",
-                (0.1, 5, 8.5),
+                (0.1, 5.0, 8.5),
                 (0.099, 8.501),
                 id="positive-float-range-including-boundaries",
             ),
@@ -670,7 +662,7 @@ class TestLueceneFilter:
             ),
             pytest.param(
                 "[-1.5 TO 1.5]",
-                (-1.5, 0, 1.5),
+                (-1.5, 0.0, 1.5),
                 (-1.501, 1.501),
                 id="float-range-across-zero",
             ),
@@ -681,27 +673,15 @@ class TestLueceneFilter:
                 id="single-float-value-range",
             ),
             pytest.param(
-                "[0 TO 10.5]",
-                (0, 5, 10.5),
-                (-0.1, 10.6),
-                id="integer-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "[-10.5 TO 10]",
-                (-10.5, 0, 10),
-                (-10.6, 10.1),
-                id="float-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
                 "[1e-3 TO 1e3]",
-                (0.001, 1, 1000),
+                (0.001, 1.0, 1000.0),
                 (0.0009, 1000.1),
                 id="scientific-notation",
             ),
             pytest.param(
                 "[-1.0e3 TO -1.0e-3]",
-                (-1000, -1, -0.001),
-                (-1000.1, 0),
+                (-1000.0, -1.0, -0.001),
+                (-1000.1, 0.0),
                 id="negative-scientific-notation",
             ),
         ),
@@ -722,15 +702,362 @@ class TestLueceneFilter:
             assert not lucene_filter.matches({"key": value})
 
     @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[bar TO foo]",
+                ("bar", "baz", "foo"),
+                ("aaa", "zoo"),
+                id="string-range-including-boundaries",
+            ),
+            pytest.param(
+                "[a TO z]",
+                ("a", "m", "z"),
+                ("A", "zz"),
+                id="single-character-string-range",
+            ),
+            pytest.param(
+                "[apple TO banana]",
+                ("apple", "apricot", "banana"),
+                ("aardvark", "carrot"),
+                id="word-string-range",
+            ),
+            pytest.param(
+                "[abc TO abc]",
+                ("abc",),
+                ("abb", "abd"),
+                id="single-string-value-range",
+            ),
+            pytest.param(
+                "[A TO z]",
+                ("A", "Z", "a", "m", "z"),
+                ("0", "zz"),
+                id="mixed-case-string-range",
+            ),
+        ),
+    )
+    def test_created_string_range_filter_matches_values_inside_lexicographic_range(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[0 TO 10]",
+                (0, 5, 10),
+                (-1, 11),
+                id="integer-inclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "{0 TO 10}",
+                (1, 5, 9),
+                (-1, 0, 10, 11),
+                id="integer-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{0 TO 10]",
+                (1, 5, 10),
+                (-1, 0, 11),
+                id="integer-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[0 TO 10}",
+                (0, 5, 9),
+                (-1, 10, 11),
+                id="integer-inclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{-10 TO -1}",
+                (-9, -5, -2),
+                (-10, -1, 0),
+                id="negative-integer-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{-10 TO -1]",
+                (-9, -5, -1),
+                (-10, 0),
+                id="negative-integer-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[-10 TO -1}",
+                (-10, -5, -2),
+                (-11, -1, 0),
+                id="negative-integer-inclusive-lower-exclusive-upper",
+            ),
+        ),
+    )
+    def test_created_integer_range_filter_respects_boundary_inclusiveness(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[0.1 TO 8.5]",
+                (0.1, 5.0, 8.5),
+                (0.099, 8.501),
+                id="float-inclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "{0.1 TO 8.5}",
+                (0.101, 5.0, 8.499),
+                (0.1, 8.5),
+                id="float-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{0.1 TO 8.5]",
+                (0.101, 5.0, 8.5),
+                (0.1, 8.501),
+                id="float-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[0.1 TO 8.5}",
+                (0.1, 5.0, 8.499),
+                (0.099, 8.5),
+                id="float-inclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{-8.5 TO -0.1}",
+                (-8.499, -4.2, -0.101),
+                (-8.5, -0.1, 0),
+                id="negative-float-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{-8.5 TO -0.1]",
+                (-8.499, -4.2, -0.1),
+                (-8.5, 0),
+                id="negative-float-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[-8.5 TO -0.1}",
+                (-8.5, -4.2, -0.101),
+                (-8.501, -0.1, 0),
+                id="negative-float-inclusive-lower-exclusive-upper",
+            ),
+        ),
+    )
+    def test_created_float_range_filter_respects_boundary_inclusiveness(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_values", "non_matching_values"),
+        (
+            pytest.param(
+                "[bar TO foo]",
+                ("bar", "baz", "foo"),
+                ("aaa", "zoo"),
+                id="string-inclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "{bar TO foo}",
+                ("baz", "faa"),
+                ("bar", "foo", "aaa", "zoo"),
+                id="string-exclusive-lower-exclusive-upper",
+            ),
+            pytest.param(
+                "{bar TO foo]",
+                ("baz", "foo"),
+                ("bar", "aaa", "zoo"),
+                id="string-exclusive-lower-inclusive-upper",
+            ),
+            pytest.param(
+                "[bar TO foo}",
+                ("bar", "baz"),
+                ("foo", "aaa", "zoo"),
+                id="string-inclusive-lower-exclusive-upper",
+            ),
+        ),
+    )
+    def test_created_string_range_filter_respects_boundary_inclusiveness(
+        self,
+        range_query,
+        range_expression,
+        matching_values,
+        non_matching_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
+
+    @pytest.mark.parametrize(
+        ("range_expression", "matching_value", "wrong_values"),
+        (
+            pytest.param(
+                "[0 TO 10]",
+                5,
+                ("5", 5.0, object()),
+                id="integer-range-does-not-match-non-integer-document-values",
+            ),
+            pytest.param(
+                "[0.1 TO 8.5]",
+                5.0,
+                ("5.0", 5, object()),
+                id="float-range-does-not-match-non-float-document-values",
+            ),
+            pytest.param(
+                "[bar TO foo]",
+                "baz",
+                (5, 5.0, object()),
+                id="string-range-does-not-match-non-string-document-values",
+            ),
+        ),
+    )
+    def test_created_range_filter_does_not_match_wrong_value_type(
+        self,
+        range_query,
+        range_expression,
+        matching_value,
+        wrong_values,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        assert lucene_filter.matches({"key": matching_value})
+
+        for wrong_value in wrong_values:
+            assert not lucene_filter.matches({"key": wrong_value})
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
+                "{0 TO 0}",
+                id="exclusive-integer-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{0 TO 0]",
+                id="exclusive-lower-integer-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "[0 TO 0}",
+                id="exclusive-upper-integer-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{1.5 TO 1.5}",
+                id="exclusive-float-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{1.5 TO 1.5]",
+                id="exclusive-lower-float-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "[1.5 TO 1.5}",
+                id="exclusive-upper-float-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{abc TO abc}",
+                id="exclusive-string-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{abc TO abc]",
+                id="exclusive-lower-string-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "[abc TO abc}",
+                id="exclusive-upper-string-range-with-equal-boundaries",
+            ),
+        ),
+    )
+    def test_created_exclusive_range_with_equal_boundaries_matches_no_value(
+        self,
+        range_query,
+        range_expression,
+    ):
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        assert not lucene_filter.matches({"key": 0})
+        assert not lucene_filter.matches({"key": 1.5})
+        assert not lucene_filter.matches({"key": "abc"})
+
+    @pytest.mark.parametrize(
         "range_expression",
         (
             pytest.param(
                 "[0 TO 10]",
-                id="integer-range",
+                id="integer-inclusive-range",
+            ),
+            pytest.param(
+                "{0 TO 10}",
+                id="integer-exclusive-range",
+            ),
+            pytest.param(
+                "{0 TO 10]",
+                id="integer-exclusive-inclusive-range",
+            ),
+            pytest.param(
+                "[0 TO 10}",
+                id="integer-inclusive-exclusive-range",
             ),
             pytest.param(
                 "[-1.5 TO 1.5]",
-                id="float-range",
+                id="float-inclusive-range",
+            ),
+            pytest.param(
+                "{-1.5 TO 1.5}",
+                id="float-exclusive-range",
+            ),
+            pytest.param(
+                "{-1.5 TO 1.5]",
+                id="float-exclusive-inclusive-range",
+            ),
+            pytest.param(
+                "[-1.5 TO 1.5}",
+                id="float-inclusive-exclusive-range",
+            ),
+            pytest.param(
+                "[bar TO foo]",
+                id="string-inclusive-range",
+            ),
+            pytest.param(
+                "{bar TO foo}",
+                id="string-exclusive-range",
+            ),
+            pytest.param(
+                "{bar TO foo]",
+                id="string-exclusive-inclusive-range",
+            ),
+            pytest.param(
+                "[bar TO foo}",
+                id="string-inclusive-exclusive-range",
             ),
         ),
     )
@@ -749,11 +1076,51 @@ class TestLueceneFilter:
         (
             pytest.param(
                 "[10 TO 0]",
-                id="reversed-integer-range",
+                id="reversed-inclusive-integer-range",
+            ),
+            pytest.param(
+                "{10 TO 0}",
+                id="reversed-exclusive-integer-range",
+            ),
+            pytest.param(
+                "{10 TO 0]",
+                id="reversed-exclusive-inclusive-integer-range",
+            ),
+            pytest.param(
+                "[10 TO 0}",
+                id="reversed-inclusive-exclusive-integer-range",
             ),
             pytest.param(
                 "[10.5 TO -1.5]",
-                id="reversed-float-range",
+                id="reversed-inclusive-float-range",
+            ),
+            pytest.param(
+                "{10.5 TO -1.5}",
+                id="reversed-exclusive-float-range",
+            ),
+            pytest.param(
+                "{10.5 TO -1.5]",
+                id="reversed-exclusive-inclusive-float-range",
+            ),
+            pytest.param(
+                "[10.5 TO -1.5}",
+                id="reversed-inclusive-exclusive-float-range",
+            ),
+            pytest.param(
+                "[foo TO bar]",
+                id="reversed-inclusive-string-range",
+            ),
+            pytest.param(
+                "{foo TO bar}",
+                id="reversed-exclusive-string-range",
+            ),
+            pytest.param(
+                "{foo TO bar]",
+                id="reversed-exclusive-inclusive-string-range",
+            ),
+            pytest.param(
+                "[foo TO bar}",
+                id="reversed-inclusive-exclusive-string-range",
             ),
         ),
     )
@@ -775,32 +1142,168 @@ class TestLueceneFilter:
         "range_expression",
         (
             pytest.param(
-                "[foo TO bar]",
-                id="string-range",
+                "[0 TO 10.5]",
+                id="integer-lower-and-float-upper-bound",
             ),
             pytest.param(
+                "{0 TO 10.5}",
+                id="exclusive-integer-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "{0 TO 10.5]",
+                id="exclusive-inclusive-integer-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "[0 TO 10.5}",
+                id="inclusive-exclusive-integer-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "[-10.5 TO 10]",
+                id="float-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "{-10.5 TO 10}",
+                id="exclusive-float-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "{-10.5 TO 10]",
+                id="exclusive-inclusive-float-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "[-10.5 TO 10}",
+                id="inclusive-exclusive-float-lower-and-integer-upper-bound",
+            ),
+        ),
+    )
+    def test_create_rejects_mixed_integer_and_float_range_boundaries(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(f'The expression "{range_expression}" is invalid!'),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
+            pytest.param(
                 "[1 TO bar]",
-                id="numeric-lower-and-string-upper-bound",
+                id="integer-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "{1 TO bar}",
+                id="exclusive-integer-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "{1 TO bar]",
+                id="exclusive-inclusive-integer-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "[1 TO bar}",
+                id="inclusive-exclusive-integer-lower-and-string-upper-bound",
             ),
             pytest.param(
                 "[foo TO 10]",
-                id="string-lower-and-numeric-upper-bound",
+                id="string-lower-and-integer-upper-bound",
             ),
+            pytest.param(
+                "{foo TO 10}",
+                id="exclusive-string-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "{foo TO 10]",
+                id="exclusive-inclusive-string-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "[foo TO 10}",
+                id="inclusive-exclusive-string-lower-and-integer-upper-bound",
+            ),
+            pytest.param(
+                "[1.5 TO bar]",
+                id="float-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "{1.5 TO bar}",
+                id="exclusive-float-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "{1.5 TO bar]",
+                id="exclusive-inclusive-float-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "[1.5 TO bar}",
+                id="inclusive-exclusive-float-lower-and-string-upper-bound",
+            ),
+            pytest.param(
+                "[foo TO 10.5]",
+                id="string-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "{foo TO 10.5}",
+                id="exclusive-string-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "{foo TO 10.5]",
+                id="exclusive-inclusive-string-lower-and-float-upper-bound",
+            ),
+            pytest.param(
+                "[foo TO 10.5}",
+                id="inclusive-exclusive-string-lower-and-float-upper-bound",
+            ),
+        ),
+    )
+    def test_create_rejects_mixed_numeric_and_string_range_boundaries(
+        self,
+        range_query,
+        range_expression,
+    ):
+        with pytest.raises(
+            LuceneFilterError,
+            match=re.escape(f'The expression "{range_expression}" is invalid!'),
+        ):
+            LuceneFilter.create(range_query(range_expression))
+
+    @pytest.mark.parametrize(
+        "range_expression",
+        (
             pytest.param(
                 "[* TO 10]",
                 id="open-lower-bound",
+            ),
+            pytest.param(
+                "{* TO 10}",
+                id="exclusive-open-lower-bound",
             ),
             pytest.param(
                 "[1 TO *]",
                 id="open-upper-bound",
             ),
             pytest.param(
+                "{1 TO *}",
+                id="exclusive-open-upper-bound",
+            ),
+            pytest.param(
                 "[* TO *]",
                 id="fully-open-range",
             ),
+            pytest.param(
+                "{* TO *}",
+                id="exclusive-fully-open-range",
+            ),
+            pytest.param(
+                "[* TO foo]",
+                id="open-lower-string-upper-bound",
+            ),
+            pytest.param(
+                "[foo TO *]",
+                id="string-lower-open-upper-bound",
+            ),
         ),
     )
-    def test_create_rejects_non_numeric_or_open_range(
+    def test_create_rejects_open_range(
         self,
         range_query,
         range_expression,
@@ -819,68 +1322,62 @@ class TestLueceneFilter:
                 id="nan-lower-bound",
             ),
             pytest.param(
+                "{nan TO 10}",
+                id="exclusive-nan-lower-bound",
+            ),
+            pytest.param(
                 "[0 TO nan]",
                 id="nan-upper-bound",
+            ),
+            pytest.param(
+                "{0 TO nan}",
+                id="exclusive-nan-upper-bound",
             ),
             pytest.param(
                 "[-inf TO 10]",
                 id="negative-infinity-lower-bound",
             ),
             pytest.param(
+                "{-inf TO 10}",
+                id="exclusive-negative-infinity-lower-bound",
+            ),
+            pytest.param(
                 "[0 TO inf]",
                 id="positive-infinity-upper-bound",
             ),
+            pytest.param(
+                "{0 TO inf}",
+                id="exclusive-positive-infinity-upper-bound",
+            ),
         ),
     )
-    def test_create_rejects_non_finite_float_range_boundaries(
+    def test_create_rejects_non_finite_range_boundaries(
         self,
         range_query,
         range_expression,
     ):
-        expected_message = (
-            f'The expression "{range_expression}" is invalid. '
-            "Range boundaries must be finite numbers."
-        )
-
         with pytest.raises(
             LuceneFilterError,
-            match=re.escape(expected_message),
+            match=re.escape(f'The expression "{range_expression}" is invalid!'),
         ):
             LuceneFilter.create(range_query(range_expression))
 
-    @pytest.mark.parametrize(
-        "range_expression",
-        (
-            pytest.param(
-                "{0 TO 10}",
-                id="both-boundaries-exclusive",
-            ),
-            pytest.param(
-                "{0 TO 10]",
-                id="lower-bound-exclusive",
-            ),
-            pytest.param(
-                "[0 TO 10}",
-                id="upper-bound-exclusive",
-            ),
-            pytest.param(
-                "{-10.5 TO 10.5}",
-                id="exclusive-float-range",
-            ),
-        ),
-    )
-    def test_create_rejects_range_with_exclusive_boundary(
+    def test_created_range_filter_prefers_integer_range_over_string_range(
         self,
         range_query,
-        range_expression,
     ):
-        expected_message = (
-            f'The expression "{range_expression}" is invalid. '
-            "Only inclusive ranges using square brackets are supported."
-        )
+        lucene_filter = LuceneFilter.create(range_query("[1 TO 10]"))
 
-        with pytest.raises(
-            LuceneFilterError,
-            match=re.escape(expected_message),
-        ):
-            LuceneFilter.create(range_query(range_expression))
+        assert lucene_filter.matches({"key": 2})
+        assert lucene_filter.matches({"key": 10})
+        assert not lucene_filter.matches({"key": "2"})
+
+    def test_created_range_filter_prefers_float_range_over_string_range(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query("[1.5 TO 10.5]"))
+
+        assert lucene_filter.matches({"key": 2.0})
+        assert lucene_filter.matches({"key": 10.5})
+        assert not lucene_filter.matches({"key": "2.0"})


### PR DESCRIPTION

## Description

* add support for inclusive numeric Lucene range expressions using square brackets, such as age:[18 TO 65].
* support integer and floating-point ranges for both regular search fields and field group syntax.
* support negative range boundaries by normalizing Luqum's Prohibit nodes.
* reject exclusive ranges, non-numeric or non-finite boundaries, and reversed ranges with descriptive errors.
* add parametrized tests covering valid ranges, boundary values, invalid expressions, and both supported syntax variants.

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--976.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->