### PR TITLE
fix: allow dotted field notation and performance upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,12 @@
 * ng: use `OutputSpec` instead of `list[dict]` to specify desired output targets for extra events
 * ng: drop "ng_" prefix completely and use a setting in the global registry to activate ng
 * ng: decouple console logging via queue/listener in separate thread
+* improve `list_comparison` performance
 
 ### Bugfix
 * fix `dissector` not dissecting multiline strings
 * fix `grokker` dropping matches on duplicate named capture groups
-* fix `list_comparison` to actually work with dotted field notation, and improve performance
+* fix `list_comparison` to actually work with dotted field notation
 
 ## 19.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### Bugfix
 * fix `dissector` not dissecting multiline strings
 * fix `grokker` dropping matches on duplicate named capture groups
+* fix `list_comparison` to actually work with dotted field notation, and improve performance
 
 ## 19.4.1
 

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -129,22 +129,17 @@ class ListComparison(Processor):
         failure tags are applied instead of producing a normal ``not_in_list`` result.
         """
         list_matches: list[str] = []
-        matched_lists: set[str] = set()
         try:
             dynamic_set = rule.get_dynamic_set(event)
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error
 
         for value in value_list:
-            if len(matched_lists) == len(dynamic_set):
-                break
-
             for compare_list, compare_values in dynamic_set.items():
-                if compare_list in matched_lists:
+                if compare_list in list_matches:
                     continue
                 if value in compare_values:
                     list_matches.append(compare_list)
-                    matched_lists.add(compare_list)
 
         return list_matches, dynamic_set
 

--- a/logprep/processor/list_comparison/processor.py
+++ b/logprep/processor/list_comparison/processor.py
@@ -128,18 +128,23 @@ class ListComparison(Processor):
         Dynamic list loading errors are converted to ``ProcessingWarning`` so the rule's
         failure tags are applied instead of producing a normal ``not_in_list`` result.
         """
-        list_matches = []
+        list_matches: list[str] = []
+        matched_lists: set[str] = set()
         try:
             dynamic_set = rule.get_dynamic_set(event)
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error
 
         for value in value_list:
+            if len(matched_lists) == len(dynamic_set):
+                break
+
             for compare_list, compare_values in dynamic_set.items():
-                if compare_list in list_matches:
+                if compare_list in matched_lists:
                     continue
                 if value in compare_values:
                     list_matches.append(compare_list)
+                    matched_lists.add(compare_list)
 
         return list_matches, dynamic_set
 

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -43,13 +43,13 @@ target field :code:`List_comparison.example`.
 
 import logging
 import os.path
-from string import Template
 
 from attrs import define, field, validators
 
 from logprep.factory_error import InvalidConfigurationError
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.util.dotted_template import DottedTemplate
 from logprep.util.getter import (
     GetterFactory,
     HttpGetter,
@@ -153,6 +153,9 @@ class ListComparisonRule(FieldManagerRule):
         self._config: ListComparisonRule.Config = self._config
         self._compare_sets = {}
         self._callback_tag = ""
+        self._is_dynamic_http = False
+        self._dynamic_templates: tuple[DottedTemplate, ...] = ()
+        self._dynamic_identifiers: tuple[str, ...] = ()
 
     def _get_list_search_base_path(self, list_search_base_path: str | None) -> str:
         if self._config.list_search_base_path:
@@ -192,11 +195,27 @@ class ListComparisonRule(FieldManagerRule):
                 else self._config.list_search_base_path
             )
 
+            base_template = DottedTemplate(self._config.list_search_base_path)
+
             # Check if this is a static (eagerly loaded) or dynamic (lazily loaded) list_comparison
             if any(
                 identifier not in [*os.environ, "LOGPREP_LIST"]
-                for identifier in Template(self._config.list_search_base_path).get_identifiers()
+                for identifier in base_template.get_identifiers()
             ):
+                self._is_dynamic_http = True
+                self._dynamic_templates = tuple(
+                    DottedTemplate(
+                        base_template.safe_substitute({**os.environ, "LOGPREP_LIST": list_path})
+                    )
+                    for list_path in self._config.list_file_paths
+                )
+                self._dynamic_identifiers = tuple(
+                    dict.fromkeys(
+                        identifier
+                        for template in self._dynamic_templates
+                        for identifier in template.get_identifiers()
+                    )
+                )
                 return
 
             self._init_static_http_list_comparison()
