### PR TITLE
docs: lucene range expression notebook

### DIFF
--- a/doc/source/development/notebooks/lucene_examples/lucene_range_expression.ipynb
+++ b/doc/source/development/notebooks/lucene_examples/lucene_range_expression.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.595512531Z",
+     "start_time": "2026-06-25T10:57:49.558727900Z"
+    }
+   },
+   "source": "from logprep.filter.lucene_filter import LuceneFilter",
+   "outputs": [],
+   "execution_count": 83
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.625253695Z",
+     "start_time": "2026-06-25T10:57:49.599209578Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def print_match(expression, value):\n",
+    "    lucene_filter = LuceneFilter.create(expression)\n",
+    "    print(\"Range:\", lucene_filter)\n",
+    "\n",
+    "    matching = lucene_filter.matches({\"key\": value})\n",
+    "    print(f\"Value: {value} ({'match' if matching else 'no match'})\", end=\"\\n\\n\")"
+   ],
+   "id": "6603efc355a144cc",
+   "outputs": [],
+   "execution_count": 84
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Example: lucene **`int`** range expression:",
+   "id": "faa50711fb185c27"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.660579200Z",
+     "start_time": "2026-06-25T10:57:49.632924539Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "lucene_range_expression = \"key:[5 TO 10]\"\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=10)\n",
+    "\n",
+    "# no match:\n",
+    "print_match(expression=lucene_range_expression, value=11)\n"
+   ],
+   "id": "a2408d10651f9d0b",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: key:[5 TO 10]\n",
+      "Value: 10 (match)\n",
+      "\n",
+      "Range: key:[5 TO 10]\n",
+      "Value: 11 (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 85
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Example: lucene **`float`** range expression:",
+   "id": "f33ff6b3033fb904"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.694634245Z",
+     "start_time": "2026-06-25T10:57:49.663221037Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "lucene_range_expression = \"key:[3.7 TO 5.5]\"\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=3.8)\n",
+    "\n",
+    "# no match:\n",
+    "print_match(expression=lucene_range_expression, value=5.6)"
+   ],
+   "id": "19922fdd76506c74",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: key:[3.7 TO 5.5]\n",
+      "Value: 3.8 (match)\n",
+      "\n",
+      "Range: key:[3.7 TO 5.5]\n",
+      "Value: 5.6 (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 86
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Example: lucene **`str`** range expression:",
+   "id": "f8a904e3bd215807"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.728510748Z",
+     "start_time": "2026-06-25T10:57:49.697492832Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "lucene_range_expression = \"key:[A TO K]\"\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=\"Bernhard\")\n",
+    "\n",
+    "# no match:\n",
+    "print_match(expression=lucene_range_expression, value=\"Leo\")"
+   ],
+   "id": "3df4dc69eaf7f37a",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: key:[A TO K]\n",
+      "Value: Bernhard (match)\n",
+      "\n",
+      "Range: key:[A TO K]\n",
+      "Value: Leo (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 87
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Example: lucene **`ISO 8601 timestamp`** range expression:",
+   "id": "d28d6ea9e868e1ee"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.758754038Z",
+     "start_time": "2026-06-25T10:57:49.729891708Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "lucene_range_expression = \"key:[2026-01-01 TO 2026-01-31]\"\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=\"2026-01-01\")\n",
+    "\n",
+    "# no match:\n",
+    "print_match(expression=lucene_range_expression, value=\"2026-02-01\")\n",
+    "\n",
+    "lucene_range_expression = \"key:[2026-01-01T06:00Z TO 2026-01-01T18:00Z]\" # one day\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=\"2026-01-01T18:00Z\")\n",
+    "\n",
+    "# no match:\n",
+    "print_match(expression=lucene_range_expression, value=\"2026-01-01T18:01Z\")"
+   ],
+   "id": "a728bdc174e81ab3",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: key:[2026-01-01 TO 2026-01-31]\n",
+      "Value: 2026-01-01 (match)\n",
+      "\n",
+      "Range: key:[2026-01-01 TO 2026-01-31]\n",
+      "Value: 2026-02-01 (no match)\n",
+      "\n",
+      "Range: key:[2026-01-01T06:00Z TO 2026-01-01T18:00Z]\n",
+      "Value: 2026-01-01T18:00Z (match)\n",
+      "\n",
+      "Range: key:[2026-01-01T06:00Z TO 2026-01-01T18:00Z]\n",
+      "Value: 2026-01-01T18:01Z (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 88
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Example: More complex expressions with `AND/OR`:",
+   "id": "56b3981957440b92"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.787797909Z",
+     "start_time": "2026-06-25T10:57:49.765951464Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# AND examples\n",
+    "lucene_range_expression = \"key:[0 TO 10] AND key:[10 TO 15]\"\n",
+    "\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=10)\n",
+    "\n",
+    "# no match\n",
+    "print_match(expression=lucene_range_expression, value=11)\n",
+    "\n",
+    "lucene_range_expression = \"key:[0 TO 10} AND key:[10 TO 15]\"\n",
+    "# no match\n",
+    "print_match(expression=lucene_range_expression, value=10)"
+   ],
+   "id": "5171ae3c92767a5",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: (key:[0 TO 10] AND key:[10 TO 15])\n",
+      "Value: 10 (match)\n",
+      "\n",
+      "Range: (key:[0 TO 10] AND key:[10 TO 15])\n",
+      "Value: 11 (no match)\n",
+      "\n",
+      "Range: (key:[0 TO 10} AND key:[10 TO 15])\n",
+      "Value: 10 (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 89
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-25T10:57:49.817633073Z",
+     "start_time": "2026-06-25T10:57:49.788837160Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# OR examples\n",
+    "lucene_range_expression = \"key:[0 TO 5] OR key:[10 TO 50]\"\n",
+    "\n",
+    "# match\n",
+    "print_match(expression=lucene_range_expression, value=2)\n",
+    "print_match(expression=lucene_range_expression, value=22)\n",
+    "\n",
+    "# no match\n",
+    "print_match(expression=lucene_range_expression, value=7)\n",
+    "print_match(expression=lucene_range_expression, value=77)\n"
+   ],
+   "id": "bc40bada424e656b",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Range: (key:[0 TO 5] OR key:[10 TO 50])\n",
+      "Value: 2 (match)\n",
+      "\n",
+      "Range: (key:[0 TO 5] OR key:[10 TO 50])\n",
+      "Value: 22 (match)\n",
+      "\n",
+      "Range: (key:[0 TO 5] OR key:[10 TO 50])\n",
+      "Value: 7 (no match)\n",
+      "\n",
+      "Range: (key:[0 TO 5] OR key:[10 TO 50])\n",
+      "Value: 77 (no match)\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 90
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
   "types-psutil",
   "types-PyYaml",
   "deepdiff>=8.6.2,<9", # [>=8.6.2]: CVE-2026-33155
