### PR TITLE
feat: add comparison support for calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Upcoming Changes
 ### Breaking
 
-### Features
+## Features
+* calculator: add support for >, <, >=, <=, ==, and != comparisons with arithmetic expressions on both sides
 
 ### Improvements
+* calculator: add clean expression-stack teardown after parsing or evaluation to safely reuse the shared BNF parser
+* calculator: refactor the expression grammar into explicit power, multiplicative, additive, and comparison precedence levels
+* calculator: extend documentation and tests for comparison semantics, chained comparisons, boolean operands, floating-point equality, postfix evaluation order, and parser reuse after failures
 * add launch configurations for ng and advanced debugging
 * preprocessor: move configs and partially (ng) logic in dedicated modules
 * partially use [msgspec.json.Decoder.type](https://github.com/fkie-cad/Logprep/pull/955) for type validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Upcoming Changes
 ### Breaking
 
-## Features
+### Features
 * calculator: add support for >, <, >=, <=, ==, and != comparisons with arithmetic expressions on both sides
 
 ### Improvements

--- a/logprep/ng/processor/calculator/processor.py
+++ b/logprep/ng/processor/calculator/processor.py
@@ -73,7 +73,7 @@ class Calculator(FieldManager):
         @timeout(seconds=rule.timeout)
         def calculate(event, rule: CalculatorRule, expression: str) -> float | None:
             try:
-                _ = self.bnf.parseString(expression, parseAll=True)
+                _ = self.bnf.parse_string(expression, parse_all=True)
                 return self.bnf.evaluate_stack()
             except (ParseException, ParseSyntaxException) as error:
                 error.msg = f"({self.name}): expression '{error.line}' could not be parsed"

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -203,14 +203,3 @@ class BNF(Forward):
                 return float(op)
             except ValueError:
                 return op
-
-    def parse_and_evaluate(self, expression: str, parse_all: bool = False, **kwargs):
-        """Parse and evaluate an expression while ensuring the stack is always cleared."""
-
-        self.exprStack.clear()
-
-        try:
-            self.parse_string(expression, parse_all=parse_all, **kwargs)
-            return self.evaluate_stack()
-        finally:
-            self.exprStack.clear()

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -22,21 +22,29 @@ from pyparsing import (
     Forward,
     Group,
     Literal,
+    Optional,
     Regex,
     Suppress,
     Word,
     alphanums,
     alphas,
+    one_of,
 )
 
 epsilon = 1e-12
-# map operator symbols to corresponding arithmetic operations
+# map operator symbols to corresponding arithmetic and comparison operations.
 opn = {
     "+": operator.add,
     "-": operator.sub,
     "*": operator.mul,
     "/": operator.truediv,
     "^": operator.pow,
+    ">": operator.gt,
+    "<": operator.lt,
+    ">=": operator.ge,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
 }
 
 fn = {
@@ -49,7 +57,7 @@ fn = {
     "from_hex": lambda a: int(a, 16),
     "round": round,
     "sgn": lambda a: -1 if a < -epsilon else 1 if a > epsilon else 0,
-    # functionsl with multiple arguments
+    # functions with multiple arguments
     "multiply": lambda a, b: a * b,
     "hypot": math.hypot,
     # functions with a variable number of arguments
@@ -59,14 +67,16 @@ fn = {
 
 class BNF(Forward):
     """
-    expop   :: '^'
-    multop  :: '*' | '/'
-    addop   :: '+' | '-'
-    integer :: ['+' | '-'] '0'..'9'+
-    atom    :: PI | E | real | fn '(' expr ')' | '(' expr ')'
-    factor  :: atom [ expop factor ]*
-    term    :: factor [ multop factor ]*
-    expr    :: term [ addop term ]*
+    expop                 :: '^'
+    multop                :: '*' | '/'
+    addop                 :: '+' | '-'
+    comparisonop          :: '>' | '<' | '>=' | '<=' | '==' | '!='
+    integer               :: ['+' | '-'] '0'..'9'+
+    atom                  :: PI | E | real | fn '(' comparison_expr ')' | '(' comparison_expr ')'
+    power_expr            :: atom [expop power_expr]*
+    multiplicative_expr   :: power_expr [multop power_expr]*
+    additive_expr         :: multiplicative_expr [addop multiplicative_expr]*
+    comparison_expr       :: additive_expr [comparisonop additive_expr]
     """
 
     exprStack: list
@@ -89,46 +99,7 @@ class BNF(Forward):
     addop = plus | minus
     multop = mult | div
     expop = Literal("^")
-
-    def push_first(self, toks):
-        self.exprStack.append(toks[0])
-
-    def push_unary_minus(self, toks):
-        for t in toks:
-            if t == "-":
-                self.exprStack.append("unary -")
-            else:
-                break
-
-    def evaluate_stack(self):
-        op, num_args = self.exprStack.pop(), 0
-        if isinstance(op, tuple):
-            op, num_args = op
-        if op == "unary -":
-            return -self.evaluate_stack()
-        if op in "+-*/^":
-            # note: operands are pushed onto the stack in reverse order
-            op2 = self.evaluate_stack()
-            op1 = self.evaluate_stack()
-            return opn[op](op1, op2)
-        if op == "PI":
-            return math.pi  # 3.1415926535
-        if op == "E":
-            return math.e  # 2.718281828
-        if op in fn:
-            # note: args are pushed onto the stack in reverse order
-            args = reversed([self.evaluate_stack() for _ in range(num_args)])
-            return fn[op](*args)
-        if op[0].isalpha():
-            raise Exception(f"invalid identifier '{op}'")  # pylint: disable=broad-exception-raised
-        # try to evaluate as int first, then as float if int fails
-        try:
-            return int(op)
-        except ValueError:
-            try:
-                return float(op)
-            except ValueError:
-                return op
+    comparisonop = one_of(">= <= == != > <")
 
     def __new__(cls):
         if not hasattr(cls, "instance"):
@@ -159,12 +130,87 @@ class BNF(Forward):
             )
         ).set_parse_action(self.push_unary_minus)
 
-        # by defining exponentiation as "atom [ ^ factor ]..." instead of "atom [ ^ atom ]...",
-        # we get right-to-left exponents,
-        # instead of left-to-right that is, 2^3^2 = 2^(3^2), not (2^3)^2.
-        factor = Forward()
-        factor <<= atom + (self.expop + factor).set_parse_action(self.push_first)[...]
-        term = factor + (self.multop + factor).set_parse_action(self.push_first)[...]
+        # A Forward declaration is required because the power expression recursively
+        # references itself on the right-hand side of the exponent operator.
+        # By defining exponentiation as "atom [ ^ power_expression ]..." instead of
+        # "atom [ ^ atom ]...", exponents are evaluated from right to left:
+        # 2^3^2 = 2^(3^2), not (2^3)^2.
+        power_expr = Forward()
+        power_expr <<= atom + (self.expop + power_expr).set_parse_action(self.push_first)[...]
 
-        forward_self: Forward = self
-        forward_self <<= term + (self.addop + term).set_parse_action(self.push_first)[...]
+        multiplicative_expr = (
+            power_expr + (self.multop + power_expr).set_parse_action(self.push_first)[...]
+        )
+        additive_expr = (
+            multiplicative_expr
+            + (self.addop + multiplicative_expr).set_parse_action(self.push_first)[...]
+        )
+
+        # Optional allows at most one comparison; chained comparisons are not supported.
+        comparison_expr = additive_expr + Optional(
+            (self.comparisonop + additive_expr).set_parse_action(self.push_first)
+        )
+
+        forward_self: Forward = self  # narrow the type for mypy before using Forward.__ilshift__
+        forward_self <<= comparison_expr
+
+    def push_first(self, toks):
+        self.exprStack.append(toks[0])
+
+    def push_unary_minus(self, toks):
+        for t in toks:
+            if t == "-":
+                self.exprStack.append("unary -")
+            else:
+                break
+
+    @staticmethod
+    def reject_boolean_operands(*operands):
+        if any(isinstance(operand, bool) for operand in operands):
+            raise Exception(  # pylint: disable=broad-exception-raised
+                "boolean values cannot be used as operands"
+            )
+
+    def evaluate_stack(self):
+        op, num_args = self.exprStack.pop(), 0
+        if isinstance(op, tuple):
+            op, num_args = op
+        if op == "unary -":
+            operand = self.evaluate_stack()
+            self.reject_boolean_operands(operand)
+            return -operand
+        if op in opn:
+            # Operands are pushed onto the stack in reverse order
+            op2 = self.evaluate_stack()
+            op1 = self.evaluate_stack()
+            self.reject_boolean_operands(op1, op2)
+            return opn[op](op1, op2)
+        if op == "PI":
+            return math.pi  # 3.1415926535
+        if op == "E":
+            return math.e  # 2.718281828
+        if op in fn:
+            # note: args are pushed onto the stack in reverse order
+            args = reversed([self.evaluate_stack() for _ in range(num_args)])
+            return fn[op](*args)
+        if op[0].isalpha():
+            raise Exception(f"invalid identifier '{op}'")  # pylint: disable=broad-exception-raised
+        # try to evaluate as int first, then as float if int fails
+        try:
+            return int(op)
+        except ValueError:
+            try:
+                return float(op)
+            except ValueError:
+                return op
+
+    def parse_and_evaluate(self, expression: str, parse_all: bool = False, **kwargs):
+        """Parse and evaluate an expression while ensuring the stack is always cleared."""
+
+        self.exprStack.clear()
+
+        try:
+            self.parse_string(expression, parse_all=parse_all, **kwargs)
+            return self.evaluate_stack()
+        finally:
+            self.exprStack.clear()

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -113,9 +113,9 @@ class BNF(Forward):
 
         # add parse action that replaces the function identifier with a (name, number of args) tuple
         def insert_fn_argcount_tuple(t):
-            fn = t.pop(0)  # pylint: disable=redefined-outer-name
+            _fn = t.pop(0)
             num_args = len(t[0])
-            t.insert(0, (fn, num_args))
+            t.insert(0, (_fn, num_args))
 
         fn_call = (self.ident + self.lpar - Group(expr_list) + self.rpar).set_parse_action(
             insert_fn_argcount_tuple
@@ -167,9 +167,7 @@ class BNF(Forward):
     @staticmethod
     def reject_boolean_operands(*operands):
         if any(isinstance(operand, bool) for operand in operands):
-            raise Exception(  # pylint: disable=broad-exception-raised
-                "boolean values cannot be used as operands"
-            )
+            raise ValueError("boolean values cannot be used as operands")
 
     def evaluate_stack(self):
         op, num_args = self.exprStack.pop(), 0
@@ -194,7 +192,7 @@ class BNF(Forward):
             args = reversed([self.evaluate_stack() for _ in range(num_args)])
             return fn[op](*args)
         if op[0].isalpha():
-            raise Exception(f"invalid identifier '{op}'")  # pylint: disable=broad-exception-raised
+            raise ValueError(f"invalid identifier '{op}'")
         # try to evaluate as int first, then as float if int fails
         try:
             return int(op)

--- a/logprep/processor/calculator/fourFn.py
+++ b/logprep/processor/calculator/fourFn.py
@@ -109,7 +109,7 @@ class BNF(Forward):
     def __init__(self) -> None:
         super().__init__()
         self.exprStack = []
-        expr_list = DelimitedList(Group(self))  # pylint: disable=E1121
+        expr_list = DelimitedList(Group(self))
 
         # add parse action that replaces the function identifier with a (name, number of args) tuple
         def insert_fn_argcount_tuple(t):

--- a/logprep/processor/calculator/processor.py
+++ b/logprep/processor/calculator/processor.py
@@ -69,7 +69,7 @@ class Calculator(FieldManager):
         @timeout(seconds=rule.timeout)
         def calculate(event, rule, expression):
             try:
-                _ = self.bnf.parseString(expression, parseAll=True)
+                _ = self.bnf.parse_string(expression, parse_all=True)
                 return self.bnf.evaluate_stack()
             except (ParseException, ParseSyntaxException) as error:
                 error.msg = f"({self.name}): expression '{error.line}' could not be parsed"

--- a/logprep/processor/calculator/processor.py
+++ b/logprep/processor/calculator/processor.py
@@ -80,6 +80,9 @@ class Calculator(FieldManager):
                     + f"{error.args[0]}"
                 ]
                 self._handle_warning_error(event, rule, error)
+            finally:
+                # always clear the expression stack so the shared BNF instance can be safely reused.
+                self.bnf.exprStack.clear()
             return None
 
         return calculate(event, rule, expression)

--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -33,8 +33,42 @@ A speaking example:
    :inherited-members:
    :no-undoc-members:
 
-Following a list with example calculation expressions, where all factors and the operators can be
-retrieved from a field with the schema :code:`${your.dotted.field}`:
+The calculator supports the following arithmetic operators:
+
+* :code:`+` addition
+* :code:`-` subtraction
+* :code:`*` multiplication
+* :code:`/` division
+* :code:`^` exponentiation
+
+The calculator supports the following comparison operators:
+
+* :code:`>` greater than
+* :code:`<` less than
+* :code:`>=` greater than or equal
+* :code:`<=` less than or equal
+* :code:`==` equal
+* :code:`!=` not equal
+
+Comparison expressions return either :code:`True` or :code:`False`. Arithmetic expressions on both
+sides of a comparison are evaluated before the comparison itself.
+
+Only one comparison operator is allowed per expression. Chained comparisons such as
+:code:`1 < 2 < 3` or :code:`1 < 2 == 2` are not supported.
+
+The result of a comparison cannot be used as an operand for another arithmetic or comparison
+operation.
+
+.. warning::
+
+The operators :code:`==` and :code:`!=` perform exact comparisons. Avoid using them to compare
+calculated floating-point values, because many decimal values cannot be represented exactly as
+binary floating-point numbers.
+
+For example, :code:`0.1 + 0.2 == 0.3` may evaluate to :code:`False`.
+
+Following is a list of example calculation expressions. All factors and operators can be retrieved
+from a field using the schema :code:`${your.dotted.field}`:
 
 * :code:`9` => :code:`9`
 * :code:`-9` => :code:`-9`
@@ -82,6 +116,21 @@ retrieved from a field with the schema :code:`${your.dotted.field}`:
 * :code:`multiply(3, 7)` => :code:`21`
 * :code:`all(1,1,1)` => :code:`True`
 * :code:`all(1,1,1,1,1,0)` => :code:`False`
+* :code:`2 > 1` => :code:`True`
+* :code:`2 > 2` => :code:`False`
+* :code:`1 < 2` => :code:`True`
+* :code:`1 < 1` => :code:`False`
+* :code:`2 >= 2` => :code:`True`
+* :code:`2 >= 3` => :code:`False`
+* :code:`1 <= 1` => :code:`True`
+* :code:`2 <= 1` => :code:`False`
+* :code:`1 == 1` => :code:`True`
+* :code:`1 == 2` => :code:`False`
+* :code:`1 != 2` => :code:`True`
+* :code:`1 != 1` => :code:`False`
+* :code:`1 + 2 < 4` => :code:`True`
+* :code:`2 * 3 == 6` => :code:`True`
+* :code:`2 ^ 3 >= 8` => :code:`True`
 
 The calc expression is not whitespace sensitive.
 

--- a/logprep/processor/calculator/rule.py
+++ b/logprep/processor/calculator/rule.py
@@ -56,16 +56,20 @@ sides of a comparison are evaluated before the comparison itself.
 Only one comparison operator is allowed per expression. Chained comparisons such as
 :code:`1 < 2 < 3` or :code:`1 < 2 == 2` are not supported.
 
-The result of a comparison cannot be used as an operand for another arithmetic or comparison
-operation.
+Boolean values are final results and cannot be reused as operands in arithmetic or comparison
+operations. Unary negation of boolean values is also not supported. This applies to boolean values
+returned by comparisons as well as boolean-returning functions such as :code:`all`.
+
+For example, expressions such as :code:`(1 < 2) + 1`, :code:`(1 < 2) == (2 < 3)`,
+:code:`-(1 < 2)`, and :code:`all(1, 1) * 2` are not supported.
 
 .. warning::
 
-The operators :code:`==` and :code:`!=` perform exact comparisons. Avoid using them to compare
-calculated floating-point values, because many decimal values cannot be represented exactly as
-binary floating-point numbers.
+   The operators :code:`==` and :code:`!=` perform exact comparisons. Avoid using them to compare
+   calculated floating-point values, because many decimal values cannot be represented exactly as
+   binary floating-point numbers.
 
-For example, :code:`0.1 + 0.2 == 0.3` may evaluate to :code:`False`.
+   For example, :code:`0.1 + 0.2 == 0.3` may evaluate to :code:`False`.
 
 Following is a list of example calculation expressions. All factors and operators can be retrieved
 from a field using the schema :code:`${your.dotted.field}`:

--- a/tests/unit/ng/processor/calculator/test_calculator.py
+++ b/tests/unit/ng/processor/calculator/test_calculator.py
@@ -103,6 +103,6 @@ class TestCalculator(BaseProcessorTestCase[Calculator]):
     )
     async def test_fourfn(self, expression, expected):
         bnf = BNF()
-        _ = bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+        _ = bnf.parse_string(expression, parse_all=True)  # pylint: disable=E1123,E1121
         result = bnf.evaluate_stack()
         assert result == expected

--- a/tests/unit/processor/calculator/test_calculator.py
+++ b/tests/unit/processor/calculator/test_calculator.py
@@ -4,11 +4,180 @@ import math
 import re
 
 import pytest
+from pyparsing import ParseException
 
 from logprep.processor.calculator.fourFn import BNF
 from tests.unit.processor.base import BaseProcessorTestCase
 
 test_cases = [
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2>1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is greater than (>)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2>2",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not greater than (>)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2>=2",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is greater equal (>=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2>=3",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not greater equal (>=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1<2",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is less than (<)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1<1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not less than (<)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1<=1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is less equal (<=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2<=1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not less equal (<=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1==1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is equal (==)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1==2",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not equal (==)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1!=2",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare is unequal (!=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1!=1",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": False},
+        id="compare is not unequal (!=)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "1 + 2 < 4",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare arithmetical less than (x+y < Z)",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "calculator": {
+                "calc": "2 ^ 3 > 4",
+                "target_field": "new_field",
+            },
+        },
+        {"message": "This is a message"},
+        {"message": "This is a message", "new_field": True},
+        id="compare expo greater than (x^y > Z)",
+    ),
     pytest.param(
         {
             "filter": "message",
@@ -459,3 +628,115 @@ class TestCalculator(BaseProcessorTestCase):
         _ = bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
         result = bnf.evaluate_stack()
         assert result == expected
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "1 < 2 < 3",
+            "1 < 2 == 2",
+        ],
+    )
+    def test_fourfn_rejects_chained_comparisons(self, expression):
+        bnf = BNF()
+
+        with pytest.raises(ParseException):
+            bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "(1 < 2) + 1",
+            "1 + (1 < 2)",
+            "-(1 < 2)",
+            "(1 < 2) == (2 < 3)",
+            "all(1, 1) * 2",
+        ],
+    )
+    def test_fourfn_rejects_boolean_operands(self, expression):
+        bnf = BNF()
+        bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+
+        with pytest.raises(
+            Exception,
+            match="boolean values cannot be used as operands",
+        ):
+            bnf.evaluate_stack()
+
+    def test_fourfn_builds_expected_postfix_stack(self):
+        """
+        Ensure that expressions are converted into the expected execution order.
+
+        The test protects the existing postfix stack structure so that future parser
+        changes do not alter the evaluation order unintentionally. Intentional changes
+        to the order must also update this test.
+        """
+        bnf = BNF()
+        expression = "round((PI + 2) * 3 ^ 2 ^ 2 / 4 - -5, 2) >= multiply(2, 3) + E"
+
+        bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+
+        assert bnf.exprStack == [
+            "PI",
+            "2",
+            "+",
+            "3",
+            "2",
+            "2",
+            "^",
+            "^",
+            "*",
+            "4",
+            "/",
+            "5",
+            "unary -",
+            "-",
+            "2",
+            ("round", 2),
+            "2",
+            "3",
+            ("multiply", 2),
+            "E",
+            "+",
+            ">=",
+        ]
+
+    @pytest.mark.parametrize(
+        "failing_expression",
+        [
+            pytest.param("1 +", id="parse error"),
+            pytest.param("1 / 0", id="evaluation error"),
+        ],
+    )
+    def test_calculator_clears_expression_stack_after_failure(
+        self,
+        failing_expression,
+    ):
+        rule = {
+            "filter": "field1",
+            "calculator": {
+                "calc": "${field1}",
+                "target_field": "result",
+            },
+        }
+        self._load_rule(rule)
+
+        bnf = self.object.bnf
+        failing_event = {"field1": failing_expression}
+
+        result = self.object.process(failing_event)
+
+        assert len(result.warnings) == 1
+        assert self.object.bnf is bnf
+        assert bnf.exprStack == []
+
+        valid_event = {"field1": "2 + 3"}
+
+        result = self.object.process(valid_event)
+
+        assert result.warnings == []
+        assert valid_event == {
+            "field1": "2 + 3",
+            "result": 5,
+        }
+        assert self.object.bnf is bnf
+        assert bnf.exprStack == []

--- a/tests/unit/processor/calculator/test_calculator.py
+++ b/tests/unit/processor/calculator/test_calculator.py
@@ -625,7 +625,7 @@ class TestCalculator(BaseProcessorTestCase):
     )
     def test_fourfn(self, expression, expected):
         bnf = BNF()
