### PR TITLE
fix: parse fractional UNIX timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Upcoming Changes
 ### Breaking
+* add support for fractional UNIX timestamps in the `timestamper` processor while preserving integer timestamp normalization
 
 ### Features
-* add support for fractional UNIX timestamps in the `timestamper` processor while preserving integer timestamp normalization
 
 ### Improvements
 
@@ -60,34 +60,6 @@
 * improve robustness of compose tests
 
 ### Bugfix
-* fix `dissector` not dissecting multiline strings
-* fix `grokker` dropping matches on duplicate named capture groups
-
-## 19.4.1
-
-### Breaking
-
-### Features
-* add support for `dict` in `generic_adder`
-
-### Improvements
-* fix Pyparsing deprecation warnings
-
-### Bugfix
-* fix `add_fields_to` injecting identical objects instead of copies
-* fix `generic_adder` accumulating state by inserting identical objects in events
-
-## 19.4.0
-### Breaking
-
-### Features
-* allow `list_comparison` and `network_comparison` to use dynamic values from event to resolve list uris
-
-### Improvements
-
-### Bugfix
-* make `list_search_base_path` actually optional and correctly overrideable by rule config
-* add missing documentation for the `network_comparison` processor
 * fix `dissector` not dissecting multiline strings
 * fix `grokker` dropping matches on duplicate named capture groups
 * fix `list_comparison` & `network_comparison` to actually work with dotted field notation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Breaking
 
 ### Features
-* add support for fractional UNIX timestamps in the timestamper processor while preserving integer timestamp normalization.
+* add support for fractional UNIX timestamps in the `timestamper` processor while preserving integer timestamp normalization
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,34 @@
 ### Bugfix
 * fix `dissector` not dissecting multiline strings
 * fix `grokker` dropping matches on duplicate named capture groups
+
+## 19.4.1
+
+### Breaking
+
+### Features
+* add support for `dict` in `generic_adder`
+
+### Improvements
+* fix Pyparsing deprecation warnings
+
+### Bugfix
+* fix `add_fields_to` injecting identical objects instead of copies
+* fix `generic_adder` accumulating state by inserting identical objects in events
+
+## 19.4.0
+### Breaking
+
+### Features
+* allow `list_comparison` and `network_comparison` to use dynamic values from event to resolve list uris
+
+### Improvements
+
+### Bugfix
+* make `list_search_base_path` actually optional and correctly overrideable by rule config
+* add missing documentation for the `network_comparison` processor
+* fix `dissector` not dissecting multiline strings
+* fix `grokker` dropping matches on duplicate named capture groups
 * fix `list_comparison` & `network_comparison` to actually work with dotted field notation
 * fix `list_comparison` & `network_comparison` rule failure handling for multiple lists
 * fix `list_comparison` & `network_comparison` to raise on http-urls without `LOGPREP_LIST`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Upcoming Changes
 ### Breaking
-* add support for fractional UNIX timestamps in the `timestamper` processor while preserving integer timestamp normalization
+* Restrict UNIX timestamp normalization to supported precisions: seconds, milliseconds, microseconds, and nanoseconds. Integer and fractional UNIX timestamps with unsupported digit lengths are now rejected.
 
 ### Features
+* Add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Breaking
 
 ### Features
+* add support for fractional UNIX timestamps in the timestamper processor while preserving integer timestamp normalization.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Upcoming Changes
 ### Breaking
-* Restrict UNIX timestamp normalization to supported precisions: seconds, milliseconds, microseconds, and nanoseconds. Integer and fractional UNIX timestamps with unsupported digit lengths are now rejected.
+* restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
 
 ### Features
-* Add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
+* add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
 
 ### Improvements
 

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -11,7 +11,7 @@ class TimeParserException(LogprepException):
 
 
 class UnixTimestampLength(IntEnum):
-    """Digit lengths of common Unix timestamp representations."""
+    """Digit lengths of common UNIX timestamp representations."""
 
     SECONDS = 10
     MILLISECONDS = 13

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -1,6 +1,6 @@
 """Logprep time helpers module"""
 
-from datetime import datetime, tzinfo, UTC
+from datetime import UTC, datetime, tzinfo
 
 from logprep.abc.exceptions import LogprepException
 