+  "ipykernel>=7.3.0",
 ]
 
 doc = [

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +581,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
 name = "confluent-kafka"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -701,6 +719,31 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/fb/cbf306d6e07a313a91e7171a98669054502840931432c227cfd505ee367f/debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264", size = 2203120, upload-time = "2026-06-01T19:30:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/57/aa739bd4ad2cbf96aeb1b20b56918ddd5ae4c28b68709bfcd327f02123ee/debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc", size = 3059958, upload-time = "2026-06-01T19:30:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/31/453d2c9a23d133fe2c8ec7ca1d816ded52a913487fe3ffef7c01b4b706af/debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e", size = 5236515, upload-time = "2026-06-01T19:30:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/6660de2f2d7bf388f229335ba4637646eebabdbf38564cb439a95a9193c9/debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7", size = 5256138, upload-time = "2026-06-01T19:30:49.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
 ]
 
 [[package]]
@@ -1118,6 +1161,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
 name = "ipython"
 version = "9.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-client"
-version = "8.8.0"
+version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-core" },
@@ -1249,10 +1316,11 @@ dependencies = [
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
 ]
 
 [[package]]
@@ -1388,6 +1456,7 @@ dev = [
     { name = "black" },
     { name = "cibuildwheel" },
     { name = "deepdiff" },
+    { name = "ipykernel" },
     { name = "isort" },
     { name = "jinja2" },
     { name = "mypy" },
@@ -1428,6 +1497,7 @@ requires-dist = [
     { name = "filelock", specifier = "<4" },
     { name = "geoip2", specifier = ">=5.2.0,<6" },
     { name = "httptools", specifier = "<1" },
+    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.3.0" },
     { name = "ipython", marker = "extra == 'doc'", specifier = ">=8.7" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "jinja2", marker = "extra == 'dev'" },
@@ -1961,6 +2031,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/d1/82081750f8a78ad0399c6ed831d42623b891904e8e7b8a75878225cf1dce/nbsphinx-0.9.8.tar.gz", hash = "sha256:d0765908399a8ee2b57be7ae881cf2ea58d66db3af7bbf33e6eb48f83bea5495", size = 417469, upload-time = "2025-11-28T17:41:02.336Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/78/843bcf0cf31f88d2f8a9a063d2d80817b1901657d83d65b89b3aa835732e/nbsphinx-0.9.8-py3-none-any.whl", hash = "sha256:92d95ee91784e56bc633b60b767a6b6f23a0445f891e24641ce3c3f004759ccf", size = 31961, upload-time = "2025-11-28T17:41:00.796Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

* add notebook file for lucene range expression with examples

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* ran related notebook examples

* List of (preferably easy reproducible) tests including OS

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--979.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->