### PR TITLE
fix: solve add_fields_to state corruption and add support for dicts in generic_adder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 ### Breaking
 
 ### Features
+* add support for `dict` in `generic_adder`
 
 ### Improvements
 
 ### Bugfix
+* fix `add_fields_to` injecting identical objects instead of copies
+* fix `generic_adder` accumulating state by inserting identical objects in events
 
 ## 19.4.0
 ### Breaking

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -24,7 +24,10 @@ Processor Configuration
 .. automodule:: logprep.processor.generic_adder.rule
 """
 
+import typing
+
 from logprep.ng.abc.processor import Processor
+from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.helper import add_fields_to
 
@@ -34,7 +37,8 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    def _apply_rules(self, event: dict, rule: GenericAdderRule) -> None:
+    def _apply_rules(self, event: dict, rule: Rule) -> None:
+        rule = typing.cast(GenericAdderRule, rule)
         items_to_add = rule.add
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -24,7 +24,10 @@ Processor Configuration
 .. automodule:: logprep.processor.generic_adder.rule
 """
 
+import typing
+
 from logprep.abc.processor import Processor
+from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.helper import add_fields_to
 
@@ -34,7 +37,8 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    def _apply_rules(self, event: dict, rule: GenericAdderRule):
+    def _apply_rules(self, event: dict, rule: Rule):
+        rule = typing.cast(GenericAdderRule, rule)
         items_to_add = rule.add
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -106,7 +106,7 @@ class GenericAdderRule(FieldManagerRule):
         add: dict = field(
             validator=validators.deep_mapping(
                 key_validator=validators.instance_of(str),
-                value_validator=validators.instance_of((str, bool, list, int, float)),
+                value_validator=validators.instance_of((str, bool, list, dict, int, float)),
             ),
             default={},
         )

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -1,5 +1,6 @@
 """This module contains helper functions that are shared by different modules."""
 
+import copy
 import functools
 import itertools
 import re
@@ -121,7 +122,7 @@ def _add_field_to(
 
     if overwrite_target:
         target_parent = reduce(_add_and_overwrite_key, field_path[:-1], event)
-        target_parent[target_key] = content
+        target_parent[target_key] = copy.deepcopy(content)
         return
     try:
         target_parent = reduce(_add_and_not_overwrite_key, field_path[:-1], event)
@@ -129,7 +130,7 @@ def _add_field_to(
         raise FieldExistsWarning(rule, event, [target_field]) from error
     existing_value = target_parent.get(target_key)
     if existing_value is None:
-        target_parent[target_key] = content
+        target_parent[target_key] = copy.deepcopy(content)
         return
     if not merge_with_target:
         raise FieldExistsWarning(rule, event, [target_field])
@@ -146,7 +147,7 @@ def _add_field_to(
     else:
         if not overwrite_target:
             raise FieldExistsWarning(rule, event, [target_field])
-        target_parent[target_key] = [existing_value, content]
+        target_parent[target_key] = [existing_value, copy.deepcopy(content)]
 
 
 def _add_field_to_silent_fail(*args, **kwargs) -> None | str:

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -6,12 +6,14 @@
 # pylint: disable=too-many-positional-arguments
 
 import re
+import typing
 from copy import deepcopy
 
 import pytest
 
 from logprep.factory import Factory
 from logprep.ng.event.log_event import LogEvent
+from logprep.ng.processor.generic_adder.processor import GenericAdder
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (
@@ -69,3 +71,38 @@ class TestGenericAdder(BaseProcessorTestCase):
             config["rules"] = [RULES_DIR_INVALID]
             configuration = {"test processor": config}
             Factory.create(configuration)
+
+    def test_add_only_copies(self):
+        instance = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "some_generic_adder": {
+                        "type": "ng_generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add": {
+                                        "some_list_field": ["some_value"],
+                                        "some_dict_field": {"some_key": "some_value"},
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+
+        event = {}
+        log_event = LogEvent(event, original=b"")
+        instance.process(log_event)
+
+        rule_add = instance.rules[0].add
+
+        assert event["some_list_field"] == ["some_value"]
+        assert event["some_list_field"] is not rule_add["some_list_field"], "only copies in events"
+
+        assert event["some_dict_field"] == {"some_key": "some_value"}
+        assert event["some_dict_field"] is not rule_add["some_dict_field"], "only copies in events"

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -3,12 +3,14 @@
 # pylint: disable=unused-argument
 # pylint: disable=too-many-arguments
 import re
+import typing
 from copy import deepcopy
 
 import pytest
 
 from logprep.factory import Factory
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.generic_adder.processor import GenericAdder
 from tests.unit.processor.base import BaseProcessorTestCase
 
 RULES_DIR_MISSING = "tests/testdata/unit/generic_adder/rules_missing"
@@ -425,3 +427,37 @@ class TestGenericAdder(BaseProcessorTestCase):
             config["rules"] = [RULES_DIR_INVALID]
             configuration = {"test processor": config}
             Factory.create(configuration)
+
+    def test_add_only_copies(self):
+        instance = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "some_generic_adder": {
+                        "type": "generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add": {
+                                        "some_list_field": ["some_value"],
+                                        "some_dict_field": {"some_key": "some_value"},
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+
+        event = {}
+        instance.process(event)
+
+        rule_add = instance.rules[0].add
+
+        assert event["some_list_field"] == ["some_value"]
+        assert event["some_list_field"] is not rule_add["some_list_field"], "only copies in events"
+
+        assert event["some_dict_field"] == {"some_key": "some_value"}
+        assert event["some_dict_field"] is not rule_add["some_dict_field"], "only copies in events"


### PR DESCRIPTION
## Description

* add support for `dict` in `generic_adder`
* fix `add_fields_to` injecting identical objects instead of copies
* fix `generic_adder` accumulating state by inserting identical objects in events

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest (new test)

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--988.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->