@@ -243,7 +262,7 @@ class ListComparisonRule(FieldManagerRule):
         assert self._config.list_search_base_path
 
         for list_path in self._config.list_file_paths:
-            resolved = Template(self._config.list_search_base_path).substitute(
+            resolved = DottedTemplate(self._config.list_search_base_path).substitute(
                 {**os.environ, **{"LOGPREP_LIST": list_path}}
             )
             self._load_http_compare_set(resolved)
@@ -300,35 +319,32 @@ class ListComparisonRule(FieldManagerRule):
             Re-raises the stored data loading error if a dynamic HTTP(S) list cannot be
             loaded, so the processor can apply the rule's failure tags.
         """
+        if not self._is_dynamic_http:
+            return self._compare_sets
+
         compare_sets_result: dict[str, set] = {}
         assert self._config.list_search_base_path
 
         if not self._config.list_search_base_path.startswith("http"):
             return self._compare_sets
 
-        for list_path in self._config.list_file_paths:
-            list_search_base_path_resolved = Template(
-                self._config.list_search_base_path
-            ).safe_substitute({**os.environ, **{"LOGPREP_LIST": list_path}})
+        key_val = {
+            identifier: get_dotted_field_value(event, identifier)
+            for identifier in self._dynamic_identifiers
+        }
 
-            resolved_tmpl = Template(list_search_base_path_resolved)
+        for identifier, val in key_val.items():
+            if val is None:
+                raise ValueError(
+                    f"missing event field {identifier!r} for dynamic list comparison path"
+                )
+            if not isinstance(val, (str, int)):
+                raise ValueError(
+                    f"value for list comparison field {identifier!r} is not a scalar value"
+                )
 
-            key_val = {
-                identifier: get_dotted_field_value(event, identifier)
-                for identifier in resolved_tmpl.get_identifiers()
-            }
-            for identifier, val in key_val.items():
-                if val is None:
-                    raise ValueError(
-                        f"missing event field {identifier!r} for dynamic list comparison path"
-                    )
-                if not isinstance(val, (str, int)):
-                    raise ValueError(
-                        f"value for list comparison field {identifier!r} is not a scalar value"
-                    )
-                pass
-
-            dynamic_resolved = resolved_tmpl.substitute(key_val)
+        for tmpl in self._dynamic_templates:
+            dynamic_resolved = tmpl.substitute(key_val)
 
             if dynamic_resolved in self._compare_sets:
                 RefreshableGetter.keep_alive_for_target(dynamic_resolved)
@@ -339,7 +355,7 @@ class ListComparisonRule(FieldManagerRule):
             compare_set = self._load_http_compare_set(dynamic_resolved, dynamic=True)
             assert compare_set is not None
 
-            compare_sets_result.update({dynamic_resolved: compare_set})
+            compare_sets_result[dynamic_resolved] = compare_set
 
         return compare_sets_result
 

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -49,13 +49,12 @@ from attrs import define, field, validators
 from logprep.factory_error import InvalidConfigurationError
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.dotted_template import DottedTemplate
 from logprep.util.getter import (
     GetterFactory,
     HttpGetter,
     RefreshableGetter,
 )
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import DottedTemplate, get_dotted_field_value
 
 logger = logging.getLogger()
 

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -155,7 +155,7 @@ class ListComparisonRule(FieldManagerRule):
         self._callback_tag = ""
         self._is_dynamic_http = False
         self._dynamic_templates: tuple[DottedTemplate, ...] = ()
-        self._dynamic_identifiers: tuple[str, ...] = ()
+        self._all_dynamic_identifiers: tuple[str, ...] = ()
 
     def _get_list_search_base_path(self, list_search_base_path: str | None) -> str:
         if self._config.list_search_base_path:
@@ -196,29 +196,31 @@ class ListComparisonRule(FieldManagerRule):
             )
 
             base_template = DottedTemplate(self._config.list_search_base_path)
-
-            # Check if this is a static (eagerly loaded) or dynamic (lazily loaded) list_comparison
-            if any(
-                identifier not in [*os.environ, "LOGPREP_LIST"]
-                for identifier in base_template.get_identifiers()
-            ):
-                self._is_dynamic_http = True
-                self._dynamic_templates = tuple(
+            resolved_templates = tuple(
+                DottedTemplate(
                     DottedTemplate(
                         base_template.safe_substitute({**os.environ, "LOGPREP_LIST": list_path})
-                    )
-                    for list_path in self._config.list_file_paths
+                    ).safe_substitute(os.environ)
                 )
-                self._dynamic_identifiers = tuple(
-                    dict.fromkeys(
-                        identifier
-                        for template in self._dynamic_templates
-                        for identifier in template.get_identifiers()
-                    )
+                for list_path in self._config.list_file_paths
+            )
+
+            dynamic_identifiers = tuple(
+                dict.fromkeys(
+                    identifier
+                    for template in resolved_templates
+                    for identifier in template.get_identifiers()
                 )
+            )
+
+            # Check if this is a static (eagerly loaded) or dynamic (lazily loaded) list_comparison
+            if dynamic_identifiers:
+                self._is_dynamic_http = True
+                self._dynamic_templates = resolved_templates
+                self._all_dynamic_identifiers = dynamic_identifiers
                 return
 
-            self._init_static_http_list_comparison()
+            self._init_static_http_list_comparison(resolved_templates)
 
     def _update_compare_sets_via_http(
         self, http_getter: HttpGetter, fully_resolved_uri: str, *, mark_rule_failed: bool = True
@@ -258,14 +260,9 @@ class ListComparisonRule(FieldManagerRule):
             filename = os.path.basename(list_path)
             self._compare_sets.update({filename: set(file_elements)})
 
-    def _init_static_http_list_comparison(self) -> None:
-        assert self._config.list_search_base_path
-
-        for list_path in self._config.list_file_paths:
-            resolved = DottedTemplate(self._config.list_search_base_path).substitute(
-                {**os.environ, **{"LOGPREP_LIST": list_path}}
-            )
-            self._load_http_compare_set(resolved)
+    def _init_static_http_list_comparison(self, templates: tuple[DottedTemplate, ...]) -> None:
+        for template in templates:
+            self._load_http_compare_set(template.substitute({}))
 
     def _load_http_compare_set(
         self, resolved_uri: str, *, dynamic: bool = False
@@ -330,7 +327,7 @@ class ListComparisonRule(FieldManagerRule):
 
         key_val = {
             identifier: get_dotted_field_value(event, identifier)
-            for identifier in self._dynamic_identifiers
+            for identifier in self._all_dynamic_identifiers
         }
 
         for identifier, val in key_val.items():

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -315,14 +315,13 @@ class ListComparisonRule(FieldManagerRule):
             Re-raises the stored data loading error if a dynamic HTTP(S) list cannot be
             loaded, so the processor can apply the rule's failure tags.
         """
-        if not self._is_dynamic_http:
+
+        assert self._config.list_search_base_path
+
+        if not self._is_dynamic_http or not self._config.list_search_base_path.startswith("http"):
             return self._compare_sets
 
         compare_sets_result: dict[str, set] = {}
-        assert self._config.list_search_base_path
-
-        if not self._config.list_search_base_path.startswith("http"):
-            return self._compare_sets
 
         key_val = {
             identifier: get_dotted_field_value(event, identifier)

--- a/logprep/util/dotted_template.py
+++ b/logprep/util/dotted_template.py
@@ -1,0 +1,5 @@
+from string import Template
+
+
+class DottedTemplate(Template):
+    braceidpattern = r"(?a:(?:\\.|[^.$\\{}])+(?:\.(?:\\.|[^.$\\{}])+)*)"

--- a/logprep/util/dotted_template.py
+++ b/logprep/util/dotted_template.py
@@ -1,5 +1,0 @@
-from string import Template
-
-
-class DottedTemplate(Template):
-    braceidpattern = r"(?a:(?:\\.|[^.$\\{}])+(?:\.(?:\\.|[^.$\\{}])+)*)"

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -10,6 +10,7 @@ from enum import Enum, auto
 from functools import lru_cache, partial, reduce
 from importlib.metadata import version
 from os import remove
+from string import Template
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -58,6 +59,10 @@ FieldValue: TypeAlias = Union[
 FieldRef: TypeAlias = str
 
 T = TypeVar("T")
+
+
+class DottedTemplate(Template):
+    braceidpattern = r"(?a:(?:\\.|[^.$\\{}])+(?:\.(?:\\.|[^.$\\{}])+)*)"
 
 
 def _add_and_overwrite_key(event: dict[str, FieldValue], key: str) -> dict[str, FieldValue]:

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -427,6 +427,137 @@ Heinz
         assert responses.calls[0].request.url == url
 
     @pytest.mark.parametrize(
+        "list_path, environment",
+        [
+            pytest.param("${tenant.id}/bad_users.list", {}, id="event-field"),
+            pytest.param(
+                "${LIST_TENANT}/${tenant.id}/bad_users.list",
+                {"LIST_TENANT": "customers"},
+                id="environment-and-event-field",
+            ),
+        ],
+    )
+    @responses.activate
+    async def test_list_comparison_resolves_dynamic_template_in_list_file_path(
+        self, list_path, environment
+    ):
+        document = {"tenant": {"id": "acme"}, "user": "Foo"}
+        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
+        path_prefix = "customers/" if environment else ""
+        url = f"http://localhost/{path_prefix}acme/bad_users.list"
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [list_path],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        with mock.patch.dict("os.environ", environment):
+            processor = Factory.create({"custom_lister": config})
+            rule = processor.rule_class.create_from_dict(rule_dict)
+            processor._rule_tree.add_rule(rule)
+            await processor.setup()
+
+            assert rule.compare_sets == {}
+            assert len(responses.calls) == 0
+
+            await processor.process(log_event)
+
+        assert document["user_results"] == {"in_list": [url]}
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    async def test_list_comparison_resolves_environment_template_in_list_file_path_during_setup(
+        self,
+    ):
+        url = "http://localhost/acme/bad_users.list"
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["${LIST_TENANT}/bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        with mock.patch.dict("os.environ", {"LIST_TENANT": "acme"}):
+            processor = Factory.create({"custom_lister": config})
+            rule = processor.rule_class.create_from_dict(rule_dict)
+            processor._rule_tree.add_rule(rule)
+            await processor.setup()
+
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    async def test_list_comparison_loads_static_and_dynamic_list_file_paths_lazily(self):
+        document = {"tenant": {"id": "acme"}, "user": "Foo"}
+        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
+        static_url = "http://localhost/common.list"
+        dynamic_url = "http://localhost/acme/bad_users.list"
+        responses.add(responses.GET, url=static_url, body="Foo\n", status=200)
+        responses.add(responses.GET, url=dynamic_url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["common.list", "${tenant.id}/bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        await processor.setup()
+
+        assert rule.compare_sets == {}
+        assert len(responses.calls) == 0
+
+        await processor.process(log_event)
+
+        assert document["user_results"] == {"in_list": [static_url, dynamic_url]}
+        assert rule.compare_sets == {
+            static_url: {"Foo"},
+            dynamic_url: {"Foo", "Bar"},
+        }
+        assert len(responses.calls) == 2
+
+    @pytest.mark.parametrize(
         "document, url_template",
         [
             pytest.param(
@@ -457,7 +588,7 @@ Heinz
         ],
     )
     @responses.activate
-    def test_list_comparison_resolves_dynamic_http_template_with_field_syntax(
+    async def test_list_comparison_resolves_dynamic_http_template_with_field_syntax(
         self, document, url_template
     ):
         log_event = LogEvent(document, original=b"", input_meta=InputMeta())
@@ -476,7 +607,7 @@ Heinz
             "description": "",
         }
         config = {
-            "type": "ng_list_comparison",
+            "type": "list_comparison",
             "rules": [],
             "list_search_base_path": url_template,
         }
@@ -486,12 +617,12 @@ Heinz
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
         processor._rule_tree.add_rule(rule)
-        processor.setup()
+        await processor.setup()
 
         assert rule.compare_sets == {}
         assert len(responses.calls) == 0
 
-        processor.process(log_event)
+        await processor.process(log_event)
 
         assert document["user_results"] == {"in_list": [url]}
         assert rule.compare_sets == {url: {"Foo", "Bar"}}
@@ -499,7 +630,7 @@ Heinz
         assert responses.calls[0].request.url == url
 
     @responses.activate
-    def test_list_comparison_dynamic_http_template_rejects_non_scalar_slice_value(self):
+    async def test_list_comparison_dynamic_http_template_rejects_non_scalar_slice_value(self):
         document = {"tenants": ["acme", "beta"], "user": "Foo"}
         log_event = LogEvent(document, original=b"", input_meta=InputMeta())
         expected = {
@@ -516,7 +647,7 @@ Heinz
             "description": "",
         }
         config = {
-            "type": "ng_list_comparison",
+            "type": "list_comparison",
             "rules": [],
             "list_search_base_path": "http://localhost/${tenants.0:2}/${LOGPREP_LIST}",
         }
@@ -526,9 +657,9 @@ Heinz
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
         processor._rule_tree.add_rule(rule)
-        processor.setup()
+        await processor.setup()
 
-        result = processor.process(log_event)
+        result = await processor.process(log_event)
 
         assert document == expected
         assert len(result.warnings) == 1

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -426,6 +426,117 @@ Heinz
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
 
+    @pytest.mark.parametrize(
+        "document, url_template",
+        [
+            pytest.param(
+                {"tenant": {"id": "acme"}, "user": "Foo"},
+                "http://localhost/${tenant.id}/${LOGPREP_LIST}",
+                id="nested-field",
+            ),
+            pytest.param(
+                {"tenants": ["acme"], "user": "Foo"},
+                "http://localhost/${tenants.0}/${LOGPREP_LIST}",
+                id="list-index",
+            ),
+            pytest.param(
+                {"tenants": ["beta", "acme"], "user": "Foo"},
+                "http://localhost/${tenants.-1}/${LOGPREP_LIST}",
+                id="negative-list-index",
+            ),
+            pytest.param(
+                {"tenant.id": "acme", "user": "Foo"},
+                r"http://localhost/${tenant\.id}/${LOGPREP_LIST}",
+                id="escaped-dot",
+            ),
+            pytest.param(
+                {r"tenant\.id": "acme", "user": "Foo"},
+                r"http://localhost/${tenant\\\.id}/${LOGPREP_LIST}",
+                id="escaped-backslash-and-dot",
+            ),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_resolves_dynamic_http_template_with_field_syntax(
+        self, document, url_template
+    ):
+        log_event = LogEvent(document, original=b"")
+        list_name = "bad_users.list"
+        url = "http://localhost/acme/bad_users.list"
+
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [list_name],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "ng_list_comparison",
+            "rules": [],
+            "list_search_base_path": url_template,
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+
+        assert rule.compare_sets == {}
+        assert len(responses.calls) == 0
+
+        processor.process(log_event)
+
+        assert document["user_results"] == {"in_list": [url]}
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    def test_list_comparison_dynamic_http_template_rejects_non_scalar_slice_value(self):
+        document = {"tenants": ["acme", "beta"], "user": "Foo"}
+        log_event = LogEvent(document, original=b"")
+        expected = {
+            **document,
+            "tags": ["_list_comparison_failure"],
+        }
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "ng_list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${tenants.0:2}/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+
+        result = processor.process(log_event)
+
+        assert document == expected
+        assert len(result.warnings) == 1
+        assert "value for list comparison field 'tenants.0:2' is not a scalar value" in str(
+            result.warnings[0]
+        )
+        assert len(responses.calls) == 0
+
     @responses.activate
     async def test_list_comparison_reuses_dynamic_http_compare_set_and_signals_activity(self):
         first_document = {"tenant": "acme", "user": "Foo"}

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -460,7 +460,7 @@ Heinz
     def test_list_comparison_resolves_dynamic_http_template_with_field_syntax(
         self, document, url_template
     ):
-        log_event = LogEvent(document, original=b"")
+        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
         list_name = "bad_users.list"
         url = "http://localhost/acme/bad_users.list"
 
@@ -501,7 +501,7 @@ Heinz
     @responses.activate
     def test_list_comparison_dynamic_http_template_rejects_non_scalar_slice_value(self):
         document = {"tenants": ["acme", "beta"], "user": "Foo"}
-        log_event = LogEvent(document, original=b"")
+        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
         expected = {
             **document,
             "tags": ["_list_comparison_failure"],

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -565,6 +565,133 @@ Heinz
         assert responses.calls[0].request.url == url
 
     @pytest.mark.parametrize(
+        "list_path, environment",
+        [
+            pytest.param("${tenant.id}/bad_users.list", {}, id="event-field"),
+            pytest.param(
+                "${LIST_TENANT}/${tenant.id}/bad_users.list",
+                {"LIST_TENANT": "customers"},
+                id="environment-and-event-field",
+            ),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_resolves_dynamic_template_in_list_file_path(
+        self, list_path, environment
+    ):
+        document = {"tenant": {"id": "acme"}, "user": "Foo"}
+        path_prefix = "customers/" if environment else ""
+        url = f"http://localhost/{path_prefix}acme/bad_users.list"
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [list_path],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        with mock.patch.dict("os.environ", environment):
+            processor = Factory.create({"custom_lister": config})
+            rule = processor.rule_class.create_from_dict(rule_dict)
+            processor._rule_tree.add_rule(rule)
+            processor.setup()
+
+            assert rule.compare_sets == {}
+            assert len(responses.calls) == 0
+
+            processor.process(document)
+
+        assert document["user_results"] == {"in_list": [url]}
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    def test_list_comparison_resolves_environment_template_in_list_file_path_during_setup(self):
+        url = "http://localhost/acme/bad_users.list"
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["${LIST_TENANT}/bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        with mock.patch.dict("os.environ", {"LIST_TENANT": "acme"}):
+            processor = Factory.create({"custom_lister": config})
+            rule = processor.rule_class.create_from_dict(rule_dict)
+            processor._rule_tree.add_rule(rule)
+            processor.setup()
+
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    def test_list_comparison_loads_static_and_dynamic_list_file_paths_lazily(self):
+        document = {"tenant": {"id": "acme"}, "user": "Foo"}
+        static_url = "http://localhost/common.list"
+        dynamic_url = "http://localhost/acme/bad_users.list"
+        responses.add(responses.GET, url=static_url, body="Foo\n", status=200)
+        responses.add(responses.GET, url=dynamic_url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["common.list", "${tenant.id}/bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+
+        assert rule.compare_sets == {}
+        assert len(responses.calls) == 0
+
+        processor.process(document)
+
+        assert document["user_results"] == {"in_list": [static_url, dynamic_url]}
+        assert rule.compare_sets == {
+            static_url: {"Foo"},
+            dynamic_url: {"Foo", "Bar"},
+        }
+        assert len(responses.calls) == 2
+
+    @pytest.mark.parametrize(
         "document, url_template",
         [
             pytest.param(

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -564,6 +564,115 @@ Heinz
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == url
 
+    @pytest.mark.parametrize(
+        "document, url_template",
+        [
+            pytest.param(
+                {"tenant": {"id": "acme"}, "user": "Foo"},
+                "http://localhost/${tenant.id}/${LOGPREP_LIST}",
+                id="nested-field",
+            ),
+            pytest.param(
+                {"tenants": ["acme"], "user": "Foo"},
+                "http://localhost/${tenants.0}/${LOGPREP_LIST}",
+                id="list-index",
+            ),
+            pytest.param(
+                {"tenants": ["beta", "acme"], "user": "Foo"},
+                "http://localhost/${tenants.-1}/${LOGPREP_LIST}",
+                id="negative-list-index",
+            ),
+            pytest.param(
+                {"tenant.id": "acme", "user": "Foo"},
+                r"http://localhost/${tenant\.id}/${LOGPREP_LIST}",
+                id="escaped-dot",
+            ),
+            pytest.param(
+                {r"tenant\.id": "acme", "user": "Foo"},
+                r"http://localhost/${tenant\\\.id}/${LOGPREP_LIST}",
+                id="escaped-backslash-and-dot",
+            ),
+        ],
+    )
+    @responses.activate
+    def test_list_comparison_resolves_dynamic_http_template_with_field_syntax(
+        self, document, url_template
+    ):
+        list_name = "bad_users.list"
+        url = "http://localhost/acme/bad_users.list"
+
+        responses.add(responses.GET, url=url, body="Foo\nBar\n", status=200)
+
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": [list_name],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": url_template,
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+
+        assert rule.compare_sets == {}
+        assert len(responses.calls) == 0
+
+        processor.process(document)
+
+        assert document["user_results"] == {"in_list": [url]}
+        assert rule.compare_sets == {url: {"Foo", "Bar"}}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == url
+
+    @responses.activate
+    def test_list_comparison_dynamic_http_template_rejects_non_scalar_slice_value(self):
+        document = {"tenants": ["acme", "beta"], "user": "Foo"}
+        expected = {
+            **document,
+            "tags": ["_list_comparison_failure"],
+        }
+        rule_dict = {
+            "filter": "user",
+            "list_comparison": {
+                "source_fields": ["user"],
+                "target_field": "user_results",
+                "list_file_paths": ["bad_users.list"],
+            },
+            "description": "",
+        }
+        config = {
+            "type": "list_comparison",
+            "rules": [],
+            "list_search_base_path": "http://localhost/${tenants.0:2}/${LOGPREP_LIST}",
+        }
+
+        HttpGetter._shared.clear()
+
+        processor = Factory.create({"custom_lister": config})
+        rule = processor.rule_class.create_from_dict(rule_dict)
+        processor._rule_tree.add_rule(rule)
+        processor.setup()
+
+        result = processor.process(document)
+
+        assert document == expected
+        assert len(result.warnings) == 1
+        assert "value for list comparison field 'tenants.0:2' is not a scalar value" in str(
+            result.warnings[0]
+        )
+        assert len(responses.calls) == 0
+
     @responses.activate
     def test_list_comparison_reuses_dynamic_http_compare_set_and_signals_activity(self):
         first_document = {"tenant": "acme", "user": "Foo"}

--- a/tests/unit/util/test_dotted_template.py
+++ b/tests/unit/util/test_dotted_template.py
@@ -1,0 +1,73 @@
+import pytest
+
+from logprep.util.dotted_template import DottedTemplate
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "tenant.id",
+        "items.0",
+        "items.-1",
+        "items.0:2",
+        "items.:2",
+        "items.::-1",
+        r"tenant\.id",
+        r"tenant\\\.id",
+    ],
+)
+def test_get_identifiers_supports_field_syntax(identifier):
+    template = DottedTemplate("${" + identifier + "}")
+
+    assert template.is_valid()
+    assert template.get_identifiers() == [identifier]
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "tenant.id",
+        "items.0",
+        "items.-1",
+        "items.0:2",
+        "items.:2",
+        "items.::-1",
+        r"tenant\.id",
+        r"tenant\\\.id",
+    ],
+)
+def test_substitute_supports_field_syntax(identifier):
+    template = DottedTemplate("http://localhost/${" + identifier + "}")
+
+    assert template.substitute({identifier: "acme"}) == "http://localhost/acme"
+
+
+def test_substitute_supports_dotted_identifier():
+    template = DottedTemplate("http://localhost/${tenant.id}/${LOGPREP_LIST}")
+
+    result = template.substitute(
+        {
+            "tenant.id": "acme",
+            "LOGPREP_LIST": "users.list",
+        }
+    )
+
+    assert result == "http://localhost/acme/users.list"
+
+
+def test_safe_substitute_preserves_missing_dotted_identifier():
+    template = DottedTemplate("${tenant.id}")
+
+    assert template.safe_substitute({}) == "${tenant.id}"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "${tenant..id}",
+        "${tenant.}",
+        "${.tenant}",
+    ],
+)
+def test_invalid_dotted_identifiers(value):
+    assert not DottedTemplate(value).is_valid()

--- a/tests/unit/util/test_dotted_template.py
+++ b/tests/unit/util/test_dotted_template.py
@@ -1,6 +1,6 @@
 import pytest
 
-from logprep.util.dotted_template import DottedTemplate
+from logprep.util.helper import DottedTemplate
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

- DottedTemplate now allows full dotted field notation
- Performance improvements for list comparison processor

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [ ] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--995.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->