### PR TITLE
feat: rework opensearch output to enable retrying, circuit breaking and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 * ng: drop "ng_" prefix completely and use a setting in the global registry to activate ng
 * ng: decouple console logging via queue/listener in separate thread
 * improve `list_comparison` performance
+* ng: implement circuit breaker utility to protect downstream systems
+* ng: enable opensearch output to retry on transport- and item-level failures + circuit breaker
+* ng: add metrics for opensearch output
+
 
 ### Bugfix
 * fix `dissector` not dissecting multiline strings

--- a/examples/exampledata/config/ng_pipeline.yml
+++ b/examples/exampledata/config/ng_pipeline.yml
@@ -106,9 +106,7 @@ output:
       - 127.0.0.1:9200
     default_index: processed
     default_op_type: create
-    message_backlog_size: 7000
     timeout: 10000
-    flush_timeout: 60
     user: admin
     secret: admin
     desired_cluster_status: ["green", "yellow"]

--- a/logprep/ng/connector/opensearch/output.py
+++ b/logprep/ng/connector/opensearch/output.py
@@ -2,13 +2,49 @@
 OpensearchOutput
 ================
 
-This section contains the connection settings for Opensearch, the default
-index, the error index and a buffer size. Documents are sent in batches to Opensearch to reduce
-the amount of times connections are created.
+This section contains the connection settings for Opensearch, the default index, the error index
+and a buffer size. Documents are sent in batches to Opensearch to reduce the amount of times
+connections are created.
 
-The documents desired index is the field :code:`_index` in the document. It is deleted afterwards.
+The documents desired index :code:`_index` can be set using :code:`event.output_target` (or
+:code:`_index` as data field).
+Data fields prefixed with an underscore (like :code:`_index`, :code:`_op_type`) will be fed to
+Opensearch as-is, meaning these will be interpreted as metadata by Opensearch.
+This functionality might change in the future to avoid unintended mixup between pure data and
+Opensearch metadata.
 If you want to send documents to data streams, you have to set the field :code:`_op_type: create` in
 the document.
+
+Sending the data involves different layers:
+- Chunking: split the batch into smaller chunks and process concurrently
+- Item-level reject: send a chunk and retry rejected items until all events are stored or failed
+- Circuit breaker: retry transient connection errors and limit concurrency
+- Opensearch client: manage connection pool and retry with another connection on errors
+
+Retry behavior can be configured in the following ways:
+- Item-level reject:
+  Retries rejected items for a configurable number of times
+  (:code:`max_bulk_item_retries`, indefinitely by default).
+  A retry is only attempted if the item status is deemed retryable
+  (:code:`retryable_item_statuses`, by default 429).
+  Other non-success statuses will lead to corresponding event failures.
+- Circuit breaker:
+  Retries connection-level failures for a configurable number of times
+  (:code:`max_connection_retries`, indefinitely by default).
+  This kind of failure includes retryable request-level status as of Opensearch,
+  timeouts and other connection errors.
+  The circuit breaker opens (=breaks) the circuit on failures and only allows for
+  single probes at a time until the downstream system is deemed healthy again.
+  The breaker also limits maximum concurrency to :code:`bulk_concurrency`.
+  Depending on the nature of failure, retries on this level might lead to duplicates.
+- Opensearch client:
+  Manages a pool of at maximum :code:`pool_maxsize` connections which will be used
+  to handle concurrent connections but also fail-over and retries in case of errors.
+  While timeouts are handled by the circuit breaker, connection errors and other
+  transport-level status codes (like 502, 503 and 504) get retried a maximum of
+  :code:`max_client_retries` times.
+
+Circuit breaker and opensearch client are instance-wide.
 
 Example
 ^^^^^^^
@@ -22,34 +58,43 @@ Example
             - 127.0.0.1:9200
         default_index: default_index
         error_index: error_index
-        message_backlog_size: 10000
         timeout: 10000
-        max_retries:
         user:
         secret:
         ca_cert: /path/to/cert.crt
+        max_bulk_item_retries:          # retry rejected items (429) forever
+        max_connection_retries:         # unbounded; bound it to limit duplicates
+        initial_backoff: 2
+        max_backoff: 600
+        bulk_concurrency: 4             # bulk requests in flight across the output
 """
 
-import contextlib
+import asyncio
 import logging
 import ssl
 import typing
-from collections.abc import Sequence
-from functools import cached_property
-from typing import Any, List, Optional
+from collections.abc import Iterator, Sequence
+from functools import cached_property, partial
+from typing import Any
 
 from attrs import define, field, validators
 from opensearchpy import (
     AsyncOpenSearch,
+)
+from opensearchpy import ConnectionError as OpenSearchConnectionError
+from opensearchpy import (
     OpenSearchException,
     SerializationError,
-    helpers,
+    TransportError,
 )
+from opensearchpy.helpers.actions import expand_action
 from opensearchpy.serializer import JSONSerializer
 
 from logprep.abc.exceptions import LogprepException
+from logprep.metrics.metrics import CounterMetric, HistogramMetric, Metric
 from logprep.ng.abc.event import OutputEvent
 from logprep.ng.abc.output import CriticalOutputError, Output
+from logprep.ng.util.retry import Backoff, BlockingCircuitBreaker, RetriesExhaustedError
 
 logger = logging.getLogger("OpenSearchOutput")
 
@@ -60,7 +105,7 @@ class BulkError(LogprepException):
     def __init__(
         self,
         message: str,
-        status: str | None = None,
+        status: int | str | None = None,
         exception: str | None = None,
     ) -> None:
         super().__init__(message)
@@ -71,17 +116,16 @@ class BulkError(LogprepException):
         return f"BulkError: {self.message}, status_code: {self.status}, exception: {self.exception}"
 
 
-class MSGPECSerializer(JSONSerializer):
-    """A MSGPEC serializer"""
+class MsgspecSerializer(JSONSerializer):
+    """Plugs Logprep's msgspec JSON codec into the opensearch-py client."""
 
-    def __init__(self, output_connector: Output, *args, **kwargs):
+    def __init__(self, encoder, decoder, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._encoder = output_connector._encoder
-        self._decoder = output_connector._decoder
+        self._encoder = encoder
+        self._decoder = decoder
 
     def dumps(self, data):
-        # don't serialize strings
-        if isinstance(data, str):
+        if isinstance(data, (str, bytes)):
             return data
         try:
             return self._encoder.encode(data).decode("utf-8")
@@ -92,8 +136,106 @@ class MSGPECSerializer(JSONSerializer):
         return self._decoder.decode(s)
 
 
+@define
+class _Chunk:
+    """One bulk request worth of events with their pre-serialized payload lines (parallel lists)."""
+
+    events: list[OutputEvent]
+    payloads: list[bytes]
+
+    @property
+    def is_resolved(self) -> bool:
+        """Whether every event of this chunk is stored or failed."""
+        return not self.events
+
+    @property
+    def payload(self) -> bytes:
+        """The bulk request body for the currently unresolved events."""
+        return b"".join(self.payloads)
+
+    def shrink_to(self, indices: list[int]) -> None:
+        """Keeps only the events at the given indices for the next attempt."""
+        self.events = [self.events[i] for i in indices]
+        self.payloads = [self.payloads[i] for i in indices]
+
+    def fail_remaining(self, error: Exception) -> None:
+        """Marks all not yet resolved events of this chunk as failed."""
+        for event in self.events:
+            if not event.stored and not event.is_failed():
+                event.mark_failed(error)
+        self.events, self.payloads = [], []
+
+
+def _validate_pool_covers_concurrency(instance: Any, _: Any, value: int) -> None:
+    if value < instance.bulk_concurrency:
+        raise ValueError(
+            f"pool_maxsize ({value}) must be >= bulk_concurrency ({instance.bulk_concurrency})"
+        )
+
+
 class OpensearchOutput(Output):
     """An OpenSearch output connector."""
+
+    @define(kw_only=True)
+    class Metrics(Output.Metrics):
+        """Tracks statistics about the OpensearchOutput"""
+
+        number_of_bulk_requests: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of bulk requests sent to Opensearch, including retries",
+                name="opensearch_output_number_of_bulk_requests",
+            )
+        )
+        """Number of bulk requests sent to Opensearch, including retries"""
+        number_of_document_rejections: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of documents rejected with a retryable status (e.g. 429)",
+                name="opensearch_output_number_of_document_rejections",
+            )
+        )
+        """Number of documents rejected with a retryable status (e.g. 429)"""
+        number_of_connection_failures: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of transient connection failures",
+                name="opensearch_output_number_of_connection_failures",
+            )
+        )
+        """Number of transient connection failures"""
+        number_of_serialization_errors: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of events that could not be serialized",
+                name="opensearch_output_number_of_serialization_errors",
+            )
+        )
+        """Number of events that could not be serialized"""
+        number_of_bytes_sent: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Total payload bytes sent in bulk requests, including retries",
+                name="opensearch_output_number_of_bytes_sent",
+            )
+        )
+        """Total payload bytes sent in bulk requests, including retries"""
+        documents_per_bulk_request: HistogramMetric = field(
+            factory=lambda: HistogramMetric(
+                description="Number of documents per sent bulk request",
+                name="opensearch_output_documents_per_bulk_request",
+            )
+        )
+        """Number of documents per sent bulk request"""
+        send_time_per_bulk_request: HistogramMetric = field(
+            factory=lambda: HistogramMetric(
+                description="Time in seconds for one bulk request",
+                name="opensearch_output_send_time_per_bulk_request",
+            )
+        )
+        """Time in seconds for one bulk request"""
+        send_time_per_batch: HistogramMetric = field(
+            factory=lambda: HistogramMetric(
+                description="Time in seconds to store one batch of events",
+                name="opensearch_output_send_time_per_batch",
+            )
+        )
+        """Time in seconds to store one batch of events"""
 
     @define(kw_only=True, slots=False)
     class Config(Output.Config):