@@ -126,10 +126,14 @@ class TimeParser:
     def _normalize_unix_timestamp(timestamp: str) -> int | float:
         """Normalize the input timestamp string to unix timestamp in seconds.
 
-        The input string is assumed to be in seconds if it is 10 digits long or shorter,
-        since seconds with more than 10 digits would be far into the future.
-        For strings longer than 10 digits the parsed integer is divided to be 10 digits long
-        before the decimal point.
+        Unix timestamps are assumed to be in seconds if the timestamp has 10 digits
+        or fewer before the decimal point, since seconds with more than 10 digits
+        would be far into the future. Timestamps with more than 10 digits before
+        the decimal point are scaled down so that 10 digits remain before the
+        decimal point.
+
+        Timestamp strings with a decimal point are parsed as float so fractional
+        seconds are preserved.
 
         Parameters
         ----------
@@ -144,16 +148,51 @@ class TimeParser:
         Raises
         ------
         TimeParserException
-            Raised if input timestamp string could not be parsed as integer
+            Raised if input timestamp string could not be parsed as a number
         """
         try:
-            return (
-                int(timestamp)
-                if len(timestamp) <= 10
-                else int(timestamp) / 10 ** (len(timestamp) - 10)
-            )
+            timestamp = timestamp.strip()
+            integer_part = TimeParser._get_unix_timestamp_integer_part(timestamp)
+
+            if "." in timestamp:
+                return TimeParser._normalize_fractional_unix_timestamp(timestamp, integer_part)
+
+            return TimeParser._normalize_integer_unix_timestamp(timestamp, integer_part)
         except ValueError as error:
             raise TimeParserException(str(error)) from error
