### PR TITLE
refactor: fix pyparsing deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * allow `list_comparison` and `network_comparison` to use dynamic values from event to resolve list uris
 
 ### Improvements
+* fix Pyparsing deprecation warnings
 
 ### Bugfix
 * make `list_search_base_path` actually optional and correctly overrideable by rule config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
 
 ### Improvements
+* fix Pyparsing deprecation warnings
 
 ### Bugfix
 
@@ -14,7 +15,6 @@
 * allow `list_comparison` and `network_comparison` to use dynamic values from event to resolve list uris
 
 ### Improvements
-* fix Pyparsing deprecation warnings
 
 ### Bugfix
 * make `list_search_base_path` actually optional and correctly overrideable by rule config

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -165,4 +165,6 @@ class BNF(Forward):
         factor = Forward()
         factor <<= atom + (self.expop + factor).set_parse_action(self.push_first)[...]
         term = factor + (self.multop + factor).set_parse_action(self.push_first)[...]
-        self <<= term + (self.addop + term).set_parse_action(self.push_first)[...]
+
+        forward_self: Forward = self
+        forward_self <<= term + (self.addop + term).set_parse_action(self.push_first)[...]

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -18,6 +18,7 @@ import operator
 
 from pyparsing import (
     CaselessKeyword,
+    DelimitedList,
     Forward,
     Group,
     Literal,
@@ -26,7 +27,6 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-    delimitedList,
 )
 
 epsilon = 1e-12
@@ -138,7 +138,7 @@ class BNF(Forward):
     def __init__(self) -> None:
         super().__init__()
         self.exprStack = []
-        expr_list = delimitedList(Group(self))  # pylint: disable=E1121
+        expr_list = DelimitedList(Group(self))  # pylint: disable=E1121
 
         # add parse action that replaces the function identifier with a (name, number of args) tuple
         def insert_fn_argcount_tuple(t):
@@ -146,23 +146,23 @@ class BNF(Forward):
             num_args = len(t[0])
             t.insert(0, (fn, num_args))
 
-        fn_call = (self.ident + self.lpar - Group(expr_list) + self.rpar).setParseAction(
+        fn_call = (self.ident + self.lpar - Group(expr_list) + self.rpar).set_parse_action(
             insert_fn_argcount_tuple
         )
         atom = (
             self.addop[...]
             + (
-                (fn_call | self.pi | self.e | self.fnumber | self.ident).setParseAction(
+                (fn_call | self.pi | self.e | self.fnumber | self.ident).set_parse_action(
                     self.push_first
                 )
                 | Group(self.lpar + self + self.rpar)
             )
-        ).setParseAction(self.push_unary_minus)
+        ).set_parse_action(self.push_unary_minus)
 
         # by defining exponentiation as "atom [ ^ factor ]..." instead of "atom [ ^ atom ]...",
         # we get right-to-left exponents,
         # instead of left-to-right that is, 2^3^2 = 2^(3^2), not (2^3)^2.
         factor = Forward()
-        factor <<= atom + (self.expop + factor).setParseAction(self.push_first)[...]
-        term = factor + (self.multop + factor).setParseAction(self.push_first)[...]
-        self <<= term + (self.addop + term).setParseAction(self.push_first)[...]
+        factor <<= atom + (self.expop + factor).set_parse_action(self.push_first)[...]
+        term = factor + (self.multop + factor).set_parse_action(self.push_first)[...]
+        self <<= term + (self.addop + term).set_parse_action(self.push_first)[...]


### PR DESCRIPTION
## Description

* use the recommended methods and class names to fix deprecation warnings. This does not break the underlying API.

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--986.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->