### PR TITLE
fix: add network_comparison to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 
 ### Bugfix
+* add missing documentation for the `network_comparison` processor
 
 ## 19.3.0
 ### Breaking

--- a/doc/source/configuration/processor.rst
+++ b/doc/source/configuration/processor.rst
@@ -25,6 +25,7 @@ Processors
 .. automodule:: logprep.processor.key_checker.processor
 .. automodule:: logprep.processor.labeler.processor
 .. automodule:: logprep.processor.list_comparison.processor
+.. automodule:: logprep.processor.network_comparison.processor
 .. automodule:: logprep.processor.pre_detector.processor
 .. automodule:: logprep.processor.pseudonymizer.processor
 .. automodule:: logprep.processor.replacer.processor


### PR DESCRIPTION
## Description

* Added the docs for network_comparison.
* Relates to #981 

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* Reviewed the RTD docs review - direct: https://logprep--982.org.readthedocs.build/en/982/configuration/processor.html#networkcomparison OR: <a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--982.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--982.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->