+
+    @staticmethod
+    def _get_unix_timestamp_integer_part(timestamp: str) -> str:
+        """Return the integer part of a UNIX timestamp."""
+        return timestamp.split(".", maxsplit=1)[0]
+
+    @staticmethod
+    def _normalize_fractional_unix_timestamp(timestamp: str, integer_part: str) -> float:
+        """Normalize a fractional UNIX timestamp to seconds.
+
+        Fractional UNIX timestamps are parsed as float to preserve sub-second
+        precision. The digit-count heuristic is applied to the integer part only.
+        """
+        parsed_timestamp = float(timestamp)
+        return (
+            parsed_timestamp
+            if len(integer_part) <= 10
+            else parsed_timestamp / 10 ** (len(integer_part) - 10)
+        )
+
+    @staticmethod
+    def _normalize_integer_unix_timestamp(timestamp: str, integer_part: str) -> int | float:
+        """Normalize an integer-only UNIX timestamp to seconds.
+
+        Existing behavior is preserved: timestamps with 10 digits or fewer are
+        interpreted as seconds. Longer values are scaled down so that 10 digits
+        remain before the decimal point.
+        """
+        return (
+            int(timestamp)
+            if len(integer_part) <= 10
+            else int(timestamp) / 10 ** (len(integer_part) - 10)
+        )
 
     @classmethod
     def parse_datetime(

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -1,12 +1,22 @@
 """Logprep time helpers module"""
 
 from datetime import UTC, datetime, tzinfo
+from enum import IntEnum
 
 from logprep.abc.exceptions import LogprepException
 
 
 class TimeParserException(LogprepException):
     """Exception class for time parsing"""
+
+
+class UnixTimestampLength(IntEnum):
+    """Digit lengths of common Unix timestamp representations."""
+
+    SECONDS = 10
+    MILLISECONDS = 13
+    MICROSECONDS = 16
+    NANOSECONDS = 19
 
 
 class TimeParser:
@@ -128,12 +138,12 @@ class TimeParser:
 
         Unix timestamps are assumed to be in seconds if the timestamp has 10 digits
         or fewer before the decimal point, since seconds with more than 10 digits
-        would be far into the future. Timestamps with more than 10 digits before
-        the decimal point are scaled down so that 10 digits remain before the
-        decimal point.
+        would be far into the future. Supported timestamp lengths before the decimal
+        point are seconds, milliseconds, microseconds, and nanoseconds.
 
         Timestamp strings with a decimal point are parsed as float so fractional
-        seconds are preserved.
+        seconds are preserved. The digit-count heuristic is applied to the integer
+        part before the decimal point.
 
         Parameters
         ----------
@@ -148,16 +158,18 @@ class TimeParser:
         Raises
         ------
         TimeParserException
-            Raised if input timestamp string could not be parsed as a number
+            Raised if input timestamp string could not be parsed as a number or
+            if the input timestamp length is not supported
         """
         try:
             timestamp = timestamp.strip()
             integer_part = TimeParser._get_unix_timestamp_integer_part(timestamp)
+            divisor = TimeParser._get_unix_timestamp_normalization_divisor(integer_part)
 
             if "." in timestamp:
-                return TimeParser._normalize_fractional_unix_timestamp(timestamp, integer_part)
+                return TimeParser._normalize_fractional_unix_timestamp(timestamp, divisor)
 
-            return TimeParser._normalize_integer_unix_timestamp(timestamp, integer_part)
+            return TimeParser._normalize_integer_unix_timestamp(timestamp, divisor)
         except ValueError as error:
             raise TimeParserException(str(error)) from error
 
@@ -167,32 +179,60 @@ class TimeParser:
         return timestamp.split(".", maxsplit=1)[0]
 
     @staticmethod
-    def _normalize_fractional_unix_timestamp(timestamp: str, integer_part: str) -> float:
+    def _get_unix_timestamp_normalization_divisor(integer_part: str) -> int:
+        """Return the divisor needed to normalize a UNIX timestamp to seconds.
+
+        Timestamps with 10 digits or fewer are interpreted as seconds. Longer
+        supported values are scaled down according to their timestamp precision.
+
+        Parameters
+        ----------
+        integer_part : str
+            The integer part of the UNIX timestamp string.
+
+        Returns
+        -------
+        int
+            Divisor used to normalize the timestamp to seconds.
+
+        Raises
+        ------
+        ValueError
+            Raised if the input timestamp length is longer than 10 digits but does
+            not match a supported UNIX timestamp precision.
+        """
+        integer_part_length = len(integer_part)
+
+        match integer_part_length:
+            case length if length <= UnixTimestampLength.SECONDS:
+                return 1
+            case UnixTimestampLength.MILLISECONDS:
+                return 10 ** (UnixTimestampLength.MILLISECONDS - UnixTimestampLength.SECONDS)
+            case UnixTimestampLength.MICROSECONDS:
+                return 10 ** (UnixTimestampLength.MICROSECONDS - UnixTimestampLength.SECONDS)
+            case UnixTimestampLength.NANOSECONDS:
+                return 10 ** (UnixTimestampLength.NANOSECONDS - UnixTimestampLength.SECONDS)
+            case _:
+                raise ValueError(f"Unsupported Unix timestamp length: {integer_part_length}")
+
+    @staticmethod
+    def _normalize_fractional_unix_timestamp(timestamp: str, divisor: int) -> float:
         """Normalize a fractional UNIX timestamp to seconds.
 
         Fractional UNIX timestamps are parsed as float to preserve sub-second
-        precision. The digit-count heuristic is applied to the integer part only.
+        precision.
         """
-        parsed_timestamp = float(timestamp)
-        return (
-            parsed_timestamp
-            if len(integer_part) <= 10
-            else parsed_timestamp / 10 ** (len(integer_part) - 10)
-        )
+        return float(timestamp) / divisor
 
     @staticmethod
-    def _normalize_integer_unix_timestamp(timestamp: str, integer_part: str) -> int | float:
-        """Normalize an integer-only UNIX timestamp to seconds.
+    def _normalize_integer_unix_timestamp(timestamp: str, divisor: int) -> int | float:
+        """Normalize an integer-only UNIX timestamp to seconds."""
+        parsed_timestamp = int(timestamp)
 
-        Existing behavior is preserved: timestamps with 10 digits or fewer are
-        interpreted as seconds. Longer values are scaled down so that 10 digits
-        remain before the decimal point.
-        """
-        return (
-            int(timestamp)
-            if len(integer_part) <= 10
-            else int(timestamp) / 10 ** (len(integer_part) - 10)
-        )
+        if divisor == 1:
+            return parsed_timestamp
+
+        return parsed_timestamp / divisor
 
     @classmethod
     def parse_datetime(

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -136,10 +136,10 @@ class TimeParser:
     def _normalize_unix_timestamp(timestamp: str) -> int | float:
         """Normalize the input timestamp string to unix timestamp in seconds.
 
-        Unix timestamps are assumed to be in seconds if the timestamp has 10 digits
-        or fewer before the decimal point, since seconds with more than 10 digits
-        would be far into the future. Supported timestamp lengths before the decimal
-        point are seconds, milliseconds, microseconds, and nanoseconds.
+        The timestamp precision is inferred from the number of digits before the
+        decimal point. Timestamps with 10 digits or fewer are interpreted as seconds.
+        Supported longer timestamp lengths are interpreted as milliseconds,
+        microseconds, or nanoseconds and are scaled down to seconds.
 
         Timestamp strings with a decimal point are parsed as float so fractional
         seconds are preserved. The digit-count heuristic is applied to the integer

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -19,6 +19,11 @@ class UnixTimestampLength(IntEnum):
     NANOSECONDS = 19
 
 
+SCALABLE_UNIX_TIMESTAMP_LENGTHS = frozenset(
+    int(length) for length in UnixTimestampLength if length > UnixTimestampLength.SECONDS
+)
+
+
 class TimeParser:
     """Encapsulation of time related methods"""
 
@@ -163,12 +168,6 @@ class TimeParser:
             raise TimeParserException(str(error)) from error
 
     @staticmethod
-    def _get_unix_timestamp_integer_part(timestamp: str) -> str:
-        """Return the integer part of a UNIX timestamp."""
-        return timestamp.split(".", maxsplit=1)[0]
-
-    @staticmethod
-    @staticmethod
     def _get_unix_timestamp_normalization_divisor(integer_part: str) -> int:
         """Return the divisor for normalizing a supported UNIX timestamp to seconds."""
 
@@ -177,33 +176,10 @@ class TimeParser:
         if integer_part_length <= UnixTimestampLength.SECONDS:
             return 1
 
-        scalable_unix_timestamp_lengths = frozenset(
-            int(length) for length in UnixTimestampLength if length > UnixTimestampLength.SECONDS
-        )
-
-        if integer_part_length in scalable_unix_timestamp_lengths:
+        if integer_part_length in SCALABLE_UNIX_TIMESTAMP_LENGTHS:
             return 10 ** (integer_part_length - UnixTimestampLength.SECONDS)
 
         raise ValueError(f"Unsupported Unix timestamp length: {integer_part_length}")
-
-    @staticmethod
-    def _normalize_fractional_unix_timestamp_to_seconds(timestamp: str, divisor: int) -> float:
-        """Normalize a fractional UNIX timestamp to seconds.
-
-        Fractional UNIX timestamps are parsed as float to preserve sub-second
-        precision.
-        """
-        return float(timestamp) / divisor
-
-    @staticmethod
-    def _normalize_integer_unix_timestamp_to_seconds(timestamp: str, divisor: int) -> int | float:
-        """Normalize an integer-only UNIX timestamp to seconds."""
-        parsed_timestamp = int(timestamp)
-
-        if divisor == 1:
-            return parsed_timestamp
-
-        return parsed_timestamp / divisor
 
     @classmethod
     def parse_datetime(

--- a/logprep/util/time.py
+++ b/logprep/util/time.py
@@ -133,43 +133,32 @@ class TimeParser:
         return time_object
 
     @staticmethod
-    def _normalize_unix_timestamp(timestamp: str) -> int | float:
-        """Normalize the input timestamp string to unix timestamp in seconds.
+    def _normalize_unix_timestamp_to_seconds(timestamp: str) -> int | float:
+        """Normalize a UNIX timestamp string to seconds.
 
-        The timestamp precision is inferred from the number of digits before the
-        decimal point. Timestamps with 10 digits or fewer are interpreted as seconds.
-        Supported longer timestamp lengths are interpreted as milliseconds,
-        microseconds, or nanoseconds and are scaled down to seconds.
-
-        Timestamp strings with a decimal point are parsed as float so fractional
-        seconds are preserved. The digit-count heuristic is applied to the integer
-        part before the decimal point.
-
-        Parameters
-        ----------
-        timestamp : str
-            The date string in unix timestamp format
-
-        Returns
-        -------
-        int | float
-            Unix timestamp parsed as number in seconds
+        The precision is inferred from the digits before the decimal point. Supported
+        precisions are seconds, milliseconds, microseconds, and nanoseconds. Fractional
+        timestamps are parsed as float to preserve sub-second precision.
 
         Raises
         ------
         TimeParserException
-            Raised if input timestamp string could not be parsed as a number or
-            if the input timestamp length is not supported
+            Raised if the timestamp cannot be parsed or has an unsupported length.
         """
+
         try:
             timestamp = timestamp.strip()
-            integer_part = TimeParser._get_unix_timestamp_integer_part(timestamp)
+            timestamp_parts = timestamp.split(".", maxsplit=1)
+            integer_part = timestamp_parts[0]
+            has_fractional_part = len(timestamp_parts) == 2
+
             divisor = TimeParser._get_unix_timestamp_normalization_divisor(integer_part)
+            value = float(timestamp) if has_fractional_part else int(timestamp)
 
-            if "." in timestamp:
-                return TimeParser._normalize_fractional_unix_timestamp(timestamp, divisor)
+            if divisor == 1:
+                return value
 
-            return TimeParser._normalize_integer_unix_timestamp(timestamp, divisor)
+            return value / divisor
         except ValueError as error:
             raise TimeParserException(str(error)) from error
 
@@ -179,44 +168,26 @@ class TimeParser:
         return timestamp.split(".", maxsplit=1)[0]
 
     @staticmethod
+    @staticmethod
     def _get_unix_timestamp_normalization_divisor(integer_part: str) -> int:
-        """Return the divisor needed to normalize a UNIX timestamp to seconds.
+        """Return the divisor for normalizing a supported UNIX timestamp to seconds."""
 
-        Timestamps with 10 digits or fewer are interpreted as seconds. Longer
-        supported values are scaled down according to their timestamp precision.
-
-        Parameters
-        ----------
-        integer_part : str
-            The integer part of the UNIX timestamp string.
-
-        Returns
-        -------
-        int
-            Divisor used to normalize the timestamp to seconds.
-
-        Raises
-        ------
-        ValueError
-            Raised if the input timestamp length is longer than 10 digits but does
-            not match a supported UNIX timestamp precision.
-        """
         integer_part_length = len(integer_part)
 
-        match integer_part_length:
-            case length if length <= UnixTimestampLength.SECONDS:
-                return 1
-            case UnixTimestampLength.MILLISECONDS:
-                return 10 ** (UnixTimestampLength.MILLISECONDS - UnixTimestampLength.SECONDS)
-            case UnixTimestampLength.MICROSECONDS:
-                return 10 ** (UnixTimestampLength.MICROSECONDS - UnixTimestampLength.SECONDS)
-            case UnixTimestampLength.NANOSECONDS:
-                return 10 ** (UnixTimestampLength.NANOSECONDS - UnixTimestampLength.SECONDS)
-            case _:
-                raise ValueError(f"Unsupported Unix timestamp length: {integer_part_length}")
+        if integer_part_length <= UnixTimestampLength.SECONDS:
+            return 1
+
+        scalable_unix_timestamp_lengths = frozenset(
+            int(length) for length in UnixTimestampLength if length > UnixTimestampLength.SECONDS
+        )
+
+        if integer_part_length in scalable_unix_timestamp_lengths:
+            return 10 ** (integer_part_length - UnixTimestampLength.SECONDS)
+
+        raise ValueError(f"Unsupported Unix timestamp length: {integer_part_length}")
 
     @staticmethod
-    def _normalize_fractional_unix_timestamp(timestamp: str, divisor: int) -> float:
+    def _normalize_fractional_unix_timestamp_to_seconds(timestamp: str, divisor: int) -> float:
         """Normalize a fractional UNIX timestamp to seconds.
 
         Fractional UNIX timestamps are parsed as float to preserve sub-second
@@ -225,7 +196,7 @@ class TimeParser:
         return float(timestamp) / divisor
 
     @staticmethod
-    def _normalize_integer_unix_timestamp(timestamp: str, divisor: int) -> int | float:
+    def _normalize_integer_unix_timestamp_to_seconds(timestamp: str, divisor: int) -> int | float:
         """Normalize an integer-only UNIX timestamp to seconds."""
         parsed_timestamp = int(timestamp)
 
@@ -258,7 +229,7 @@ class TimeParser:
             The parsed timestamp as datetime object.
         """
         if source_format == "UNIX":
-            normalized_unix_timestamp = cls._normalize_unix_timestamp(timestamp)
+            normalized_unix_timestamp = cls._normalize_unix_timestamp_to_seconds(timestamp)
             parsed_datetime = cls.from_unix_timestamp(normalized_unix_timestamp)
         elif source_format == "ISO8601":
             parsed_datetime = cls.from_string(timestamp, set_missing_utc=False)

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -12,7 +12,85 @@ from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [  # testcase, rule, event, expected
     (
-        "parses unix timestamps with fractional seconds",
+        "normalizes unix timestamp with seconds precision",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000",
+        },
+        {
+            "message": "1700000000",
+            "@timestamp": "2023-11-14T23:13:20+01:00",
+        },
+    ),
+    (
+        "normalizes unix timestamp with milliseconds precision",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000123",
+        },
+        {
+            "message": "1700000000123",
+            "@timestamp": "2023-11-14T23:13:20.123000+01:00",
+        },
+    ),
+    (
+        "normalizes unix timestamp with microseconds precision",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000123456",
+        },
+        {
+            "message": "1700000000123456",
+            "@timestamp": "2023-11-14T23:13:20.123456+01:00",
+        },
+    ),
+    (
+        "normalizes unix timestamp with nanoseconds precision",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000123456789",
+        },
+        {
+            "message": "1700000000123456789",
+            # The timestamp is normalized from nanoseconds, but datetime only supports
+            # microsecond precision. Therefore 123456789 ns is rounded to 123457 us.
+            "@timestamp": "2023-11-14T23:13:20.123457+01:00",
+        },
+    ),
+    (
+        "parses fractional unix timestamp with seconds precision",
         {
             "filter": "message",
             "timestamper": {
@@ -31,7 +109,7 @@ test_cases = [  # testcase, rule, event, expected
         },
     ),
     (
-        "parses unix timestamps with microseconds",
+        "parses fractional unix timestamp with microseconds",
         {
             "filter": "message",
             "timestamper": {
@@ -50,7 +128,7 @@ test_cases = [  # testcase, rule, event, expected
         },
     ),
     (
-        "normalizes long fractional unix timestamp string",
+        "normalizes fractional unix timestamp with milliseconds precision",
         {
             "filter": "message",
             "timestamper": {
@@ -69,7 +147,7 @@ test_cases = [  # testcase, rule, event, expected
         },
     ),
     (
-        "parses unix timestamps with fractional seconds from float",
+        "parses fractional unix timestamp from float with seconds precision",
         {
             "filter": "message",
             "timestamper": {
@@ -88,7 +166,7 @@ test_cases = [  # testcase, rule, event, expected
         },
     ),
     (
-        "normalizes long fractional unix timestamp from float",
+        "normalizes fractional unix timestamp from float with milliseconds precision",
         {
             "filter": "message",
             "timestamper": {
@@ -386,6 +464,46 @@ failure_test_cases = [
             "tags": ["_timestamper_failure"],
         },
         r"Could not parse timestamp.*event=\{'message': ''\}",
+    ),
+    (
+        "fails on unsupported unix timestamp length",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "17000000001",
+        },
+        {
+            "message": "17000000001",
+            "tags": ["_timestamper_failure"],
+        },
+        r"Could not parse timestamp.*event=\{'message': '17000000001'\}",
+    ),
+    (
+        "fails on unsupported fractional unix timestamp length",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "17000000001.123",
+        },
+        {
+            "message": "17000000001.123",
+            "tags": ["_timestamper_failure"],
+        },
+        r"Could not parse timestamp.*event=\{'message': '17000000001\.123'\}",
     ),
     (
         "normalization from timestamp with non matching patterns",

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -12,6 +12,101 @@ from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [  # testcase, rule, event, expected
     (
+        "parses unix timestamps with fractional seconds",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000.123",
+        },
+        {
+            "message": "1700000000.123",
+            "@timestamp": "2023-11-14T23:13:20.123000+01:00",
+        },
+    ),
+    (
+        "parses unix timestamps with microseconds",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000.123456",
+        },
+        {
+            "message": "1700000000.123456",
+            "@timestamp": "2023-11-14T23:13:20.123456+01:00",
+        },
+    ),
+    (
+        "normalizes long fractional unix timestamp string",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000123.456",
+        },
+        {
+            "message": "1700000000123.456",
+            "@timestamp": "2023-11-14T23:13:20.123456+01:00",
+        },
+    ),
+    (
+        "parses unix timestamps with fractional seconds from float",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": 1700000000.123,
+        },
+        {
+            "message": 1700000000.123,
+            "@timestamp": "2023-11-14T23:13:20.123000+01:00",
+        },
+    ),
+    (
+        "normalizes long fractional unix timestamp from float",
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": 1700000000123.456,
+        },
+        {
+            "message": 1700000000123.456,
+            "@timestamp": "2023-11-14T23:13:20.123456+01:00",
+        },
+    ),
+    (
         "parses iso8601 without pattern",
         {
             "filter": "message",


### PR DESCRIPTION
## Description

* Parse UNIX timestamps with fractional seconds as seconds with sub-second precision.
Keep existing length-based normalization for integer-only UNIX timestamps.
Update the _normalize_unix_timestamp docstring to document fractional timestamp handling.
Add regression tests for fractional UNIX timestamps in the timestamper processor.
* Relates to #984

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [ ] Patch test coverage > 95% and does not decrease
- [ ] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest: Added test cases for UNIX timestamps with fractional seconds.

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--985.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->