### PR TITLE
release: 19.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 ### Breaking
 
 ### Features
+
+### Improvements
+
+### Bugfix
+
+## 19.3.0
+### Breaking
+
+### Features
 * add Lucene range support for integer, floating-point, and lexicographic string values, including quoted ISO-8601 timestamps with timezone offsets.
 * add `deduplicator` processor that removes duplicates from lists
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
 requires-python = ">=3.11"
 readme = "README.md"
-version = "19.2.0"
+version = "19.3.0"
 license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "logprep"
-version = "19.2.0"
+version = "19.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--980.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->