### PR TITLE
fix: fix grokker dropping matches on duplicate named capture groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Bugfix
 * fix `dissector` not dissecting multiline strings
+* fix `grokker` dropping matches on duplicate named capture groups
 
 ## 19.4.1
 

--- a/logprep/processor/grokker/rule.py
+++ b/logprep/processor/grokker/rule.py
@@ -183,7 +183,7 @@ class GrokkerRule(DissectorRule):
 
         # to ensure no string splitting is done during processing for target fields:
         for _, grok in self.actions.items():
-            target_fields = list(grok.field_mapper.values())
+            target_fields = list(grok.field_mappings.values())
             if not target_fields:
                 raise InvalidRuleDefinitionError("no target fields defined")
             for target_field in target_fields:

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -65,8 +65,8 @@ class Grok:
     custom_patterns: dict = field(factory=dict)
     fullmatch: bool = field(default=True)
     predefined_patterns: dict = field(init=False, factory=dict, repr=False)
-    type_mapper: dict = field(init=False, factory=dict)
-    field_mapper: dict = field(init=False, factory=dict)
+    type_mappings: dict = field(init=False, factory=dict)
+    field_mappings: dict = field(init=False, factory=dict)
     regex_obj = field(init=False, default=None)
 
     def __attrs_post_init__(self):
@@ -106,16 +106,16 @@ class Grok:
         if not matches:
             return {}
         first_match = matches[0]
-        if self.type_mapper:
+        if self.type_mappings:
             for key, match in first_match.items():
-                type_ = INT_FLOAT.get(self.type_mapper.get(key))
-                if type_ is not None:
-                    first_match[key] = type_(match)
-        return {self.field_mapper[field_hash]: value for field_hash, value in first_match.items()}
+                type_mapper = INT_FLOAT.get(self.type_mappings.get(key))
+                if type_mapper is not None:
+                    first_match[key] = type_mapper(match)
+        return {self.field_mappings[field_hash]: value for field_hash, value in first_match.items()}
 
     def _map_types(self, matches):
         for key, match in matches.items():
-            type_ = INT_FLOAT.get(self.type_mapper.get(key))
+            type_ = INT_FLOAT.get(self.type_mappings.get(key))
             if type_ is not None and match is not None:
                 matches[key] = type_(match)
         return matches
@@ -147,13 +147,13 @@ class Grok:
         type_str = match.group(8)
         dotted_fields = self._logstash_to_dotted_field(fields)
         fields_hash = f"md5{md5(fields.encode()).hexdigest()}"  # nosemgrep
-        if fields_hash in self.field_mapper:
+        if fields_hash in self.field_mappings:
             fields_hash += (
                 f"_{''.join(np.random.choice(list(string.ascii_letters), size=10, replace=True))}"
             )
         if type_str is not None:
-            self.type_mapper |= {fields_hash: type_str}
-        self.field_mapper |= {fields_hash: dotted_fields}
+            self.type_mappings |= {fields_hash: type_str}
+        self.field_mappings |= {fields_hash: dotted_fields}
         return rf"(?P<{fields_hash}>" rf"{pattern.regex_str})"
 
     def _resolve_oniguruma(self, match: re.Match) -> str:
@@ -161,11 +161,11 @@ class Grok:
         pattern = match.group(2)
         dotted_fields = self._logstash_to_dotted_field(fields)
         fields_hash = f"md5{md5(fields.encode()).hexdigest()}"  # nosemgrep
-        if fields_hash in self.field_mapper:
+        if fields_hash in self.field_mappings:
             fields_hash += (
                 f"_{''.join(np.random.choice(list(string.ascii_letters), size=10, replace=True))}"
             )
-        self.field_mapper |= {fields_hash: dotted_fields}
+        self.field_mappings |= {fields_hash: dotted_fields}
         return rf"(?P<{fields_hash}>" rf"{pattern})"
 
     def _load_search_pattern(self):

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -100,14 +100,16 @@ class Grok:
             match_obj = [regex_pattern.search(text) for regex_pattern in self.regex_obj]
 
         match_obj = [match for match in match_obj if match is not None]
-        matches = [match.groupdict() for match in match_obj]
+        matches = [
+            {k: v for k, v in match.groupdict(None).items() if v is not None} for match in match_obj
+        ]
         if not matches:
             return {}
         first_match = matches[0]
         if self.type_mapper:
             for key, match in first_match.items():
                 type_ = INT_FLOAT.get(self.type_mapper.get(key))
-                if type_ is not None and match is not None:
+                if type_ is not None:
                     first_match[key] = type_(match)
         return {self.field_mapper[field_hash]: value for field_hash, value in first_match.items()}
 

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -151,19 +151,46 @@ test_cases = [
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"normalize me!": "123.123.123.123 1234 bar"},
+                "event_data": {"normalize me!": "123.123.123.123 1234 foo"},
             }
         },
         {
             "winlog": {
                 "api": "wineventlog",
                 "event_id": 123456789,
-                "event_data": {"normalize me!": "123.123.123.123 1234 bar"},
+                "event_data": {"normalize me!": "123.123.123.123 1234 foo"},
             },
             "some_ip": "123.123.123.123",
             "port": 1234,
         },
         id="grok list match first matching after skipping non matching with same target fields",
+    ),
+    pytest.param(
+        {
+            "filter": "winlog.event_id: 123456789",
+            "grokker": {
+                "mapping": {
+                    "winlog.event_data.normalize me!": "%{IP:some_ip} %{NUMBER:port:int} foo|%{IP:some_ip} %{NUMBER:port:int} bar",
+                }
+            },
+        },
+        {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234 foo"},
+            }
+        },
+        {
+            "winlog": {
+                "api": "wineventlog",
+                "event_id": 123456789,
+                "event_data": {"normalize me!": "123.123.123.123 1234 foo"},
+            },
+            "some_ip": "123.123.123.123",
+            "port": 1234,
+        },
+        id="grok non-list match first matching after skipping non matching with same target fields",
     ),
     pytest.param(
         {


### PR DESCRIPTION
## Description

* fix grokker dropping matches on duplicate named capture groups

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest, [regression test](https://github.com/fkie-cad/Logprep/pull/993/changes#diff-293449d90c046d869f8ccbe5271621ccf65ad41dc00e32087db2578a8ed30f0bR168)

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--993.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->