-        _ = bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+        _ = bnf.parse_string(expression, parse_all=True)  # pylint: disable=E1123,E1121
         result = bnf.evaluate_stack()
         assert result == expected
 
@@ -640,7 +640,7 @@ class TestCalculator(BaseProcessorTestCase):
         bnf = BNF()
 
         with pytest.raises(ParseException):
-            bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+            bnf.parse_string(expression, parse_all=True)  # pylint: disable=E1123,E1121
 
     @pytest.mark.parametrize(
         "expression",
@@ -654,7 +654,7 @@ class TestCalculator(BaseProcessorTestCase):
     )
     def test_fourfn_rejects_boolean_operands(self, expression):
         bnf = BNF()
-        bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+        bnf.parse_string(expression, parse_all=True)  # pylint: disable=E1123,E1121
 
         with pytest.raises(
             Exception,
@@ -673,7 +673,7 @@ class TestCalculator(BaseProcessorTestCase):
         bnf = BNF()
         expression = "round((PI + 2) * 3 ^ 2 ^ 2 / 4 - -5, 2) >= multiply(2, 3) + E"
 
-        bnf.parseString(expression, parseAll=True)  # pylint: disable=E1123,E1121
+        bnf.parse_string(expression, parse_all=True)  # pylint: disable=E1123,E1121
 
         assert bnf.exprStack == [
             "PI",


### PR DESCRIPTION
## Description

* support `>`, `<`, `>=`, `<=`, `==`, and `!=` comparisons
* reject boolean operands in arithmetic and comparison operations
* refactor the expression grammar into explicit precedence levels
* extend documentation and tests for comparison behavior and parser reuse

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--994.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->