### PR TITLE
release: bump logprep version 19.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 ### Breaking
 
 ### Features
+
+### Improvements
+
+### Bugfix
+
+## 19.4.1
+
+### Breaking
+
+### Features
 * add support for `dict` in `generic_adder`
 
 ### Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
 requires-python = ">=3.11"
 readme = "README.md"
-version = "19.4.0"
+version = "19.4.1"
 license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1420,7 +1420,7 @@ wheels = [
 
 [[package]]
 name = "logprep"
-version = "19.4.0"
+version = "19.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--989.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->