@@ -106,12 +248,12 @@ class OpensearchOutput(Output):
            :code:`secret` and a valid :code:`ca_cert`.
         """
 
-        hosts: List[str] = field(
+        hosts: list[str] = field(
             validator=validators.deep_iterable(
                 member_validator=validators.instance_of((str, type(None))),
                 iterable_validator=validators.instance_of(list),
             ),
-            default=[],
+            factory=list,
         )
         """Addresses of opensearch/opensearch servers. Can be a list of hosts or one single host
         in the format HOST:PORT without specifying a schema. The schema is set automatically to
@@ -122,84 +264,145 @@ class OpensearchOutput(Output):
         be indexed. The document will be transformed into a string to prevent rejections by the
         default index."""
 
-        message_backlog_size: int = field(validator=validators.instance_of(int), default=1)
-        """Amount of documents to store before sending them.
-        DEPRECATED: This Argument is deprecated and doesnt do anything anymore,
-        it will be removed in the future
-        """
-
         timeout: int = field(validator=validators.instance_of(int), default=500)
         """(Optional) Timeout for the connection (default is 500ms)."""
 
-        user: Optional[str] = field(validator=validators.instance_of(str), default="")
+        user: str | None = field(validator=validators.instance_of(str), default="")
         """(Optional) User used for authentication."""
 
-        secret: Optional[str] = field(validator=validators.instance_of(str), default="")
+        secret: str | None = field(validator=validators.instance_of(str), default="")
         """(Optional) Secret used for authentication."""
 
-        ca_cert: Optional[str] = field(validator=validators.instance_of(str), default="")
+        ca_cert: str | None = field(validator=validators.instance_of(str), default="")
         """(Optional) Path to a SSL ca certificate to verify the ssl context."""
 
-        flush_timeout: Optional[int] = field(validator=validators.instance_of(int), default=60)
-        """(Optional) Timeout after :code:`message_backlog` is flushed if
-        :code:`message_backlog_size` is not reached.
-        DEPRECATED: This Argument is deprecated and doesnt do anything anymore,
-        it will be removed in the future
-        """
-
-        thread_count: int = field(
-            default=4, validator=(validators.instance_of(int), validators.gt(1))
-        )
-        """Number of threads to use for bulk requests.
-        DEPRECATED: This Argument is deprecated and doesnt do anything anymore,
-        it will be removed in the future"""
-
-        queue_size: int = field(
-            default=4, validator=(validators.instance_of(int), validators.gt(1))
-        )
-        """Number of queue size to use for bulk requests.
-        DEPRECATED: This Argument is deprecated and doesnt do anything anymore,
-        it will be removed in the future"""
-
         chunk_size: int = field(
-            default=500, validator=(validators.instance_of(int), validators.gt(1))
+            default=500, validator=[validators.instance_of(int), validators.gt(1)]
         )
         """Chunk size to use for bulk requests."""
 
         max_chunk_bytes: int = field(
             default=100 * 1024 * 1024,
-            validator=(validators.instance_of(int), validators.gt(1)),
+            validator=[validators.instance_of(int), validators.gt(1)],
         )
         """Max chunk size to use for bulk requests. The default is 100MB."""
 
-        max_retries: int = field(
-            default=3, validator=(validators.instance_of(int), validators.gt(0))
+        max_client_retries: int = field(
+            default=3, validator=[validators.instance_of(int), validators.gt(0)]
         )
-        """Max retries for all requests. Default is 3."""
+        """Max retries the transport layer performs *per request*, immediately
+        and without backoff: node failover on connection errors and
+        request-level 502/503/504 responses, marking failing nodes dead in
+        the connection pool. Failures that survive this budget continue in
+        the connector's circuit breaker (:code:`max_connection_retries`, with
+        backoff); item-level rejections are invisible to the transport and
+        governed by :code:`max_bulk_item_retries`. Default is 3."""
+
+        max_bulk_item_retries: int | None = field(
+            default=None,
+            validator=validators.optional([validators.instance_of(int), validators.ge(0)]),
+        )
+        """Max retries for bulk items rejected with a status listed in
+        :code:`retryable_item_statuses` (e.g. 429). Such rejections are
+        authoritative "not stored" responses, so retrying them is
+        duplicate-free. :code:`None` (the default) retries indefinitely,
+        stalling the batch and thereby applying backpressure towards the
+        input. On exhaustion the affected events are marked as failed."""
+
+        max_connection_retries: int | None = field(
+            default=None,
+            validator=validators.optional([validators.instance_of(int), validators.ge(0)]),
+        )
+        """Max consecutive transport-level failures (timeout, connection
+        reset) across the whole output before affected events are marked as
+        failed. Transport failures are coordinated instance-wide: one request
+        probes the broken connection with backoff while all others wait.
+        :code:`None` (the default) retries indefinitely, stalling the batch
+        and thereby applying backpressure towards the input. The outcome of a
+        transport failure is unknown, so every retry may produce duplicates;
+        set a bound to limit duplicates at the price of failing events."""
+
+        initial_backoff: float = field(
+            default=2.0, validator=[validators.instance_of((int, float)), validators.gt(0)]
+        )
+        """Backoff in seconds before the first retry (item retries and
+        connection probes alike); doubles per retry up to :code:`max_backoff`,
+        with equal jitter applied. Default is 2."""
+
+        max_backoff: float = field(
+            default=600.0, validator=[validators.instance_of((int, float)), validators.gt(0)]
+        )
+        """Upper bound in seconds for the retry backoff. Default is 600."""
+
+        bulk_concurrency: int = field(
+            default=4, validator=[validators.instance_of(int), validators.ge(1)]
+        )
+        """Number of bulk requests in flight concurrently across the whole
+        output (enforced by the circuit breaker, shared by concurrently
+        processed batches). Higher values increase throughput at the cost of
+        more parallel load on the cluster. Must not exceed
+        :code:`pool_maxsize`. Default is 4."""
+
+        pool_maxsize: int = field(
+            default=10,
+            validator=[
+                validators.instance_of(int),
+                validators.ge(1),
+                _validate_pool_covers_concurrency,
+            ],
+        )
+        """Connection pool size of the async transport. Must be at least
+        :code:`bulk_concurrency` so that concurrent chunks never starve on
+        connections. Default is 10."""
+
+        retryable_item_statuses: list[int] = field(
+            factory=lambda: [429],
+            validator=validators.deep_iterable(
+                member_validator=validators.instance_of(int),
+                iterable_validator=validators.instance_of(list),
+            ),
+        )
+        """Item-level response statuses that are retried under
+        :code:`max_bulk_item_retries`. All other non-2xx item statuses are
+        treated as permanent failures. Default is [429], matching the
+        client's own bulk-retry policy. 503 (unavailable shards) can be
+        added: retrying it is duplicate-free, but a persistently red index
+        will stall an unlimited budget."""
+
+        retryable_transport_statuses: list[int] = field(
+            factory=lambda: [502, 503, 504],
+            validator=validators.deep_iterable(
+                member_validator=validators.instance_of(int),
+                iterable_validator=validators.instance_of(list),
+            ),
+        )
+        """Transport-level response statuses that are retried under
+        :code:`max_client_retries` (opensearch client) and
+        :code:`max_connection_retries` (circuit breaker). Default is
+        [502, 503, 504], matching the client's own transport retry policy
+        (:code:`retry_on_status`)."""
 
         desired_cluster_status: list = field(
-            default=["green"], validator=validators.instance_of(list)
+            factory=lambda: ["green"], validator=validators.instance_of(list)
         )
         """Desired cluster status for health check as list of strings. Default is ["green"]"""
 
         default_op_type: str = field(
             default="index",
-            validator=(
+            validator=[
                 validators.instance_of(str),
                 validators.in_(["create", "index"]),
-            ),
+            ],
         )
         """Default op_type for indexing documents. Default is 'index',
         Consider using 'create' for data streams or to prevent overwriting existing documents."""
 
     __slots__ = ("_search_context",)
 
-    """List of messages to be sent to Opensearch."""
-
     @property
-    def _metrics(self) -> Output.Metrics:
+    def _metrics(self) -> "OpensearchOutput.Metrics":
         """Provides the properly typed metrics object"""
-        return typing.cast(Output.Metrics, self.metrics)
+        return typing.cast(OpensearchOutput.Metrics, self.metrics)
 
     @property
     def config(self) -> Config:
@@ -225,6 +428,39 @@ class OpensearchOutput(Output):
             "_op_type": self.config.default_op_type,
         }
 
+    @cached_property
+    def _serializer(self) -> MsgspecSerializer:
+        return MsgspecSerializer(self._encoder, self._decoder)
+
+    @cached_property
+    def _backoff(self) -> Backoff:
+        return Backoff(
+            initial=self.config.initial_backoff,
+            maximum=self.config.max_backoff,
+        )
+
+    @cached_property
+    def _circuit_breaker(self) -> BlockingCircuitBreaker:
+        return BlockingCircuitBreaker(
+            backoff=self._backoff,
+            max_retries=self.config.max_connection_retries,
+            is_transient=self._is_transient_connection_error,
+            on_transient_failure=self._count_connection_failure,
+            concurrency=self.config.bulk_concurrency,
+        )
+
+    def _is_transient_connection_error(self, error: Exception) -> bool:
+        """Transport failures with unknown outcome: connection errors including
+        timeouts, and retryable request-level statuses."""
+        if isinstance(error, OpenSearchConnectionError):  # includes ConnectionTimeout
+            return True
+        if isinstance(error, TransportError):
+            return error.status_code in self.config.retryable_transport_statuses
+        return isinstance(error, OSError)  # includes TimeoutError
+
+    def _count_connection_failure(self, _: Exception) -> None:
+        self._metrics.number_of_connection_failures += 1
+
     def _describe(self) -> str:
         """Get name of Opensearch endpoint with the host."""
         return f"{Output._describe(self)} - Opensearch Output: {self.config.hosts}"
@@ -241,87 +477,151 @@ class OpensearchOutput(Output):
             scheme=self.schema,
             http_auth=self.http_auth,
             ssl_context=self._create_ssl_context(),
-            verify_certs=True,  # default is True, but we want to be explicit
+            verify_certs=True,
             timeout=self.config.timeout,
-            serializer=MSGPECSerializer(self),
-            max_retries=self.config.max_retries,
-            pool_maxsize=10,
-            # default for connection pooling is 10 see:
-            # https://github.com/opensearch-project/opensearch-py/blob/main/guides/connection_classes.md
+            serializer=self._serializer,
+            max_client_retries=self.config.max_client_retries,
+            retry_on_status=self.config.retryable_transport_statuses,
+            pool_maxsize=self.config.pool_maxsize,
         )
         return await super().setup()
 
-    async def _store(self, events: Sequence[OutputEvent]) -> None:
-        logger.debug("Flushing %d documents to opensearch", len(events))
-
-        actions = (
-            {
-                **self._default_action_config,
-                **({"_index": event.output_target} if event.output_target is not None else {}),
-                **event.data,
-            }
-            for event in events
-        )
-
-        index = 0
-        bulk_error: Exception | None = None
+    def _serialize(self, event: OutputEvent) -> bytes:
+        """
+        Serializes one event into its bulk request lines.\n
+        Raises :code:`SerializationError` for any unserializable event.
+        """
+        raw_action = {
+            **self._default_action_config,
+            **({"_index": event.output_target} if event.output_target is not None else {}),
+            **event.data,
+            # TODO disallow overwriting arbitrary os metadata (_ prefixed) in the future
+        }
         try:
-            async with contextlib.aclosing(
-                helpers.async_streaming_bulk(
-                    client=self._search_context,
-                    actions=actions,
-                    max_retries=0,  # retries break order
-                    max_chunk_bytes=self.config.max_chunk_bytes,
-                    chunk_size=self.config.chunk_size,
-                    raise_on_error=False,
-                    raise_on_exception=False,
+            meta, source = expand_action(raw_action)
+            lines = [self._encoder.encode(meta)]
+            if source is not None:
+                lines.append(self._encoder.encode(source))
+        except (ValueError, TypeError) as error:
+            raise SerializationError(raw_action) from error
+        return b"\n".join(lines) + b"\n"
+
+    def _chunks(self, events: Sequence[OutputEvent]) -> Iterator[_Chunk]:
+        """
+        Serializes the batch into chunks bounded by :code:`chunk_size` and :code:`max_chunk_bytes`.
+        Serialization errors result in immediate event failures.
+        Oversized events get their own chunk.
+        """
+        chunk_events: list[OutputEvent] = []
+        chunk_payloads: list[bytes] = []
+        chunk_bytes = 0
+        for event in events:
+            try:
+                payload = self._serialize(event)
+            except SerializationError as error:
+                logger.info("failed to serialize event %s", event, exc_info=True)
+                self._metrics.number_of_serialization_errors += 1
+                event.mark_failed(
+                    BulkError(message=f"failed to serialize event: {error}", exception=str(error))
                 )
-            ) as send_results:
-                async for success, action_item in send_results:
-                    # TODO improve item to event mapping to allow for automatic retries
-                    event = events[index]
-                    index += 1
+                continue
+            size = len(payload)
+            if chunk_events and (
+                len(chunk_events) >= self.config.chunk_size
+                or chunk_bytes + size > self.config.max_chunk_bytes
+            ):
+                yield _Chunk(chunk_events, chunk_payloads)
+                chunk_events, chunk_payloads, chunk_bytes = [], [], 0
+            chunk_events.append(event)
+            chunk_payloads.append(payload)
+            chunk_bytes += size
+        if chunk_events:
+            yield _Chunk(chunk_events, chunk_payloads)
 
-                    if success:
-                        event.stored = True
-                        continue
-
-                    logger.debug("event failed to send: %s", action_item)
-
-                    if not (isinstance(action_item, dict) and len(action_item) == 1):
-                        raise CriticalOutputError(
-                            f"unexpected structure of response item: {action_item}"
-                        )
-                    # structure of action_item is always `{ $op_type: { ... } }`
-                    op_type, item = typing.cast(tuple[str, dict[str, Any]], action_item.popitem())
-
-                    event.mark_failed(
-                        BulkError(
-                            message=item.get("error", f"Failed to `${op_type}` document"),
-                            exception=item.get("exception"),
-                            status=item.get("status"),
-                        )
-                    )
-        except Exception as ex:
-            logger.error("failure during sending to opensearch")
-            bulk_error = ex
-
-        if index < len(events):
-            error = (
-                bulk_error
-                if bulk_error is not None
-                else CriticalOutputError.from_message(self, "iteration ended abruptly")
+    def _resolve_response_items(self, chunk: _Chunk, response: dict[str, Any]) -> bool:
+        """
+        Handles the bulk response for each item individually:
+        - Item stored successfully -> mark event stored and remove from chunk
+        - Item failed with retryable error -> keep in chunk for next attempt
+        - Item failed otherwise -> mark event failed and remove from chunk
+        """
+        response_items = response.get("items", [])
+        if len(response_items) != len(chunk.events):
+            raise CriticalOutputError.from_message(
+                self,
+                f"bulk response contained {len(response_items)} items "
+                f"for {len(chunk.events)} actions",
             )
 
-            for event in events:
-                if not event.stored and not event.is_failed():
-                    event.mark_failed(error)
+        retry_indices: list[int] = []
+        for i, (event, response_item) in enumerate(zip(chunk.events, response_items)):
+            # structure of response_item is always `{ $op_type: { ... } }`
+            if not (isinstance(response_item, dict) and len(response_item) == 1):
+                raise CriticalOutputError.from_message(
+                    self, f"unexpected structure of response item: {response_item}"
+                )
+            op_type, result = typing.cast(
+                tuple[str, dict[str, Any]], next(iter(response_item.items()))
+            )
+            status = result.get("status", 500)
+            if isinstance(status, int) and 200 <= status < 300:
+                event.stored = True
+            elif status in self.config.retryable_item_statuses:
+                retry_indices.append(i)
+            else:
+                logger.debug("event failed to send: %s", response_item)
+                event.mark_failed(
+                    BulkError(
+                        message=result.get("error", f"Failed to `{op_type}` document"),
+                        exception=result.get("exception"),
+                        status=status,
+                    )
+                )
+        if retry_indices:
+            self._metrics.number_of_document_rejections += len(retry_indices)
+        chunk.shrink_to(retry_indices)
+        return chunk.is_resolved
+
+    @Metric.measure_time_async(metric_name="send_time_per_bulk_request")
+    async def _send(self, chunk: _Chunk) -> dict[str, Any]:
+        """One bulk network request; counts requests, documents and bytes."""
+        payload = chunk.payload
+        self._metrics.number_of_bulk_requests += 1
+        self._metrics.documents_per_bulk_request += len(chunk.events)
+        self._metrics.number_of_bytes_sent += len(payload)
+        return await self._search_context.bulk(body=payload)
+
+    async def _resolve_chunk(self, chunk: _Chunk) -> None:
+        """
+        Sends chunk repeatedly for retryable item errors until all events are stored or failed.
+        The circuit breaker handles transient connectivity issues and limits concurrency.
+        """
+        try:
+            attempt = 0
+            async for attempt in self._backoff.attempts(self.config.max_bulk_item_retries):
+                response = await self._circuit_breaker.call(partial(self._send, chunk))
+
+                if self._resolve_response_items(chunk, response):
+                    return
+
+                logger.info("%d events were rejected (attempt %d)", len(chunk.events), attempt)
+            raise RetriesExhaustedError(f"bulk item retries exhausted after {attempt} attempts")
+        except RetriesExhaustedError as error:
+            chunk.fail_remaining(error)
+        except Exception as error:
+            logger.error("critical failure while sending bulk chunk", exc_info=True)
+            chunk.fail_remaining(error)
+
+    @Metric.measure_time_async(metric_name="processing_time_per_event")
+    @Metric.measure_time_async(metric_name="send_time_per_batch")
+    async def _store(self, events: Sequence[OutputEvent]) -> None:
+        logger.debug("Flushing %d documents to opensearch", len(events))
+        await asyncio.gather(*(self._resolve_chunk(chunk) for chunk in self._chunks(events)))
 
     async def health(self) -> bool:  # type: ignore[override]
-        """Check the health of the component."""
-        if not await super().health():
+        """Check the health of the component. Shortcuts on unhealthy cluster breaker."""
+        if not self._circuit_breaker.healthy:
             return False
-
         try:
             resp = await self._search_context.cluster.health(
                 params={"timeout": self.config.health_timeout}
@@ -330,7 +630,7 @@ class OpensearchOutput(Output):
             logger.error("Health check failed: %s", error)
             self._metrics.number_of_errors += 1
             return False
-        return resp.get("status") in self.config.desired_cluster_status
+        return (await super().health()) and resp.get("status") in self.config.desired_cluster_status
 
     async def shut_down(self):
         await self._search_context.close()

--- a/logprep/ng/connector/opensearch/output.py
+++ b/logprep/ng/connector/opensearch/output.py
@@ -77,6 +77,7 @@ from collections.abc import Iterator, Sequence
 from functools import cached_property, partial
 from typing import Any
 
+import msgspec
 from attrs import define, field, validators
 from opensearchpy import (
     AsyncOpenSearch,
@@ -119,7 +120,9 @@ class BulkError(LogprepException):
 class MsgspecSerializer(JSONSerializer):
     """Plugs Logprep's msgspec JSON codec into the opensearch-py client."""
 
