### PR TITLE
fix: dissector not being able to dissect multiline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 
 ### Bugfix
+* fix dissector not dissecting multiline strings
 
 ## 19.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Improvements
 
 ### Bugfix
-* fix dissector not dissecting multiline strings
+* fix `dissector` not dissecting multiline strings
 
 ## 19.4.1
 

--- a/logprep/processor/dissector/rule.py
+++ b/logprep/processor/dissector/rule.py
@@ -118,7 +118,7 @@ SEPERATOR = r"(\((?P<separator>\\\)|[^)]+)\))?"
 TARGET_FIELD = r"(?P<target_field>[^\/\|\}-]*)"
 POSITION = r"(\/(?P<position>\d*))?"
 DATATYPE = r"(\|(?P<datatype>int|float|bool))?"
-SECTION_MATCH = rf"{START}{ACTION}{SEPERATOR}{TARGET_FIELD}{STRIP_CHAR}{POSITION}{DATATYPE}{END}(?P<delimiter>.*)"
+SECTION_MATCH = rf"{START}{ACTION}{SEPERATOR}{TARGET_FIELD}{STRIP_CHAR}{POSITION}{DATATYPE}{END}(?P<delimiter>[\s\S]*)"
 
 MAPPING_VALIDATION_REGEX = re.compile(rf"^({DELIMITER})?({DISSECT}({DELIMITER})?)+({DISSECT})?$")
 
@@ -226,7 +226,7 @@ class DissectorRule(FieldManagerRule):
                 pattern = "%{}" + pattern
             sections = re.findall(r"%\{[^%]+", pattern)
             for section in sections:
-                section_match = re.match(SECTION_MATCH, section)
+                section_match = re.fullmatch(SECTION_MATCH, section)
                 separator = section_match.group("separator")
                 separator = "" if separator is None else separator
                 separator = separator.replace("\\(", "(")

--- a/logprep/processor/dissector/rule.py
+++ b/logprep/processor/dissector/rule.py
@@ -227,6 +227,8 @@ class DissectorRule(FieldManagerRule):
             sections = re.findall(r"%\{[^%]+", pattern)
             for section in sections:
                 section_match = re.fullmatch(SECTION_MATCH, section)
+                if section_match is None:
+                    raise ValueError("section did not match fully")
                 separator = section_match.group("separator")
                 separator = "" if separator is None else separator
                 separator = separator.replace("\\(", "(")

--- a/tests/unit/processor/dissector/test_dissector.py
+++ b/tests/unit/processor/dissector/test_dissector.py
@@ -691,6 +691,19 @@ test_cases = [
         },
         id="handle curly braces in message full case",
     ),
+    pytest.param(
+        {
+            "filter": "message",
+            "dissector": {"mapping": {"message": "%{field1}\n%{field2}"}},
+        },
+        {"message": "first line\nsecond line"},
+        {
+            "message": "first line\nsecond line",
+            "field1": "first line",
+            "field2": "second line",
+        },
+        id="dissects fields seperated by newline delimiter",
+    ),
 ]
 failure_test_cases = [
     pytest.param(


### PR DESCRIPTION
## Description

The dissector was unable to dissect multiline strings because of a faulty regex expression, that is now fixed

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest: https://github.com/fkie-cad/Logprep/pull/991/changes#diff-7b488a0576c7b60709a597efd12d83aa01e6a50e96b021b158d61f21dcce8f36

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--991.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->