-    def __init__(self, encoder, decoder, *args, **kwargs):
+    def __init__(
+        self, encoder: msgspec.json.Encoder, decoder: msgspec.json.Decoder, *args, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self._encoder = encoder
         self._decoder = decoder
@@ -182,7 +185,9 @@ class OpensearchOutput(Output):
 
         number_of_bulk_requests: CounterMetric = field(
             factory=lambda: CounterMetric(
-                description="Number of bulk requests sent to Opensearch, including retries",
+                description="Number of bulk requests sent to Opensearch,"
+                "excluding transport-level retries and including client-level"
+                "and circuit breaker triggered retries",
                 name="opensearch_output_number_of_bulk_requests",
             )
         )
@@ -288,7 +293,7 @@ class OpensearchOutput(Output):
         """Max chunk size to use for bulk requests. The default is 100MB."""
 
         max_client_retries: int = field(
-            default=3, validator=[validators.instance_of(int), validators.gt(0)]
+            default=3, validator=[validators.instance_of(int), validators.ge(0)]
         )
         """Max retries the transport layer performs *per request*, immediately
         and without backoff: node failover on connection errors and
@@ -480,7 +485,7 @@ class OpensearchOutput(Output):
             verify_certs=True,
             timeout=self.config.timeout,
             serializer=self._serializer,
-            max_client_retries=self.config.max_client_retries,
+            max_retries=self.config.max_client_retries,
             retry_on_status=self.config.retryable_transport_statuses,
             pool_maxsize=self.config.pool_maxsize,
         )
@@ -616,6 +621,7 @@ class OpensearchOutput(Output):
     @Metric.measure_time_async(metric_name="send_time_per_batch")
     async def _store(self, events: Sequence[OutputEvent]) -> None:
         logger.debug("Flushing %d documents to opensearch", len(events))
+        # TODO maybe introduce step-wise chunking in the future, if memory use becomes a problem
         await asyncio.gather(*(self._resolve_chunk(chunk) for chunk in self._chunks(events)))
 
     async def health(self) -> bool:  # type: ignore[override]

--- a/logprep/ng/util/retry.py
+++ b/logprep/ng/util/retry.py
@@ -1,0 +1,164 @@
+"""
+Retry helpers
+=============
+
+Shared retry and connection management helpers.
+"""
+
+import asyncio
+import random
+from collections.abc import AsyncIterator, Awaitable, Callable
+from enum import Enum, auto
+from typing import TypeVar
+
+from attrs import define, field, validators
+
+from logprep.abc.exceptions import LogprepException
+
+T = TypeVar("T")
+
+
+class _TransientFailure(Enum):
+    """Internal sentinel: the attempt failed transiently and was recorded."""
+
+    TRANSIENT_FAILURE = auto()
+
+
+_TRANSIENT_FAILURE = _TransientFailure.TRANSIENT_FAILURE  # pylint: disable=invalid-name
+"""Internal sentinel: the attempt failed transiently and was recorded."""
+
+
+class RetriesExhaustedError(LogprepException):
+    """Indicates that all retry attempts failed"""
+
+
+def is_exhausted(attempts: int, max_retries: int | None) -> bool:
+    """Whether a retries (:code:`None` = unlimited) are exhausted after :code:`attempts` failures"""
+    return max_retries is not None and attempts > max_retries
+
+
+@define(kw_only=True, frozen=True)
+class Backoff:
+    """Capped exponential backoff with equal jitter."""
+
+    initial: float = field(
+        default=2.0,
+        validator=[validators.instance_of((int, float)), validators.gt(0)],
+    )
+    """Backoff before the first retry in seconds; doubles per retry."""
+
+    maximum: float = field(
+        default=600.0,
+        validator=[validators.instance_of((int, float)), validators.gt(0)],
+    )
+    """Upper bound for the backoff in seconds."""
+
+    jitter: bool = field(default=True, validator=validators.instance_of(bool))
+    """Randomizes the upper half of each backoff duration."""
+
+    def duration(self, retry_number: int) -> float:
+        """Backoff in seconds before retry :code:`retry_number` (1-based)."""
+        exponent = min(retry_number - 1, 64)  # clamped: avoids float overflow, exceeds any maximum
+        duration = min(self.maximum, self.initial * 2**exponent)
+        if self.jitter:
+            return duration / 2 + random.uniform(0, duration / 2)
+        return duration
+
+    async def sleep(self, retry_number: int) -> None:
+        """Sleeps the (cancellable) backoff duration for the given retry."""
+        await asyncio.sleep(self.duration(retry_number))
+
+    async def attempts(self, max_retries: int | None) -> AsyncIterator[int]:
+        """Yields attempt numbers (1-based), sleeping before every attempt
+        but the first, until the retry budget is exhausted."""
+        attempt = 0
+        while not is_exhausted(attempt, max_retries):
+            if attempt:  # failed attempts so far == retry number of the next one
+                await self.sleep(attempt)
+            attempt += 1
+            yield attempt
+
+
+@define(kw_only=True)
+class BlockingCircuitBreaker:
+    """
+    A circuit breaker that blocks instead of failing fast.
+
+    While the circuit is broken, one caller at a time probes it after the shared, growing backoff;
+    all others queue on the probe lock. Beyond :code:`max_retries` consecutive failures,
+    each further failed probe raises :code:`RetriesExhaustedError` to its caller,
+    so work keeps draining during a long outage. Any success closes the circuit.
+    """
+
+    _backoff: Backoff = field(validator=validators.instance_of(Backoff))
+    _max_retries: int | None = field(
+        default=None,
+        validator=validators.optional([validators.instance_of(int), validators.ge(0)]),
+    )
+    _is_transient: Callable[[Exception], bool] = field(validator=validators.is_callable())
+    """Whether an exception is considered circuit breaking; others pass through"""
+
+    _on_transient_failure: Callable[[Exception], None] | None = field(
+        default=None, validator=validators.optional(validators.is_callable())
+    )
+    """Optional hook invoked for every recorded transient failure, e.g. to feed metrics."""
+
+    _concurrency: int = field(default=1, validator=[validators.instance_of(int), validators.ge(1)])
+    """Maximum number of sends allowed concurrently"""
+
+    _failures: int = field(default=0, init=False)
+    """Consecutive transient failures; 0 means healthy."""
+
+    _limit_to_single_probe: asyncio.Lock = field(factory=asyncio.Lock, init=False, repr=False)
+    _limit_concurrent_send: asyncio.Semaphore = field(init=False, repr=False)
+
+    def __attrs_post_init__(self):
+        self._limit_concurrent_send = asyncio.Semaphore(self._concurrency)
+
+    @property
+    def healthy(self) -> bool:
+        """Whether the last send through this breaker succeeded."""
+        return self._failures == 0
+
+    async def call(self, send: Callable[[], Awaitable[T]]) -> T:
+        """Awaits :code:`send()` until it succeeds, retrying transient
+        failures; non-transient exceptions propagate untouched."""
+        while True:
+            if not self.healthy:
+                async with self._limit_to_single_probe:
+                    if not self.healthy:  # might have recovered during the wait
+                        await self._backoff.sleep(self._failures)
+                        async with self._limit_concurrent_send:
+                            result = await self._attempt(send, probing=True)
+                        if result is not _TRANSIENT_FAILURE:
+                            return result
+                        continue
+                    # circuit closed while we waited: send concurrently below
+            async with self._limit_concurrent_send:
+                if not self.healthy:  # might have failed during the wait
+                    continue
+                result = await self._attempt(send, probing=False)
+            if result is not _TRANSIENT_FAILURE:
+                return result
+
+    async def _attempt(
+        self, send: Callable[[], Awaitable[T]], probing: bool
+    ) -> T | _TransientFailure:
+        """Runs one attempt and records its outcome. Returns the result, or
+        :code:`_TRANSIENT_FAILURE` for a recorded transient failure."""
+        try:
+            result = await send()
+        except Exception as error:
+            if not self._is_transient(error):
+                raise
+            # probe failures accumulate, non-probes only activate failure mode
+            self._failures = self._failures + 1 if probing else max(self._failures, 1)
+            if self._on_transient_failure is not None:
+                self._on_transient_failure(error)
+            if is_exhausted(self._failures, self._max_retries):
+                raise RetriesExhaustedError(
+                    f"connection retries exhausted after {self._failures} consecutive failures"
+                ) from error
+            return _TRANSIENT_FAILURE
+        self._failures = 0
+        return result

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytest
 
 from logprep.ng.abc.connector import Connector
-from logprep.ng.abc.event import ErrorEvent, InputMeta, LogEvent, OutputEvent
+from logprep.ng.abc.event import ErrorEvent, InputMeta, LogEvent
 from logprep.ng.abc.input import Input
 from logprep.ng.abc.output import Output
 from logprep.util.helper import FieldValue, get_dotted_field_value
@@ -724,16 +724,12 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
         assert result.data == expected, f"{expected} is not the same as {result.data}"
 
 
-def _create_log_event(data: dict[str, FieldValue], output_target: str | None = None) -> OutputEvent:
-    return LogEvent(data, output_target=output_target, original=b"", input_meta=InputMeta())
-
-
 class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[OutputTypeT]):
 
     @staticmethod
     def _create_log_event(
         data: dict[str, FieldValue], output_target: str | None = None
-    ) -> OutputEvent:
+    ) -> LogEvent:
         return LogEvent(data, output_target=output_target, original=b"", input_meta=InputMeta())
 
     async def test_is_output_instance(self):
@@ -743,13 +739,14 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
     @abstractmethod
     def mock_output_delivery_for_events(
         self,
-    ) -> Callable[[Sequence[bool | Exception]], None]:
+    ) -> Callable[[Sequence[list[bool] | Exception]], None]:
         """
         Returns a helper method which configures the mock in the concrete test class.
-        Whereas `True` indicates a successful store operation, `False` represents a failed
-        operation which has been gracefully handled by the used client.
-        `Exception` on the other hand is an error scenario which the client was not able
-        (or does not indent to) to handle gracefully.
+        Each element of the given sequence describes one delivery attempt of the client:
+        a list of per-event outcomes (`True` for a successful store operation, `False`
+        for a failure which has been gracefully handled by the used client), or a
+        single `Exception` for an error scenario which the client was not able
+        (or does not intend to) handle gracefully for that whole attempt.
         """
 
     @pytest.mark.parametrize(("count"), [pytest.param(n, id=f"{n} events") for n in [0, 1, 2, 5]])
@@ -758,7 +755,7 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
         self.object.metrics.number_of_processed_events = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
-        mock_output_delivery_for_events([True for _ in events])
+        mock_output_delivery_for_events([[True for _ in events]])
         await self.object.store(events)
 
         assert self.object.metrics.number_of_processed_events == count
@@ -769,7 +766,7 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
         self.object.metrics.number_of_errors = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
-        mock_output_delivery_for_events([False for _ in events])
+        mock_output_delivery_for_events([[False for _ in events]])
         await self.object.store(events)
 
         assert self.object.metrics.number_of_errors == count
@@ -782,7 +779,7 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
         self.object.metrics.number_of_errors = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
-        mock_output_delivery_for_events([Exception("unexpected client failure") for _ in events])
+        mock_output_delivery_for_events([Exception("unexpected client failure")])
         await self.object.store(events)
 
         assert self.object.metrics.number_of_errors == count

--- a/tests/unit/ng/connector/test_confluent_kafka_output.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_output.py
@@ -20,6 +20,7 @@ from logprep.factory import Factory
 from logprep.factory_error import InvalidConfigurationError
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.abc.output import FatalOutputError
+from logprep.ng.connector.confluent_kafka.output import ConfluentKafkaOutput
 from logprep.util.helper import get_dotted_field_value
 from tests.unit.ng.connector.base import BaseOutputTestCase
 
@@ -29,7 +30,7 @@ KAFKA_STATS_JSON_PATH = "tests/testdata/kafka_stats_return_value.json"
 @pytest.mark.skip
 @mock.patch("confluent_kafka.Consumer", new=mock.MagicMock())
 @mock.patch("confluent_kafka.Producer", new=mock.MagicMock())
-class TestConfluentKafkaOutput(BaseOutputTestCase):
+class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
 
     CONFIG = {
         "type": "confluentkafka_output",

--- a/tests/unit/ng/connector/test_opensearch_output.py
+++ b/tests/unit/ng/connector/test_opensearch_output.py
@@ -7,33 +7,63 @@
 # pylint: disable=too-many-arguments
 # pylint: disable=line-too-long
 
+import asyncio
 import json
 from collections.abc import Callable, Sequence
-from contextlib import nullcontext
-from functools import partial
 from unittest import mock
 
 import pytest
 from opensearchpy import AsyncOpenSearch
+from opensearchpy import ConnectionError as OpenSearchConnectionError
+from opensearchpy import ConnectionTimeout
 from opensearchpy import OpenSearchException as SearchException
-from opensearchpy import helpers
+from opensearchpy import RequestError, TransportError
 
-from logprep.ng.abc.event import InputMeta, LogEvent
+from logprep.ng.abc.event import InputMeta, LogEvent, OutputEvent
+from logprep.ng.abc.output import CriticalOutputError
 from logprep.ng.connector.opensearch.output import BulkError, OpensearchOutput
+from logprep.ng.util.retry import RetriesExhaustedError
 from tests.unit.ng.connector.base import BaseOutputTestCase
-
-helpers.parallel_bulk = mock.MagicMock()
 
 MODULE = OpensearchOutput.__module__
 
+CONNECTION_ERROR = OpenSearchConnectionError("N/A", "connection refused", None)
 
+
+def _bulk_response(*statuses: int | dict, op_type: str = "index") -> dict:
+    """Builds a bulk response with one item per given status (or raw item)."""
+    return {
+        "items": [
+            status if isinstance(status, dict) else {op_type: {"status": status}}
+            for status in statuses
+        ]
+    }
+
+
+@pytest.mark.timeout(5)
 class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
+    expected_metrics = [
+        "logprep_opensearch_output_number_of_bulk_requests",
+        "logprep_opensearch_output_number_of_document_rejections",
+        "logprep_opensearch_output_number_of_connection_failures",
+        "logprep_opensearch_output_number_of_serialization_errors",
+        "logprep_opensearch_output_number_of_bytes_sent",
+        "logprep_opensearch_output_documents_per_bulk_request",
+        "logprep_opensearch_output_send_time_per_bulk_request",
+        "logprep_opensearch_output_send_time_per_batch",
+        "logprep_processing_time_per_event",
+        "logprep_number_of_processed_events",
+        "logprep_number_of_warnings",
+        "logprep_number_of_errors",
+    ]
+
     CONFIG = {
         "type": "opensearch_output",
         "hosts": ["localhost:9200"],
         "default_index": "default_index",
-        "message_backlog_size": 1,
         "timeout": 5000,
+        "initial_backoff": 0.001,
+        "max_backoff": 0.001,
     }
 
     @pytest.fixture
@@ -43,63 +73,71 @@ class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
             mock_client.cluster = mock.MagicMock()
             mock_client.cluster.health = mock.AsyncMock()
             mock_client.cluster.health.return_value = mock.MagicMock()
-            mock_client.transport = mock.MagicMock()
-            mock_client.transport.serializer = mock.MagicMock()
-            mock_client.transport.serializer.dumps = json.dumps
+            mock_client.bulk = mock.AsyncMock()
             yield mock_client
 
-    @pytest.fixture
-    def mock_async_streaming_bulk(self):
-        with mock.patch(
-            f"{MODULE}.helpers.async_streaming_bulk",
-            wraps=helpers.async_streaming_bulk,
-        ) as mock_helper:
-            yield mock_helper
+    @pytest.fixture(autouse=True)
+    def autouse_central_fixtures(self, mock_client):
+        yield mock_client  # return technically not required
 
     @pytest.fixture
     def mock_output_delivery_for_events(  # pylint: disable=arguments-differ
-        self, mock_async_streaming_bulk
-    ) -> Callable[[Sequence[bool | Exception | tuple[bool | Exception, dict]]], None]:
-        """Concrete implementation ensures the given events are delivered successfully"""
+        self, mock_client
+    ) -> Callable[[Sequence[list[bool] | Exception]], None]:
+        """Adapter for the inherited base tests: each element becomes one
+        bulk interaction — a response with per-item statuses, or a raised
+        exception."""
 
-        def _set_side_effect(responses: Sequence[bool | Exception | tuple[bool | Exception, dict]]):
-            async def gen_return_values(helper_mock, *_, **kwargs):
-                actions = list(kwargs["actions"])
-
-                # we have exhausted the actions generator, let's restore it in the call record
-                helper_mock.mock_calls[-1].kwargs["actions"] = actions  # (a for a in actions)
-
-                for i, (action, response) in enumerate(zip(actions, responses)):
-                    if isinstance(response, tuple):
-                        response_ok, response_data = response
-                    else:
-                        response_ok, response_data = response, None
-                    if isinstance(response_ok, Exception):
-                        raise response_ok
-                    yield response_ok, (
-                        response_data
-                        if response_data is not None
-                        else {action["_op_type"]: {"_index": action["_index"], "_id": i}}
-                    )
-
-            mock_async_streaming_bulk.side_effect = partial(
-                gen_return_values, mock_async_streaming_bulk
-            )
+        def _set_side_effect(responses: Sequence[list[bool] | Exception]):
+            mock_client.bulk.side_effect = [
+                (
+                    response
+                    if isinstance(response, Exception)
+                    else _bulk_response(*(201 if ok else 400 for ok in response))
+                )
+                for response in responses
+            ]
 
         return _set_side_effect
 
-    @pytest.fixture(autouse=True)
-    def autouse_central_fixtures(self, mock_client, mock_async_streaming_bulk):
-        yield mock_client, mock_async_streaming_bulk  # return technically not required
-
     @pytest.fixture
-    def mock_async_streaming_bulk_get_actions(self, mock_async_streaming_bulk):
+    def get_sent_bulk_actions(self, mock_client):
+        """Reconstructs the action dicts from the NDJSON bulk request bodies."""
+
         def _get_actions(call_index: int = 0):
-            return list(mock_async_streaming_bulk.mock_calls[call_index].kwargs["actions"])
+            body = mock_client.bulk.mock_calls[call_index].kwargs["body"]
+            lines = [json.loads(line) for line in body.decode("utf-8").splitlines()]
+            actions = []
+            for meta, source in zip(lines[::2], lines[1::2]):
+                op_type, meta_fields = next(iter(meta.items()))
+                actions.append({"_op_type": op_type, **meta_fields, **source})
+            return actions
 
         return _get_actions
 
-    # ==========================================================================
+    async def _setup_and_store(self, events: Sequence[OutputEvent]) -> None:
+        await self.object.setup()
+        await self.object.store(events)
+
+    def _create_log_events(self, count: int) -> list[LogEvent]:
+        return [self._create_log_event({"message": f"test message {i}"}) for i in range(count)]
+
+    @pytest.fixture
+    def tracking_mock_client(self, mock_client):
+        """A mock client whose (slow, succeeding) bulk records the peak
+        number of in-flight requests in :code:`mock_client.tracking`."""
+        mock_client.tracking = {"in_flight": 0, "peak": 0}
+
+        async def bulk(body):
+            tracking = mock_client.tracking
+            tracking["in_flight"] += 1
+            tracking["peak"] = max(tracking["peak"], tracking["in_flight"])
+            await asyncio.sleep(0.01)
+            tracking["in_flight"] -= 1
+            return _bulk_response(*[201] * (body.count(b"\n") // 2))
+
+        mock_client.bulk = bulk
+        return mock_client
 
     async def test_describe_returns_output(self):
         assert (
@@ -107,80 +145,334 @@ class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
             == "OpensearchOutput (Test Instance Name) - Opensearch Output: ['localhost:9200']"
         )
 
-    async def test_store_sends_to_default_index(
-        self, mock_output_delivery_for_events, mock_async_streaming_bulk_get_actions
-    ):
+    async def test_store_sends_to_default_index(self, mock_client, get_sent_bulk_actions):
+        mock_client.bulk.return_value = _bulk_response(201)
         event = LogEvent({"field": "content"}, original=b"", input_meta=InputMeta())
 
-        await self.object.setup()
-        mock_output_delivery_for_events([True])
-        await self.object.store([event])
+        await self._setup_and_store([event])
 
         assert len(event.errors) == 0
-        assert mock_async_streaming_bulk_get_actions()[0]["_index"] == self.CONFIG.get(
-            "default_index"
-        )
+        assert get_sent_bulk_actions()[0]["_index"] == self.CONFIG.get("default_index")
 
     async def test_store_custom_sends_event_to_expected_index(
-        self, mock_output_delivery_for_events, mock_async_streaming_bulk_get_actions
+        self, mock_client, get_sent_bulk_actions
     ):
+        mock_client.bulk.return_value = _bulk_response(201)
         data_payload = {"field": "content"}
         event = LogEvent(
             data_payload, output_target="custom_index", original=b"", input_meta=InputMeta()
         )
 
-        await self.object.setup()
-        mock_output_delivery_for_events([True])
-        await self.object.store([event])
+        await self._setup_and_store([event])
 
         assert len(event.errors) == 0
-        assert mock_async_streaming_bulk_get_actions()[0] == {
+        assert get_sent_bulk_actions()[0] == {
             **data_payload,
             "_index": "custom_index",
             "_op_type": "index",
         }
 
-    async def test_store_handles_individual_errors(self, mock_output_delivery_for_events):
-        event1 = self._create_log_event({"message": "test message"}, output_target=None)
-        event2 = self._create_log_event({"message": "test message"}, output_target="custom")
-        await self.object.setup()
-        mock_output_delivery_for_events([False, False])
-        await self.object.store([event1, event2])
-        assert len(event1.errors) == 1
-        assert len(event2.errors) == 1
+    async def test_store_uses_configured_default_op_type(self, mock_client, get_sent_bulk_actions):
+        self.object = self._create_test_instance(config_patch={"default_op_type": "create"})
+        mock_client.bulk.return_value = _bulk_response(201)
+        event = self._create_log_event({"field": "content"})
 
-    async def test_store_handles_immediate_helper_failures(self, mock_async_streaming_bulk):
-        helper_exception = Exception("something unexpected")
-        mock_async_streaming_bulk.side_effect = helper_exception
-        event1 = self._create_log_event({"message": "test message"}, output_target=None)
-        event2 = self._create_log_event({"message": "test message"}, output_target="custom")
-        await self.object.setup()
-        await self.object.store([event1, event2])
-        assert event1.errors == [helper_exception]
-        assert event2.errors == [helper_exception]
+        await self._setup_and_store([event])
 
-    async def test_store_handles_intermediate_helper_failurs(self, mock_output_delivery_for_events):
-        event1 = self._create_log_event({"message": "test message"}, output_target=None)
-        event2 = self._create_log_event({"message": "test message"}, output_target="custom")
-        await self.object.setup()
-        mock_output_delivery_for_events([True, Exception("something unexpected")])
-        await self.object.store([event1, event2])
-        assert event1.stored
-        assert "something unexpected" == str(event2.errors[0])
+        assert get_sent_bulk_actions()[0]["_op_type"] == "create"
 
-    async def test_store_handles_mixed_results(self, mock_output_delivery_for_events):
-        event1 = self._create_log_event({"message": "test message"})
-        event2 = self._create_log_event({"message": "test message"})
-        await self.object.setup()
-        mock_output_delivery_for_events([True, False])
-        await self.object.store([event1, event2])
-        assert len(event1.errors) == 0
-        assert len(event2.errors) == 1
+    async def test_store_handles_individual_errors(self, mock_client):
+        mock_client.bulk.return_value = _bulk_response(400, 400)
+        events = self._create_log_events(2)
 
-    @mock.patch("inspect.getmembers", return_value=[("mock_prop", lambda: None)])
-    async def test_setup_populates_cached_properties(self, mock_getmembers):
+        await self._setup_and_store(events)
+
+        assert all(len(event.errors) == 1 for event in events)
+
+    async def test_store_handles_mixed_results(self, mock_client):
+        mock_client.bulk.return_value = _bulk_response(201, 400)
+        events = self._create_log_events(2)
+
+        await self._setup_and_store(events)
+
+        assert len(events[0].errors) == 0
+        assert len(events[1].errors) == 1
+
+    async def test_store_handles_critical_client_failures(self, mock_client):
+        client_exception = Exception("something unexpected")
+        mock_client.bulk.side_effect = client_exception
+        events = self._create_log_events(2)
+
+        await self._setup_and_store(events)
+
+        assert all(event.errors == [client_exception] for event in events)
+
+    async def test_store_critical_failure_in_one_chunk_does_not_affect_others(self, mock_client):
+        self.object = self._create_test_instance(config_patch={"chunk_size": 2})
+        client_exception = Exception("something unexpected")
+        mock_client.bulk.side_effect = [client_exception, _bulk_response(201, 201)]
+        events = self._create_log_events(4)
+
+        await self._setup_and_store(events)
+
+        assert events[0].errors == [client_exception]
+        assert events[1].errors == [client_exception]
+        assert events[2].stored and events[3].stored
+
+    async def test_store_fails_only_unserializable_events(self, mock_client, get_sent_bulk_actions):
+        mock_client.bulk.return_value = _bulk_response(201)
+        unserializable = self._create_log_event({"message": object()})
+        serializable = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([unserializable, serializable])
+
+        assert isinstance(unserializable.errors[0], BulkError)
+        assert serializable.stored
+        assert len(get_sent_bulk_actions()) == 1
+
+    async def test_store_splits_batch_by_chunk_size(self, mock_client):
+        self.object = self._create_test_instance(config_patch={"chunk_size": 2})
+        mock_client.bulk.return_value = _bulk_response(201, 201)
+        events = self._create_log_events(4)
+
+        await self._setup_and_store(events)
+
+        assert mock_client.bulk.await_count == 2
+        assert all(event.stored for event in events)
+
+    async def test_store_splits_batch_by_max_chunk_bytes(self, mock_client):
+        self.object = self._create_test_instance(config_patch={"max_chunk_bytes": 100})
+        mock_client.bulk.return_value = _bulk_response(201)
+        events = [self._create_log_event({"message": "x" * 100}) for _ in range(2)]
+
+        await self._setup_and_store(events)
+
+        assert mock_client.bulk.await_count == 2
+
+    async def test_store_limits_concurrent_bulk_requests(self, tracking_mock_client):
+        self.object = self._create_test_instance(
+            config_patch={"chunk_size": 2, "bulk_concurrency": 2}
+        )
+        events = self._create_log_events(8)
+
+        await self._setup_and_store(events)
+
+        assert all(event.stored for event in events)
+        assert tracking_mock_client.tracking["peak"] == 2
+
+    async def test_bulk_concurrency_is_shared_across_concurrent_batches(self, tracking_mock_client):
+        self.object = self._create_test_instance(
+            config_patch={"chunk_size": 2, "bulk_concurrency": 2}
+        )
+        batch_a, batch_b = self._create_log_events(4), self._create_log_events(4)
+
         await self.object.setup()
-        mock_getmembers.assert_called_with(self.object)
+        await asyncio.gather(self.object.store(batch_a), self.object.store(batch_b))
+
+        assert all(event.stored for event in batch_a + batch_b)
+        assert tracking_mock_client.tracking["peak"] == 2  # instance-wide cap, not per batch
+
+    async def test_pool_maxsize_must_cover_bulk_concurrency(self):
+        with pytest.raises(ValueError, match="pool_maxsize"):
+            OpensearchOutput.Config(**{**self.CONFIG, "bulk_concurrency": 16})
+
+    async def test_store_retries_rejected_items_until_success(self, mock_client):
+        mock_client.bulk.side_effect = [_bulk_response(201, 429), _bulk_response(200)]
+        events = self._create_log_events(2)
+
+        await self._setup_and_store(events)
+
+        assert all(event.stored for event in events)
+        assert mock_client.bulk.await_count == 2
+
+    async def test_store_retries_only_the_rejected_events(self, mock_client, get_sent_bulk_actions):
+        mock_client.bulk.side_effect = [_bulk_response(201, 429), _bulk_response(200)]
+        events = [
+            self._create_log_event({"message": "stored first try"}),
+            self._create_log_event({"message": "rejected first try"}),
+        ]
+
+        await self._setup_and_store(events)
+
+        [retried_action] = get_sent_bulk_actions(call_index=1)
+        assert retried_action["message"] == "rejected first try"
+
+    async def test_store_fails_rejected_items_when_item_retries_are_exhausted(self, mock_client):
+        self.object = self._create_test_instance(config_patch={"max_bulk_item_retries": 2})
+        mock_client.bulk.return_value = _bulk_response(429)
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        [error] = event.errors
+        assert isinstance(error, RetriesExhaustedError)
+        assert mock_client.bulk.await_count == 3  # initial attempt + 2 retries
+
+    async def test_item_status_503_is_permanent_by_default(self, mock_client):
+        mock_client.bulk.return_value = _bulk_response(503)
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        [error] = event.errors
+        assert isinstance(error, BulkError)
+        assert mock_client.bulk.await_count == 1
+
+    async def test_retryable_item_statuses_are_configurable(self, mock_client):
+        self.object = self._create_test_instance(
+            config_patch={"retryable_item_statuses": [429, 503]}
+        )
+        mock_client.bulk.side_effect = [_bulk_response(503), _bulk_response(201)]
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.stored
+        assert mock_client.bulk.await_count == 2
+
+    async def test_bulk_creates_bulk_error(self, mock_client):
+        mock_client.bulk.return_value = _bulk_response(
+            {
+                "create": {
+                    "error": "Failed to index document",
+                    "status": "503",
+                    "exception": "Service Unavailable",
+                }
+            }
+        )
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        [error] = event.errors
+        assert isinstance(error, BulkError)
+        assert "Failed to index document" in str(error)
+        assert "503" in str(error)
+        assert "Service Unavailable" in str(error)
+
+    async def test_store_retries_connection_errors(self, mock_client):
+        mock_client.bulk.side_effect = [CONNECTION_ERROR, CONNECTION_ERROR, _bulk_response(201)]
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.stored
+        assert self.object._circuit_breaker.healthy
+        assert mock_client.bulk.await_count == 3
+
+    async def test_store_retries_connection_timeouts(self, mock_client):
+        mock_client.bulk.side_effect = [
+            ConnectionTimeout("TIMEOUT", "read timeout", TimeoutError()),
+            _bulk_response(201),
+        ]
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.stored
+        assert mock_client.bulk.await_count == 2
+
+    async def test_store_fails_events_when_connection_retries_are_exhausted(self, mock_client):
+        self.object = self._create_test_instance(config_patch={"max_connection_retries": 1})
+        mock_client.bulk.side_effect = CONNECTION_ERROR
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        [error] = event.errors
+        assert isinstance(error, RetriesExhaustedError)
+        assert mock_client.bulk.await_count == 2  # initial attempt + 1 retry
+        assert not self.object._circuit_breaker.healthy
+
+    async def test_store_retries_transport_errors_with_retryable_status(self, mock_client):
+        mock_client.bulk.side_effect = [
+            TransportError(503, "service_unavailable", {}),
+            _bulk_response(201),
+        ]
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.stored
+        assert mock_client.bulk.await_count == 2
+
+    async def test_retryable_transport_statuses_are_configurable(self, mock_client):
+        self.object = self._create_test_instance(
+            config_patch={"retryable_transport_statuses": [418]}
+        )
+        mock_client.bulk.side_effect = [
+            TransportError(418, "im_a_teapot", {}),
+            _bulk_response(201),
+        ]
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.stored
+        assert mock_client.bulk.await_count == 2
+
+    async def test_store_does_not_retry_request_errors(self, mock_client):
+        request_error = RequestError(400, "mapper_parsing_exception", {})
+        mock_client.bulk.side_effect = request_error
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert event.errors == [request_error]
+        assert mock_client.bulk.await_count == 1
+        assert self.object._circuit_breaker.healthy
+
+    async def test_store_does_not_retry_bulk_responses_violating_the_item_contract(
+        self, mock_client
+    ):
+        mock_client.bulk.return_value = {"items": []}
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        [error] = event.errors
+        assert isinstance(error, CriticalOutputError)
+        assert mock_client.bulk.await_count == 1
+
+    async def test_metrics_count_bulk_requests_documents_and_rejections(self, mock_client):
+        mock_client.bulk.side_effect = [_bulk_response(201, 429), _bulk_response(200)]
+        self.object.metrics.number_of_bulk_requests = 0
+        self.object.metrics.number_of_document_rejections = 0
+        self.object.metrics.documents_per_bulk_request = 0
+        events = self._create_log_events(2)
+
+        await self._setup_and_store(events)
+
+        assert self.object.metrics.number_of_bulk_requests == 2
+        assert self.object.metrics.number_of_document_rejections == 1
+        assert self.object.metrics.documents_per_bulk_request == 2 + 1
+
+    async def test_metrics_count_bytes_sent(self, mock_client):
+        mock_client.bulk.return_value = _bulk_response(201)
+        self.object.metrics.number_of_bytes_sent = 0
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        sent_body = mock_client.bulk.await_args.kwargs["body"]
+        assert self.object.metrics.number_of_bytes_sent == len(sent_body)
+
+    async def test_metrics_count_connection_failures(self, mock_client):
+        mock_client.bulk.side_effect = [CONNECTION_ERROR, CONNECTION_ERROR, _bulk_response(201)]
+        self.object.metrics.number_of_connection_failures = 0
+        event = self._create_log_event({"message": "test message"})
+
+        await self._setup_and_store([event])
+
+        assert self.object.metrics.number_of_connection_failures == 2
+
+    async def test_metrics_count_serialization_errors(self):
+        self.object.metrics.number_of_serialization_errors = 0
+        unserializable = self._create_log_event({"message": object()})
+
+        await self._setup_and_store([unserializable])
+
+        assert self.object.metrics.number_of_serialization_errors == 1
 
     async def test_health_returns_true_on_success(self, mock_client):
         mock_client.cluster.health.return_value = {"status": "green"}
@@ -212,111 +504,8 @@ class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
         await self.object.setup()
         assert not await self.object.health()
 
-    async def test_bulk_creates_bulk_error(self, mock_output_delivery_for_events):
-        event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
+    async def test_health_returns_false_while_connection_is_degraded(self, mock_client):
         await self.object.setup()
-        mock_output_delivery_for_events(
-            [
-                (
-                    False,
-                    {
-                        "create": {
-                            "error": "Failed to index document",
-                            "status": "503",
-                            "exception": "Service Unavailable",
-                        }
-                    },
-                )
-            ]
-        )
-        await self.object.store([event])
-        [error] = event.errors
-        assert isinstance(error, BulkError)
-        assert "Failed to index document" in str(error)
-        assert "503" in str(error)
-        assert "Service Unavailable" in str(error)
-
-    @pytest.mark.parametrize(
-        "status_codes, client_kwargs, maybe_expect_exception",
-        [
-            pytest.param(
-                [
-                    (True, (200,)),
-                    (True, (200,)),
-                    (True, (200,)),
-                    (True, (200,)),
-                ],
-                {"chunk_size": 2, "max_retries": 0},
-                nullcontext(),
-                id="4x-successful-on-first-try",
-            ),
-            pytest.param(
-                [
-                    (False, (500,)),
-                    (True, (200,)),
-                    (True, (200,)),
-                    (False, (500,)),
-                ],
-                {"chunk_size": 2, "max_retries": 0},
-                nullcontext(),
-                id="1x-final-fail-per-chunk",
-            ),
-            pytest.param(
-                [
-                    (True, (429, 200)),
-                    (True, (200,)),
-                    (True, (200,)),
-                    (True, (429, 200)),
-                ],
-                {"chunk_size": 2, "max_retries": 1},
-                pytest.raises(AssertionError, match="ordering broken"),
-                id="retries-break-ordering",
-            ),
-        ],
-    )
-    async def test_async_streaming_bulk_maintains_order(
-        self, mock_client, status_codes, client_kwargs, maybe_expect_exception
-    ):
-        item_id_to_status_code_seq = {i: list(codes) for i, (_, codes) in enumerate(status_codes)}
-        item_id_to_expected_success = {i: ok for i, (ok, _) in enumerate(status_codes)}
-
-        async def _bulk(body: str):
-            # body is a jsonl string like:
-            #   { "index": {} }\n
-            #   { "id": X     }\n <- first item id
-            #   { "index": {} }\n
-            #   { "id": X + 1 }\n <- second item id ...
-            items = [json.loads(entry) for entry in body.splitlines()][1::2]
-            item_ids = [action["id"] for action in items]
-            return {
-                "items": [
-                    {
-                        "index": {
-                            "status": item_id_to_status_code_seq[item_id].pop(0),
-                            "id": item_id,
-                        }
-                    }
-                    for item_id in item_ids
-                ]
-            }
-
-        mock_client.bulk = mock.AsyncMock(wraps=_bulk)
-
-        actions = ({"_op_type": "index", "id": i} for i in range(len(status_codes)))
-
-        last_index = None
-
-        with maybe_expect_exception:
-            async for success, item in helpers.async_streaming_bulk(
-                mock_client,
-                actions,
-                max_backoff=0,  # disable sleep when retrying
-                max_chunk_bytes=9999,  # no limit
-                raise_on_error=False,
-                raise_on_exception=False,
-                **client_kwargs,
-            ):
-                item_id = item["index"]["id"]
-                assert success is item_id_to_expected_success[item_id]
-                assert last_index is None or last_index < item_id, "ordering broken"
-                last_index = item_id
+        self.object._circuit_breaker._failures = 2
+        assert not await self.object.health()
+        mock_client.cluster.health.assert_not_called()

--- a/tests/unit/ng/test_retry.py
+++ b/tests/unit/ng/test_retry.py
@@ -1,0 +1,202 @@
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+
+import asyncio
+from collections.abc import Callable
+from unittest import mock
+
+import pytest
+
+from logprep.ng.util.retry import (
+    _TRANSIENT_FAILURE,
+    Backoff,
+    BlockingCircuitBreaker,
+    RetriesExhaustedError,
+    is_exhausted,
+)
+
+FAST_BACKOFF = Backoff(initial=0.001, maximum=0.001, jitter=False)
+
+
+class TransientError(Exception):
+    pass
+
+
+def _breaker(
+    max_retries: int | None = None,
+    on_transient_failure: Callable[[Exception], None] | None = None,
+    concurrency: int = 1,
+) -> BlockingCircuitBreaker:
+    return BlockingCircuitBreaker(
+        backoff=FAST_BACKOFF,
+        max_retries=max_retries,
+        is_transient=lambda error: isinstance(error, TransientError),
+        on_transient_failure=on_transient_failure,
+        concurrency=concurrency,
+    )
+
+
+@pytest.mark.timeout(5)
+class TestIsExhausted:
+    @pytest.mark.parametrize(
+        "attempts, max_retries, expected",
+        [
+            (0, 0, False),
+            (1, 0, True),
+            (2, 2, False),
+            (3, 2, True),
+            (1000, None, False),
+        ],
+    )
+    def test_is_exhausted(self, attempts, max_retries, expected):
+        assert is_exhausted(attempts, max_retries) is expected
+
+
+class TestBackoff:
+    def test_duration_doubles_per_retry_without_jitter(self):
+        backoff = Backoff(initial=2, maximum=600, jitter=False)
+        assert [backoff.duration(n) for n in (1, 2, 3)] == [2, 4, 8]
+
+    def test_duration_is_capped_at_maximum(self):
+        backoff = Backoff(initial=2, maximum=5, jitter=False)
+        assert backoff.duration(100) == 5
+
+    def test_duration_does_not_overflow_for_huge_retry_numbers(self):
+        backoff = Backoff(initial=2, maximum=5, jitter=False)
+        assert backoff.duration(10_000) == 5
+
+    def test_duration_with_jitter_stays_in_the_upper_half(self):
+        backoff = Backoff(initial=4, maximum=600)
+        assert all(2 <= backoff.duration(1) <= 4 for _ in range(100))
+
+    async def test_attempts_yields_initial_attempt_plus_retries(self):
+        assert [attempt async for attempt in FAST_BACKOFF.attempts(2)] == [1, 2, 3]
+
+    async def test_attempts_with_zero_budget_yields_single_attempt(self):
+        assert [attempt async for attempt in FAST_BACKOFF.attempts(0)] == [1]
+
+    async def test_attempts_sleeps_before_every_attempt_but_the_first(self):
+        with mock.patch.object(Backoff, "sleep") as mock_sleep:
+            assert [_ async for _ in FAST_BACKOFF.attempts(2)] == [1, 2, 3]
+        assert mock_sleep.mock_calls == [mock.call(1), mock.call(2)]
+
+    async def test_attempts_with_unlimited_budget_keeps_yielding(self):
+        count = 0
+        async for attempt in FAST_BACKOFF.attempts(None):
+            count += 1
+            if attempt == 100:
+                break
+        assert count == 100
+
+
+class TestBlockingCircuitBreaker:
+    async def test_call_returns_the_send_result(self):
+        breaker = _breaker()
+        assert await breaker.call(mock.AsyncMock(return_value="response")) == "response"
+        assert breaker.healthy
+
+    async def test_call_retries_transient_failures_until_success(self):
+        breaker = _breaker()
+        send = mock.AsyncMock(side_effect=[TransientError(), TransientError(), "response"])
+        assert await breaker.call(send) == "response"
+        assert send.await_count == 3
+        assert breaker.healthy
+
+    async def test_call_raises_non_transient_failures_without_touching_the_circuit(self):
+        breaker = _breaker()
+        with pytest.raises(ValueError):
+            await breaker.call(mock.AsyncMock(side_effect=ValueError()))
+        assert breaker.healthy
+
+    async def test_call_raises_when_the_budget_is_exceeded(self):
+        breaker = _breaker(max_retries=1)
+        send = mock.AsyncMock(side_effect=TransientError())
+        with pytest.raises(RetriesExhaustedError):
+            await breaker.call(send)
+        assert send.await_count == 2  # initial attempt + 1 retry
+        assert not breaker.healthy
+
+    async def test_call_probes_serially_while_the_circuit_is_broken(self):
+        breaker = _breaker()
+        in_flight, peak_probes = 0, 0
+
+        async def send():
+            nonlocal in_flight, peak_probes
+            in_flight += 1
+            if not breaker.healthy:
+                peak_probes = max(peak_probes, in_flight)
+            await asyncio.sleep(0.001)
+            in_flight -= 1
+            if send_mock.await_count <= 5:
+                raise TransientError()
+            return "response"
+
+        send_mock = mock.AsyncMock(wraps=send)
+        results = await asyncio.gather(*(breaker.call(send_mock) for _ in range(3)))
+        assert results == ["response"] * 3
+        assert peak_probes == 1
+        assert breaker.healthy
+
+    async def test_concurrent_failures_of_one_outage_only_open_the_circuit_once(self):
+        breaker = _breaker()
+        started = asyncio.Barrier(2)
+
+        async def send():
+            await started.wait()  # both requests in flight before either fails
+            raise TransientError()
+
+        results = await asyncio.gather(
+            breaker._attempt(send, probing=False),
+            breaker._attempt(send, probing=False),
+            return_exceptions=True,
+        )
+        assert all(result is _TRANSIENT_FAILURE for result in results)
+        assert breaker._failures == 1
+
+    async def test_call_limits_concurrent_sends(self):
+        breaker = _breaker(concurrency=2)
+        in_flight, peak = 0, 0
+
+        async def send():
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.001)
+            in_flight -= 1
+            return "response"
+
+        results = await asyncio.gather(*(breaker.call(send) for _ in range(5)))
+        assert results == ["response"] * 5
+        assert peak == 2
+
+    async def test_on_transient_failure_hook_fires_per_recorded_failure(self):
+        hook = mock.Mock()
+        breaker = _breaker(max_retries=1, on_transient_failure=hook)
+        transient = TransientError()
+        send = mock.AsyncMock(side_effect=transient)
+        with pytest.raises(RetriesExhaustedError):
+            await breaker.call(send)
+        # fires for every recorded failure, including the exhausting one
+        assert hook.mock_calls == [mock.call(transient), mock.call(transient)]
+
+    async def test_on_transient_failure_hook_ignores_non_transient_failures(self):
+        hook = mock.Mock()
+        breaker = _breaker(on_transient_failure=hook)
+        with pytest.raises(ValueError):
+            await breaker.call(mock.AsyncMock(side_effect=ValueError()))
+        hook.assert_not_called()
+
+    async def test_call_is_cancellable_while_probing(self):
+        breaker = _breaker()
+        breaker._failures = 1
+
+        async def slow_backoff(*_):
+            await asyncio.sleep(10)
+
+        with mock.patch.object(Backoff, "sleep", slow_backoff):
+            task = asyncio.create_task(breaker.call(mock.AsyncMock()))
+            await asyncio.sleep(0.01)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        assert not breaker._limit_to_single_probe.locked()


### PR DESCRIPTION
## Description

* ng: implement circuit breaker utility to protect downstream systems
* ng: enable opensearch output to retry on transport- and item-level failures + circuit breaker
* ng: add metrics for opensearch output

Configuration changes for Opensearch output:
- removed message_backlog_size
- removed flush_timeout
- removed queue_size
- removed thread_count
- renamed max_retries --> max_client_retries
- added max_bulk_item_retries
- added max_connection_retries
- added initial_backoff
- added max_backoff
- added bulk_concurrency
- added pool_maxsize
- added retryable_item_statuses
- added retryable_transport_statuses

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest and benchmark

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--992.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->