### PR TITLE
feat: add getter logging & refactor environ handling

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Send test data to kafka
         id: kafka_input
         run: |
-          event_count=`cat $EVENT_DATA_SOURCE | jq -s length`
+          event_count=$(cat $EVENT_DATA_SOURCE | jq -s length)
           echo event_count=$event_count >> $GITHUB_OUTPUT
           echo "Sending $event_count events to kafka"
           (docker exec -i kafka kafka-console-producer.sh --bootstrap-server 127.0.0.1:9092 --topic consumer) \
@@ -67,7 +67,6 @@ jobs:
       - name: Wait and check for processed events in opensearch
         id: wait_for_opensearch_index
         timeout-minutes: 2
-        working-directory: examples/compose
         run: |
           while true
           do
@@ -80,7 +79,6 @@ jobs:
           sleep 5
       - name: Debug - show processed index in opensearch
         if: failure() && steps.wait_for_opensearch_index.outcome == 'failure'
-        working-directory: examples/compose
         run: |
           echo "Indices:"
           curl -X GET "http://localhost:9200/_list/indices" -s
@@ -89,11 +87,19 @@ jobs:
       - name: Query opensearch for events in index 'processed'
         working-directory: examples/compose
         id: opensearch_output
+        timeout-minutes: 1
         run: |
-          event_count=`curl -X GET "http://localhost:9200/processed/_count" -s | jq '.count'`
+          while true
+          do
+            # it might take multiple batches to write all the data, let's check repeatedly
+            event_count=$(curl -X GET "http://localhost:9200/processed/_count" -s | jq '.count')
+            if [ "${{ steps.kafka_input.outputs.event_count }}" == "$event_count" ]; then
+              break
+            fi
+            sleep 5
+          done
           echo event_count=${event_count} >> $GITHUB_OUTPUT
       - name: Check if all events were processed
-        working-directory: examples/compose
         run: |
           echo "Kafka: #events = ${{ steps.kafka_input.outputs.event_count }}"
           echo "Opensearch: #events = ${{ steps.opensearch_output.outputs.event_count }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@
 * ng: implement circuit breaker utility to protect downstream systems
 * ng: enable opensearch output to retry on transport- and item-level failures + circuit breaker
 * ng: add metrics for opensearch output
-
+* improve env var access performance by using a cached snapshot
+* getter: add debug logs
+* improve robustness of compose tests
 
 ### Bugfix
 * fix `dissector` not dissecting multiline strings

--- a/benchmark.py
+++ b/benchmark.py
@@ -252,8 +252,8 @@ def resolve_pipeline_config(ng: int) -> Path:
         Pipeline config path.
     """
     if ng == 1:
-        return Path("./examples/exampledata/config/_benchmark_ng_pipeline.yml")
-    return Path("./examples/exampledata/config/_benchmark_non_ng_pipeline.yml")
+        return Path("./examples/exampledata/config/benchmark_ng_pipeline.yml")
+    return Path("./examples/exampledata/config/benchmark_non_ng_pipeline.yml")
 
 
 def read_vm_max_map_count() -> int:

--- a/examples/exampledata/config/benchmark_ng_pipeline.yml
+++ b/examples/exampledata/config/benchmark_ng_pipeline.yml
@@ -9,16 +9,7 @@ logger:
   format: "%(asctime)-15s %(hostname)-5s %(name)-10s %(levelname)-8s: %(message)s"
   datefmt: "%Y-%m-%d %H:%M:%S"
   loggers:
-    "py.warnings": {"level": "ERROR"}
-    "Runner": {"level": "INFO"}
-    "Processor": {"level": "ERROR"}
-    "Exporter": {"level": "ERROR"}
-    "uvicorn": {"level": "ERROR"}
-    "uvicorn.access": {"level": "ERROR"}
-    "OpenSearchOutput": {"level": "ERROR"}
-    "KafkaOutput": {"level": "ERROR"}
-    "Input": {"level": "ERROR"}
-    "KafkaOffsetTracker": {"level": "ERROR"}
+    Runner: {"level": "INFO"}
 metrics:
   enabled: true
   port: 8001

--- a/examples/exampledata/config/benchmark_ng_pipeline.yml
+++ b/examples/exampledata/config/benchmark_ng_pipeline.yml
@@ -10,6 +10,7 @@ logger:
   datefmt: "%Y-%m-%d %H:%M:%S"
   loggers:
     Runner: {"level": "INFO"}
+    py.warnings: {"level": "ERROR"}
 metrics:
   enabled: true
   port: 8001

--- a/examples/exampledata/config/benchmark_non_ng_pipeline.yml
+++ b/examples/exampledata/config/benchmark_non_ng_pipeline.yml
@@ -9,15 +9,7 @@ logger:
   format: "%(asctime)-15s %(hostname)-5s %(name)-10s %(levelname)-8s: %(message)s"
   datefmt: "%Y-%m-%d %H:%M:%S"
   loggers:
-    "py.warnings": {"level": "ERROR"}
-    "Runner": {"level": "INFO"}
-    "Processor": {"level": "ERROR"}
-    "Exporter": {"level": "ERROR"}
-    "uvicorn": {"level": "ERROR"}
-    "uvicorn.access": {"level": "ERROR"}
-    "OpenSearchOutput": {"level": "ERROR"}
-    "KafkaOutput": {"level": "ERROR"}
-    "Input": {"level": "ERROR"}
+    Runner: {"level": "INFO"}
 metrics:
   enabled: true
   port: 8001

--- a/examples/exampledata/config/benchmark_non_ng_pipeline.yml
+++ b/examples/exampledata/config/benchmark_non_ng_pipeline.yml
@@ -10,6 +10,7 @@ logger:
   datefmt: "%Y-%m-%d %H:%M:%S"
   loggers:
     Runner: {"level": "INFO"}
+    py.warnings: {"level": "ERROR"}
 metrics:
   enabled: true
   port: 8001

--- a/examples/exampledata/config/ng_pipeline.yml
+++ b/examples/exampledata/config/ng_pipeline.yml
@@ -5,22 +5,31 @@ restart_count: 2
 config_refresh_interval: 300
 error_backlog_size: 1500000
 logger:
-  level: DEBUG
+  level: WARNING
   format: "%(asctime)-15s %(hostname)-5s %(name)-10s %(levelname)-8s: %(message)s"
   datefmt: "%Y-%m-%d %H:%M:%S"
   loggers:
-    "py.warnings": {"level": "ERROR"}
-    "Runner": {"level": "DEBUG"}
-    "Processor": {"level": "ERROR"}
-    "Exporter": {"level": "ERROR"}
-    "uvicorn": {"level": "ERROR"}
-    "uvicorn.access": {"level": "ERROR"}
-    "OpenSearchOutput": {"level": "ERROR"}
-    "KafkaOutput": {"level": "ERROR"}
-    "Input": {"level": "ERROR"}
-    "Worker": {"level": "ERROR"}
-    "async_helpers": {"level": "ERROR"}
-    "KafkaOffsetTracker": {"level": "ERROR"}
+    "Config": {"level": "WARNING"}
+    "Credentials": {"level": "WARNING"}
+    "Compoonent": {"level": "WARNING"}
+    "Input": {"level": "WARNING"}
+    "Output": {"level": "WARNING"}
+    "Processor": {"level": "WARNING"}
+    "Rule": {"level": "WARNING"}
+    "Runner": {"level": "WARNING"}
+    "Exporter": {"level": "WARNING"}
+    "uvicorn": {"level": "WARNING"}
+    "uvicorn.access": {"level": "WARNING"}
+    "OpenSearchOutput": {"level": "WARNING"}
+    "KafkaOutput": {"level": "WARNING"}
+    "Worker": {"level": "WARNING"}
+    "PipelineManager": {"level": "DEBUG"}
+    "async_helpers": {"level": "WARNING"}
+    "config_refresh": {"level": "WARNING"}
+    "Queue": {"level": "WARNING"}
+    "KafkaOffsetTracker": {"level": "WARNING"}
+    "Getter": {"level": "WARNING"}
+    "RefreshableGetter": {"level": "WARNING"}
 metrics:
   enabled: true
   port: 8001

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -13,13 +13,6 @@ from logprep.util.environ import ENV_VARS, EnvTemplate
 logger = logging.getLogger("Getter")
 yaml = YAML(typ="safe", pure=True)
 
-BLOCKLIST_VARIABLE_NAMES = [
-    "",
-    " ",
-    "LOGPREP_LIST",  # used by list_comparison processor
-]
-
-VALID_PREFIXES = ["LOGPREP_", "CI_", "GITHUB_", "PYTEST_"]
 
 ContentType: TypeAlias = str
 
@@ -142,7 +135,7 @@ class Getter(ABC):
         """Gets dict and fails otherwise"""
         result = self.get_collection()
         if not isinstance(result, dict):
-            raise ValueError("Value is not a dictionary")
+            raise ValueError(f"Expected a dict, got {type(result)}")
         return result
 
     @staticmethod
@@ -159,7 +152,7 @@ class Getter(ABC):
             content = content[content_field]
         elif content_field is not None:
             raise ValueError(
-                f"Expected mapping type when content_field is set, got {type(content)}."
+                f"Expected mapping type when content_field is set, got {type(content)}"
             )
 
         if isinstance(content, str):

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -1,16 +1,15 @@
 """Module for getter interface"""
 
+import itertools
 import json
 import logging
-import os
-import re
 from abc import ABC, abstractmethod
-from copy import deepcopy
-from string import Template
-from typing import TypeAlias
+from typing import Iterable, TypeAlias
 
 from attrs import define, field, validators
 from ruamel.yaml import YAML, YAMLError
+
+from logprep.util.environ import ENV_VARS, EnvTemplate
 
 logger = logging.getLogger("Getter")
 yaml = YAML(typ="safe", pure=True)
@@ -30,37 +29,24 @@ ContentType: TypeAlias = str
 class Getter(ABC):
     """Abstract base class describing the getter interface and providing of a factory method."""
 
-    class EnvTemplate(Template):
-        """Template class for uppercase only template variables"""
-
-        pattern = r"""
-            \$(?:
-                (?P<escaped>\$\$\$)|
-                (?P<named>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)|
-                {(?P<braced>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)}|
-                (?P<invalid>)
-            )
-        """  # type: ignore[assignment]
-
-        flags = re.VERBOSE
-
     protocol: str = field(validator=validators.instance_of(str))
     """Indicates the protocol for the factory to chose a matching getter."""
     target: str = field(validator=validators.instance_of(str))
     """The target which holds the content to return by get method."""
 
-    missing_env_vars: list = field(
+    missing_env_vars: Iterable[str] = field(
         validator=[
-            validators.instance_of(list),
+            validators.instance_of((list, set)),
             validators.deep_iterable(member_validator=validators.instance_of(str)),
         ],
-        factory=list,
+        factory=set,
         repr=False,
     )
     """used variables in content but not set in environment"""
 
     @property
     def uri(self) -> str:
+        """Full-length URI of the getter target, including the protocol"""
         return f"{self.protocol}://{self.target}"
 
     def get(self) -> str:
@@ -70,30 +56,28 @@ class Getter(ABC):
 
     def _resolve_content(self, raw_content: bytes) -> str:
         content = raw_content.decode("utf8")
-        template = self.EnvTemplate(content)
-        kwargs = self._get_kwargs(template, content)
-        return template.safe_substitute(**kwargs)
+        template = EnvTemplate(content)
+        resolved_content = template.safe_substitute(self._get_kwargs(template, content))
+        logger.debug("resolved environment placeholders in content: %s", resolved_content)
+        return resolved_content
 
-    def _get_kwargs(self, template, content):
-        used_env_vars = list(self._get_used_env_vars(content, template))
-        self.missing_env_vars = [env_var for env_var in used_env_vars if env_var not in os.environ]
-        defaults_for_missing = {missing_key: "" for missing_key in self.missing_env_vars}
-        kwargs = deepcopy(os.environ)
-        kwargs |= defaults_for_missing
-        return kwargs
+    def _get_kwargs(self, template: EnvTemplate, content: str):
+        used_env_vars = self._get_used_env_vars(template, content)
+        self.missing_env_vars = used_env_vars.difference(ENV_VARS.keys())
+        return ENV_VARS | {missing_key: "" for missing_key in self.missing_env_vars}
 
-    def _get_used_env_vars(self, content, template):
-        found_variables = template.pattern.findall(
-            content
-        )  # returns a list of tuples in form (escaped, named, braced, invalid)
+    def _get_used_env_vars(self, template: EnvTemplate, content: str) -> set[str]:
+        # returns a list of tuples in form (escaped, named, braced, invalid)
+        found_variables = template.compiled_pattern.findall(content)
         used_named_env_vars = map(lambda x: x[1], found_variables)
         used_braced_env_vars = map(lambda x: x[2], found_variables)
-        return (item for item in {*used_named_env_vars, *used_braced_env_vars} if item)
+        return {item for item in itertools.chain(used_named_env_vars, used_braced_env_vars) if item}
 
     def _resolve_content_by_content_type(self) -> dict | list | str:
         """Get content with enriched environment variables parsed based on content type."""
 
         raw, content_type = self._get_raw()
+        # TODO make resolving env variables optional, especially for user-defiend pure data payloads
         content = self._resolve_content(raw)
 
         match content_type:
@@ -113,7 +97,11 @@ class Getter(ABC):
 
         Note: if parsed_yaml is empty, an empty dict will be returned."""
 
-        parsed_yaml = list(yaml.load_all(content))
+        try:
+            parsed_yaml = list(yaml.load_all(content))
+        except YAMLError:
+            logger.warning("getter failed to deserialize yaml: %s", content, exc_info=True)
+            raise
         if not parsed_yaml:
             return {}
         if len(parsed_yaml) > 1:
@@ -129,7 +117,11 @@ class Getter(ABC):
     @staticmethod
     def _parse_json(content: str) -> dict | list:
         """Parse content to json"""
-        return json.loads(content)
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("getter failed to deserialize json: %s", content, exc_info=True)
+            raise
 
     def get_json(self) -> dict | list:
         """Gets and parses the raw content as json"""
@@ -151,6 +143,7 @@ class Getter(ABC):
         try:
             return self._parse_yaml(content)
         except YAMLError:
+            logger.debug("parsing yaml failed, falling back to json for content: %s", content)
             return self._parse_json(content)
 
     def get_dict(self) -> dict:
@@ -174,8 +167,7 @@ class Getter(ABC):
             content = content[content_field]
         elif content_field is not None:
             raise ValueError(
-                "Expected mapping type, like json object when content_field is set, got %s.",
-                type(content),
+                f"Expected mapping type when content_field is set, got {type(content)}."
             )
 
         if isinstance(content, str):

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -1,6 +1,5 @@
 """Module for getter interface"""
 
-import itertools
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -57,21 +56,14 @@ class Getter(ABC):
     def _resolve_content(self, raw_content: bytes) -> str:
         content = raw_content.decode("utf8")
         template = EnvTemplate(content)
-        resolved_content = template.safe_substitute(self._get_kwargs(template, content))
+        resolved_content = template.safe_substitute(self._get_kwargs(template))
         logger.debug("resolved environment placeholders in content: %s", resolved_content)
         return resolved_content
 
-    def _get_kwargs(self, template: EnvTemplate, content: str):
-        used_env_vars = self._get_used_env_vars(template, content)
+    def _get_kwargs(self, template: EnvTemplate) -> dict[str, str]:
+        used_env_vars = set(template.get_identifiers())
         self.missing_env_vars = used_env_vars.difference(ENV_VARS.keys())
         return ENV_VARS | {missing_key: "" for missing_key in self.missing_env_vars}
-
-    def _get_used_env_vars(self, template: EnvTemplate, content: str) -> set[str]:
-        # returns a list of tuples in form (escaped, named, braced, invalid)
-        found_variables = template.compiled_pattern.findall(content)
-        used_named_env_vars = map(lambda x: x[1], found_variables)
-        used_braced_env_vars = map(lambda x: x[2], found_variables)
-        return {item for item in itertools.chain(used_named_env_vars, used_braced_env_vars) if item}
 
     def _resolve_content_by_content_type(self) -> dict | list | str:
         """Get content with enriched environment variables parsed based on content type."""
@@ -100,7 +92,7 @@ class Getter(ABC):
         try:
             parsed_yaml = list(yaml.load_all(content))
         except YAMLError:
-            logger.warning("getter failed to deserialize yaml: %s", content, exc_info=True)
+            logger.debug("getter failed to deserialize yaml: %s", content, exc_info=True)
             raise
         if not parsed_yaml:
             return {}
@@ -120,7 +112,7 @@ class Getter(ABC):
         try:
             return json.loads(content)
         except json.JSONDecodeError:
-            logger.warning("getter failed to deserialize json: %s", content, exc_info=True)
+            logger.debug("getter failed to deserialize json: %s", content, exc_info=True)
             raise
 
     def get_json(self) -> dict | list:

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -62,7 +62,7 @@ class Getter(ABC):
         """Get content with enriched environment variables parsed based on content type."""
 
         raw, content_type = self._get_raw()
-        # TODO make resolving env variables optional, especially for user-defiend pure data payloads
+        # TODO make resolving env variables optional, especially for user-defined pure data payloads
         content = self._resolve_content(raw)
 
         match content_type:

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -5,7 +5,6 @@ New input endpoint types are created by implementing it.
 import base64
 import hashlib
 import json
-import os
 import typing
 import zlib
 from abc import abstractmethod
@@ -22,6 +21,7 @@ from logprep.abc.exceptions import LogprepException
 from logprep.metrics.metrics import Metric
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.util.converters import convert_from_dict
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import (
     MISSING,
     FieldValue,
@@ -257,8 +257,7 @@ class Input(Connector):
     def _add_env_enrichment_to_event(self, event: dict, enrichments: dict) -> None:
         """Add the env enrichment information to the event"""
         fields = {
-            target: os.environ.get(variable_name, "")
-            for target, variable_name in enrichments.items()
+            target: ENV_VARS.get(variable_name, "") for target, variable_name in enrichments.items()
         }
         add_fields_to(event, fields)
 

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -1,7 +1,6 @@
 """Abstract module for processors"""
 
 import logging
-import os
 import typing
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
@@ -17,6 +16,7 @@ from logprep.processor.base.exceptions import (
     ProcessingError,
     ProcessingWarning,
 )
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import (
     FieldValue,
     add_and_overwrite,
@@ -126,7 +126,7 @@ class Processor(Component):
         self.load_rules(rules_targets=self.config.rules)
         self._result = None
         self._bypass_rule_tree = False
-        if os.environ.get("LOGPREP_BYPASS_RULE_TREE"):
+        if ENV_VARS.get("LOGPREP_BYPASS_RULE_TREE"):
             self._bypass_rule_tree = True
             logger.debug("Bypassing rule tree for processor %s", self.name)
 

--- a/logprep/metrics/exporter.py
+++ b/logprep/metrics/exporter.py
@@ -10,6 +10,7 @@ from prometheus_client import REGISTRY, make_asgi_app, multiprocess
 from logprep.util import http
 from logprep.util.configuration import MetricsConfig
 from logprep.util.defaults import DEFAULT_HEALTH_STATE
+from logprep.util.environ import ENV_VARS
 
 logger = getLogger("Exporter")
 
@@ -66,7 +67,7 @@ class PrometheusExporter:
 
     def cleanup_prometheus_multiprocess_dir(self):
         """removes the prometheus multiprocessing directory"""
-        multiprocess_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        multiprocess_dir = ENV_VARS.get("PROMETHEUS_MULTIPROC_DIR")
         if not multiprocess_dir:
             return
         for root, dirs, files in os.walk(multiprocess_dir):

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -116,7 +116,6 @@ Processor Specific Metrics
 """
 
 import functools
-import os
 import time
 import typing
 from abc import ABC, abstractmethod
@@ -127,6 +126,7 @@ from attrs import define, field, validators
 from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram
 from prometheus_client.metrics import MetricWrapperBase
 
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import _add_field_to_silent_fail
 
 
@@ -159,7 +159,7 @@ class Metric(ABC):
         # In that mode it is not allowed to set a Registry specifically.
         # For the non multiprocessing mode, we need to set a Registry otherwise our custom metrics never get
         # registered and then subsequently cannot be exported
-        if os.environ.get("PROMETHEUS_MULTIPROC_DIR", "") != "":
+        if ENV_VARS.get("PROMETHEUS_MULTIPROC_DIR", "") != "":
             self._registry = None
         else:
             self._registry = REGISTRY
@@ -211,7 +211,7 @@ class Metric(ABC):
     def measure_time(metric_name: str = "processing_time_per_event", self_arg: int = 0):
         """Decorate function to measure execution time for function and add results to event."""
 
-        if not os.environ.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
+        if not ENV_VARS.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
 
             def without_append(func):
                 @functools.wraps(func)
@@ -265,7 +265,7 @@ class Metric(ABC):
     def measure_time_async(metric_name: str = "processing_time_per_event", self_arg: int = 0):
         """Decorate function to measure execution time for function and add results to event."""
 
-        if not os.environ.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
+        if not ENV_VARS.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
 
             def without_append(func):
                 @functools.wraps(func)

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -1,7 +1,6 @@
 """Abstract module for processors"""
 
 import logging
-import os
 import typing
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
@@ -14,6 +13,7 @@ from logprep.metrics.metrics import Metric
 from logprep.ng.abc.component import NgComponent as Component
 from logprep.ng.abc.event import LogEvent
 from logprep.processor.base.exceptions import ProcessingCriticalError, ProcessingWarning
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import (
     FieldValue,
     add_and_overwrite,
@@ -87,7 +87,7 @@ class Processor(Component):
         self._rule_tree = RuleTree(config=self.config.tree_config)
         self.load_rules(rules_targets=self.config.rules)
         self._bypass_rule_tree = False
-        if os.environ.get("LOGPREP_BYPASS_RULE_TREE"):
+        if ENV_VARS.get("LOGPREP_BYPASS_RULE_TREE"):
             self._bypass_rule_tree = True
             logger.debug("Bypassing rule tree for processor %s", self.name)
 

--- a/logprep/ng/util/configuration.py
+++ b/logprep/ng/util/configuration.py
@@ -192,7 +192,6 @@ The following config file will be valid by setting the given environment variabl
 
 import json
 import logging
-import os
 import typing
 from copy import deepcopy
 from importlib.metadata import version
@@ -223,6 +222,7 @@ from logprep.ng.util.defaults import (
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.util import http
 from logprep.util.credentials import CredentialsEnvNotFoundError, CredentialsFactory
+from logprep.util.environ import ENV_VARS, del_env_var, set_env_var
 from logprep.util.getter import (
     FileGetter,
     GetterFactory,
@@ -442,7 +442,7 @@ class LoggerConfig:
         """
 
         log_config = asdict(self)
-        os.environ["LOGPREP_LOG_CONFIG"] = json.dumps(log_config)
+        set_env_var("LOGPREP_LOG_CONFIG", json.dumps(log_config))
         logging.config.dictConfig(log_config)
 
     def _set_loggers_levels(self) -> None:
@@ -1062,9 +1062,9 @@ class Configuration:
                 self._verify_processor_outputs(processor_config)
             except Exception as error:  # pylint: disable=broad-except
                 errors.append(error)
-        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in os.environ:
+        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in ENV_VARS:
             try:
-                credentials_file_path = os.environ.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
+                credentials_file_path = ENV_VARS.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
                 if credentials_file_path is None:
                     raise ValueError("credentials file path was None but expected it to be set")
                 _ = CredentialsFactory.get_content(Path(credentials_file_path))
@@ -1093,8 +1093,8 @@ class Configuration:
         missing_env_vars = tuple(chain(*[getter.missing_env_vars for getter in getters]))
         if missing_env_vars:
             raise MissingEnvironmentError(", ".join(missing_env_vars))
-        if "PROMETHEUS_MULTIPROC_DIR" in os.environ and self.metrics.enabled:
-            os.environ.pop("PROMETHEUS_MULTIPROC_DIR", None)
+        if "PROMETHEUS_MULTIPROC_DIR" in ENV_VARS and self.metrics.enabled:
+            del_env_var("PROMETHEUS_MULTIPROC_DIR")
             logger.warning(
                 "PROMETHEUS_MULTIPROC_DIR was set, even though it should be unset for ng"
             )

--- a/logprep/ng/util/preprocessor.py
+++ b/logprep/ng/util/preprocessor.py
@@ -32,7 +32,6 @@ Configuration properties shared between input types.
 import base64
 import hashlib
 import json
-import os
 import zlib
 from functools import cached_property
 from hmac import HMAC
@@ -44,6 +43,7 @@ from msgspec import DecodeError
 
 from logprep.ng.abc.event import LogEvent
 from logprep.processor.base.exceptions import FieldExistsWarning
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import (
     MISSING,
     FieldValue,
@@ -176,8 +176,7 @@ class Preprocessor:
     def _add_env_enrichment_to_event(self, event: dict, enrichments: dict) -> None:
         """Add the env enrichment information to the event"""
         fields = {
-            target: os.environ.get(variable_name, "")
-            for target, variable_name in enrichments.items()
+            target: ENV_VARS.get(variable_name, "") for target, variable_name in enrichments.items()
         }
         add_fields_to(event, fields)
 

--- a/logprep/processor/list_comparison/rule.py
+++ b/logprep/processor/list_comparison/rule.py
@@ -49,6 +49,7 @@ from attrs import define, field, validators
 from logprep.factory_error import InvalidConfigurationError
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.util.environ import ENV_VARS
 from logprep.util.getter import (
     GetterFactory,
     HttpGetter,
@@ -198,8 +199,8 @@ class ListComparisonRule(FieldManagerRule):
             resolved_templates = tuple(
                 DottedTemplate(
                     DottedTemplate(
-                        base_template.safe_substitute({**os.environ, "LOGPREP_LIST": list_path})
-                    ).safe_substitute(os.environ)
+                        base_template.safe_substitute({**ENV_VARS, "LOGPREP_LIST": list_path})
+                    ).safe_substitute(ENV_VARS)
                 )
                 for list_path in self._config.list_file_paths
             )

--- a/logprep/run_logprep.py
+++ b/logprep/run_logprep.py
@@ -3,7 +3,6 @@
 
 import logging
 import logging.config
-import os
 import signal
 import sys
 import warnings
@@ -18,6 +17,7 @@ from logprep.util.auto_rule_tester.auto_rule_tester import AutoRuleTester
 from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.context_managers import disable_loggers, logqueue_listener
 from logprep.util.defaults import DEFAULT_LOG_CONFIG, EXITCODES
+from logprep.util.environ import ENV_VARS
 from logprep.util.helper import get_versions_string
 from logprep.util.pseudo.commands import depseudonymize, generate_keys, pseudonymize
 from logprep.util.rule_dry_runner import DryRunner
@@ -95,7 +95,7 @@ def run(configs: tuple[str], version=None) -> None:
         sys.exit(error.code)
     # pylint: disable=broad-except
     except Exception as error:
-        if os.environ.get("DEBUG", False):
+        if ENV_VARS.get("DEBUG", False):
             logger.exception(f"A critical error occurred: {error}")  # pragma: no cover
         else:
             logger.critical(f"A critical error occurred: {error}")

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -1,9 +1,8 @@
 """Module for caching items and checking if they need to be stored (again)."""
 
-from typing import Union
-
 import datetime
 from collections import OrderedDict
+from typing import Union
 
 
 class Cache(OrderedDict):

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -2,7 +2,6 @@
 
 import datetime
 from collections import OrderedDict
-from typing import Union
 
 
 class Cache(OrderedDict):
@@ -15,7 +14,7 @@ class Cache(OrderedDict):
         self._max_timedelta = max_timedelta
         super().__init__()
 
-    def requires_storing(self, item: Union[int, str]) -> bool:
+    def requires_storing(self, item: int | str) -> bool:
         """Check if the item was stored within the last timedelta.
 
         Parameters

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -192,7 +192,6 @@ The following config file will be valid by setting the given environment variabl
 
 import json
 import logging
-import os
 import typing
 from copy import deepcopy
 from importlib.metadata import version
@@ -226,6 +225,7 @@ from logprep.util.defaults import (
     ENV_NAME_LOGPREP_CREDENTIALS_FILE,
     MIN_CONFIG_REFRESH_INTERVAL,
 )
+from logprep.util.environ import ENV_VARS, set_env_var
 from logprep.util.getter import (
     GetterFactory,
     GetterNotFoundError,
@@ -436,7 +436,7 @@ class LoggerConfig:
         make it available for the uvicorn server in :code:'logprep.util.http'.
         """
         log_config = asdict(self)
-        os.environ["LOGPREP_LOG_CONFIG"] = json.dumps(log_config)
+        set_env_var("LOGPREP_LOG_CONFIG", json.dumps(log_config))
         dictConfig(log_config)
 
     def _set_loggers_levels(self) -> None:
@@ -1045,9 +1045,9 @@ class Configuration:
                 self._verify_processor_outputs(processor_config)
             except Exception as error:  # pylint: disable=broad-except
                 errors.append(error)
-        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in os.environ:
+        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in ENV_VARS:
             try:
-                credentials_file_path = os.environ.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
+                credentials_file_path = ENV_VARS.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
                 if credentials_file_path is None:
                     raise ValueError("missing credentials file path")
                 _ = CredentialsFactory.get_content(Path(credentials_file_path))
@@ -1076,8 +1076,8 @@ class Configuration:
         missing_env_vars = tuple(chain(*[getter.missing_env_vars for getter in getters]))
         if missing_env_vars:
             raise MissingEnvironmentError(", ".join(missing_env_vars))
-        if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
-            prometheus_multiproc_path = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+        if "PROMETHEUS_MULTIPROC_DIR" in ENV_VARS:
+            prometheus_multiproc_path = ENV_VARS["PROMETHEUS_MULTIPROC_DIR"]
             if not Path(prometheus_multiproc_path).exists():
                 raise InvalidConfigurationError(
                     (
@@ -1086,7 +1086,7 @@ class Configuration:
                     )
                 )
         if self.metrics.enabled:
-            if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+            if "PROMETHEUS_MULTIPROC_DIR" not in ENV_VARS:
                 raise InvalidConfigurationError(
                     "Metrics enabled but PROMETHEUS_MULTIPROC_DIR is not set"
                 )

--- a/logprep/util/credentials.py
+++ b/logprep/util/credentials.py
@@ -101,7 +101,6 @@ Authentication Process:
 
 import json
 import logging
-import os
 from base64 import b64encode
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -117,6 +116,7 @@ from urllib3 import Retry
 
 from logprep.factory_error import InvalidConfigurationError
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from logprep.util.environ import ENV_VARS
 
 yaml = YAML(typ="safe", pure=True)
 
@@ -152,7 +152,7 @@ class CredentialsFactory:
             Credentials object representing the correct authorization method
 
         """
-        credentials_file_path = os.environ.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
+        credentials_file_path = ENV_VARS.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
         if credentials_file_path is None:
             return None
         credentials_file: CredentialsFileSchema = cls.get_content(Path(credentials_file_path))
@@ -180,7 +180,7 @@ class CredentialsFactory:
             Credentials object representing the correct authorization method
 
         """
-        credentials_file_path = os.environ.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
+        credentials_file_path = ENV_VARS.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE)
         if credentials_file_path is None:
             return None
         credentials_file: CredentialsFileSchema = cls.get_content(Path(credentials_file_path))

--- a/logprep/util/environ.py
+++ b/logprep/util/environ.py
@@ -1,0 +1,43 @@
+"""Utility module for handling environment variables"""
+
+import os
+import re
+from string import Template
+from types import MappingProxyType
+
+_ENV_SNAPSHOT = dict(os.environ)
+
+ENV_VARS = MappingProxyType(_ENV_SNAPSHOT)
+
+
+def del_env_var(name: str):
+    """Remove an env var from :code:`os.environ` and the cached snapshot"""
+    os.environ.pop(name, None)
+    _ENV_SNAPSHOT.pop(name)
+
+
+def set_env_var(name: str, value: str):
+    """Set an env var in :code:`os.environ` and in the cache"""
+    os.environ[name] = value
+    _ENV_SNAPSHOT[name] = value
+
+
+class EnvTemplate(Template):
+    """Template class for uppercase only template variables"""
+
+    pattern = r"""
+        \$(?:
+            (?P<escaped>\$\$\$)|
+            (?P<named>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)|
+            {(?P<braced>(?!LOGPREP_LIST)(?=LOGPREP_|CI_|GITHUB_|PYTEST_)[_A-Z0-9]*)}|
+            (?P<invalid>)
+        )
+    """  # type: ignore[assignment]
+
+    flags = re.VERBOSE
+
+    @property
+    def compiled_pattern(self) -> re.Pattern[str]:
+        """Return the compiled internal pattern used to identify vars"""
+        # Template sets `pattern = re.compile(pattern)` internally
+        return self.pattern  # type: ignore

--- a/logprep/util/environ.py
+++ b/logprep/util/environ.py
@@ -23,7 +23,14 @@ def set_env_var(name: str, value: str):
 
 
 class EnvTemplate(Template):
-    """Template class for uppercase only template variables"""
+    """
+    Template class for substituting environment variables in the forms
+    `${LOGPREP_VAR}` and `$LOGPREP_VAR`.
+    Functionality is restricted to uppercase variables which are prefixed with:
+    `LOGPREP_`, `CI_`, `GITHUB_` or `PYTEST_`.
+    The variable `LOGPREP_LIST` is specifically excluded as it is being used dynamically
+    in processors.
+    """
 
     pattern = r"""
         \$(?:
@@ -35,9 +42,3 @@ class EnvTemplate(Template):
     """  # type: ignore[assignment]
 
     flags = re.VERBOSE
-
-    @property
-    def compiled_pattern(self) -> re.Pattern[str]:
-        """Return the compiled internal pattern used to identify vars"""
-        # Template sets `pattern = re.compile(pattern)` internally
-        return self.pattern  # type: ignore

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -2,15 +2,12 @@
 They are returned by the GetterFactory.
 """
 
-import datetime
 import logging
-import os
 import re
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from functools import cached_property
-from gc import callbacks
 from importlib.metadata import version
 from pathlib import Path
 from string import Template
@@ -33,6 +30,11 @@ from logprep.util.defaults import (
     ENV_NAME_LOGPREP_CREDENTIALS_FILE,
     ENV_NAME_LOGPREP_GETTER_CONFIG,
 )
+from logprep.util.environ import ENV_VARS
+
+logger = logging.getLogger("Getter")
+
+rg_logger = logging.getLogger("RefreshableGetter")
 
 
 class GetterNotFoundError(LogprepException):
@@ -70,7 +72,7 @@ class GetterFactory:
             The generated getter.
         """
         protocol, target = cls._dissect(getter_string)
-        target = cls._expand_variables(target, os.environ)
+        target = cls._expand_variables(target, ENV_VARS)
         # get credentials
         if protocol is None:
             protocol = "file"
@@ -99,6 +101,9 @@ class GetterFactory:
 class DataSharedPerTarget:
     """Contains data that is shared for getters with the same target"""
 
+    target: str
+    """The target for which this objects caches data"""
+
     cache: bytes | None = None
     """Value of the resource when it was last obtained"""
 
@@ -112,7 +117,7 @@ class DataSharedPerTarget:
     """Interval after which getters attempt to obtain the resource again"""
 
     timeout_interval: int | None = None
-    """Timeout interval after which no more refresh attempts should be made, and resources should be cleaned up"""
+    """Amount of time after the last access, after which the cache will be invalidated"""
 
     default_return_value: bytes | None = None
     """Default value to be returned if defined in the configuration"""
@@ -134,20 +139,27 @@ class DataSharedPerTarget:
 
     @property
     def timed_out(self) -> bool:
+        """
+        Whether the cached object has timed out,
+        meaning :code:`timeout_interval` has passed since the last access
+        """
         if self.timeout_interval is None:
             return False
         if self.last_called is None:
             return False
         return time.monotonic() - self.last_called > self.timeout_interval
 
+    def keep_alive(self) -> None:
+        """Signal a data access, rendering :code:`timeout_interval` to reset for this target"""
+        rg_logger.debug("target signaled as still in use: %s", self.target)
+        self.last_called = time.monotonic()
+
 
 @define(kw_only=True)
 class RefreshableGetter(Getter, ABC):
     """Interface for getters that refresh their value periodically"""
 
-    _logger = logging.getLogger("RefreshableGetter")
-
-    _shared: ClassVar[dict[str, DataSharedPerTarget]] = {}
+    _target_to_data_caches: ClassVar[dict[str, DataSharedPerTarget]] = {}
     """Dictionary to store DataSharedPerTarget objects per getter target"""
 
     def _init_scheduler(self):
@@ -163,14 +175,14 @@ class RefreshableGetter(Getter, ABC):
     @property
     def shared(self) -> DataSharedPerTarget:
         """Returns the shared data for current target"""
-        if self.target not in self._shared:
-            self.shared = DataSharedPerTarget()
-        return self._shared[self.target]
+        if self.target not in self._target_to_data_caches:
+            self.shared = DataSharedPerTarget(target=self.target)
+        return self._target_to_data_caches[self.target]
 
     @shared.setter
     def shared(self, value: DataSharedPerTarget) -> None:
         """Set shared data for current target"""
-        self._shared[self.target] = value
+        self._target_to_data_caches[self.target] = value
 
     @property
     def scheduler(self) -> Scheduler | None:
@@ -340,7 +352,7 @@ class RefreshableGetter(Getter, ABC):
         This is a no-op if the target has no shared getter state. ``deduplication_key``
         prevents duplicate callback registration without affecting tag-based removal.
         """
-        shared = cls._shared.get(target)
+        shared = cls._target_to_data_caches.get(target)
         if shared is None:
             return
 
@@ -379,10 +391,10 @@ class RefreshableGetter(Getter, ABC):
         )
 
     def _get_getter_config_entry(self) -> dict:
-        if ENV_NAME_LOGPREP_GETTER_CONFIG not in os.environ:
+        if ENV_NAME_LOGPREP_GETTER_CONFIG not in ENV_VARS:
             return {}
 
-        getter_file_path = os.environ.get(ENV_NAME_LOGPREP_GETTER_CONFIG)
+        getter_file_path = ENV_VARS.get(ENV_NAME_LOGPREP_GETTER_CONFIG)
         if not getter_file_path or getter_file_path == self.target and self.protocol == "file":
             return {}
 
@@ -433,8 +445,10 @@ class RefreshableGetter(Getter, ABC):
             self._log_cache_warning(error)
             was_modified = False
         if not was_modified:
+            rg_logger.debug("target has not been modified, cache is up-to-date: %s", self.target)
             self.shared.refreshing = False
             return
+        rg_logger.debug("target was modified, cache updated and running callbacks: %s", self.target)
         for callback in self._callbacks:
             callback["function"](*callback["args"], **callback["kwargs"])
         self.shared.refreshing = False
@@ -462,7 +476,7 @@ class RefreshableGetter(Getter, ABC):
         self.cache = self._default_return_value
 
     def _log_cache_warning(self, error: Exception):
-        self._logger.warning(
+        rg_logger.warning(
             f"Not updating {type(self).__name__} cache with URI '{self.uri}' due to: %s", error
         )
 
@@ -488,14 +502,17 @@ class RefreshableGetter(Getter, ABC):
         return self.cache, self.content_type
 
     def keep_alive(self):
-        self.shared.last_called = time.monotonic()
+        """Signal a data access, rendering :code:`timeout_interval` to reset for this target"""
+        self.shared.keep_alive()
 
     def timed_out(self) -> bool:
+        """Whether the target has timed out"""
         return self.shared.timed_out
 
     @classmethod
     def timed_out_for_target(cls, target: str) -> bool:
-        target_shared = cls._shared.get(target)
+        """Whether the target has timed out"""
+        target_shared = cls._target_to_data_caches.get(target)
         if target_shared is None:
             return False
 
@@ -503,9 +520,10 @@ class RefreshableGetter(Getter, ABC):
 
     @classmethod
     def remove_callbacks_for_tag(cls, tag: str) -> None:
+        """Removes update and cleanup callbacks for the given tag"""
         empty_targets = []
 
-        for target, shared in cls._shared.items():
+        for target, shared in cls._target_to_data_caches.items():
             shared.callbacks = [
                 callback for callback in shared.callbacks if callback.get("tag") != tag
             ]
@@ -517,28 +535,42 @@ class RefreshableGetter(Getter, ABC):
                 empty_targets.append(target)
 
         for target in empty_targets:
-            cls._shared.pop(target, None)
+            cls._target_to_data_caches.pop(target, None)
 
     @classmethod
     def keep_alive_for_target(cls, target: str):
-        shared = cls._shared.get(target)
+        """Signal a data access, rendering :code:`timeout_interval` to reset for this target"""
+
+        shared = cls._target_to_data_caches.get(target)
         if shared is None:
+            rg_logger.warning("attempted to keep alive an already deleted target: %s", target)
             return
 
-        shared.last_called = time.monotonic()
+        shared.keep_alive()
 
     @classmethod
     def refresh(cls):
         """Run pending refresh schedulers and cleanup timed-out targets."""
-        for target, shared_target_data in list(cls._shared.items()):
+        rg_logger.debug("refreshing all cached getters")
+        for target, shared_target_data in list(cls._target_to_data_caches.items()):
             if cls.timed_out_for_target(target):
-                del cls._shared[target]
+                rg_logger.debug("target has timed out and will be cleaned up: %s", target)
+                del cls._target_to_data_caches[target]
                 for callback in shared_target_data.cleanup_callbacks:
                     callback["function"](*callback["args"], **callback["kwargs"])
                 continue
 
             if shared_target_data.scheduler:
                 shared_target_data.scheduler.run_pending()
+
+    @classmethod
+    def reset(cls, cleanup: bool = False):
+        """Wipe the cache and optionall run cleanup callbacks"""
+        for target, shared_target_data in list(cls._target_to_data_caches.items()):
+            del cls._target_to_data_caches[target]
+            if cleanup:
+                for callback in shared_target_data.cleanup_callbacks:
+                    callback["function"](*callback["args"], **callback["kwargs"])
 
 
 @define(kw_only=True)
@@ -549,7 +581,6 @@ class FileGetter(Getter):
 
     * :code:`/yourpath/yourfile.extension`
     * :code:`file://yourpath/yourfile.extension`
-
     """
 
     def _get_raw(self) -> tuple[bytes, ContentType | None]:
@@ -621,7 +652,7 @@ class HttpGetter(RefreshableGetter):
     def credentials(self) -> Credentials:
         """Get credentials for target from environment variable"""
         creds = None
-        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in os.environ:
+        if ENV_NAME_LOGPREP_CREDENTIALS_FILE in ENV_VARS:
             creds = CredentialsFactory.from_target(self.uri)
         return creds if creds else Credentials()
 
@@ -644,6 +675,9 @@ class HttpGetter(RefreshableGetter):
             resp.raise_for_status()
         except requests.exceptions.HTTPError as error:
             self._handle_http_error(error)
+        logger.debug(
+            "querying %s with etag=%s yielded status=%d", self.uri, self.hash, resp.status_code
+        )
         if "etag" in resp.headers:
             self.hash = resp.headers["etag"]
         return resp
@@ -662,7 +696,7 @@ class HttpGetter(RefreshableGetter):
     def _handle_http_error(error: requests.exceptions.HTTPError):
         if not error.response.status_code == 401:
             raise RefreshableGetterError(str(error)) from error
-        if os.environ.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE):
+        if ENV_VARS.get(ENV_NAME_LOGPREP_CREDENTIALS_FILE):
             raise RefreshableGetterError(str(error)) from error
         raise CredentialsEnvNotFoundError(
             (

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -506,7 +506,7 @@ class RefreshableGetter(Getter, ABC):
         self.shared.keep_alive()
 
     def timed_out(self) -> bool:
-        """Whether the target has timed out"""
+        """Whether this target has timed out"""
         return self.shared.timed_out
 
     @classmethod
@@ -565,7 +565,7 @@ class RefreshableGetter(Getter, ABC):
 
     @classmethod
     def reset(cls, cleanup: bool = False):
-        """Wipe the cache and optionall run cleanup callbacks"""
+        """Wipe the cache and optionally run cleanup callbacks"""
         for target, shared_target_data in list(cls._target_to_data_caches.items()):
             del cls._target_to_data_caches[target]
             if cleanup:

--- a/logprep/util/http.py
+++ b/logprep/util/http.py
@@ -4,13 +4,13 @@ import atexit
 import inspect
 import json
 import logging
-import os
 import threading
 import time
 
 import uvicorn
 
 from logprep.util.defaults import DEFAULT_LOG_CONFIG
+from logprep.util.environ import ENV_VARS
 
 uvicorn_parameter_keys = inspect.signature(uvicorn.Config).parameters.keys()
 UVICORN_CONFIG_KEYS = [
@@ -72,7 +72,7 @@ class ThreadingHTTPServer:  # pylint: disable=too-many-instance-attributes
         self._logger_name = logger_name
         self._logger = logging.getLogger(self._logger_name)
         logprep_log_config = json.loads(
-            os.environ.get("LOGPREP_LOG_CONFIG", json.dumps(DEFAULT_LOG_CONFIG))
+            ENV_VARS.get("LOGPREP_LOG_CONFIG", json.dumps(DEFAULT_LOG_CONFIG))
         )
         self.uvicorn_config = uvicorn.Config(
             **uvicorn_config, app=app, log_config=logprep_log_config

--- a/tests/acceptance/test_config_refresh.py
+++ b/tests/acceptance/test_config_refresh.py
@@ -25,7 +25,7 @@ def get_config():
         "profile_pipelines": False,
         "config_refresh_interval": 5,
         "metrics": {"enabled": False},
-        "logger": {"level": "DEBUG"},
+        "logger": {"level": "INFO"},
         "pipeline": [],
         "input": {
             "file_input": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Global configuration and fixtures for all pytest-based tests"""
 
+import contextlib
 import functools
 from multiprocessing import active_children, set_start_method
 from unittest import mock
@@ -9,6 +10,7 @@ from prometheus_client import REGISTRY
 
 from logprep.registry import Registry
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
+from logprep.util.environ import _ENV_SNAPSHOT
 from logprep.util.getter import RefreshableGetter
 
 
@@ -36,7 +38,7 @@ def clear_prometheus_registry():
 @pytest.fixture(autouse=True)
 def clear_getter_cache():
     """Clear getter cache after each test"""
-    RefreshableGetter._shared.clear()  # pylint: disable=protected-access
+    RefreshableGetter.reset()
 
 
 def pytest_sessionstart(session):  # pylint: disable=unused-argument
@@ -73,3 +75,28 @@ def cleanup_child_processes():
     for child in active_children():
         child.terminate()
         child.join(timeout=2)
+
+
+@contextlib.contextmanager
+def mock_env(env_dict):
+    """
+    Mock helper to update the env snapshot.
+
+    Usage:
+        @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
+        def test_something():
+            ...
+
+        def test_something_else():
+            with mock_env({"PYTEST_TEST_TOKEN": "mytoken"}):
+    """
+
+    original = dict(_ENV_SNAPSHOT)
+    try:
+        _ENV_SNAPSHOT.clear()
+        _ENV_SNAPSHOT.update(env_dict)
+        with mock.patch("os.environ", env_dict):
+            yield _ENV_SNAPSHOT
+    finally:
+        _ENV_SNAPSHOT.clear()
+        _ENV_SNAPSHOT.update(original)

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -4,7 +4,6 @@
 # pylint: disable=unnecessary-dunder-call
 import base64
 import json
-import os
 import re
 import zlib
 from copy import deepcopy
@@ -19,6 +18,7 @@ from logprep.abc.output import Output
 from logprep.factory import Factory
 from logprep.util.helper import get_dotted_field_value
 from logprep.util.time import TimeParser
+from tests.conftest import mock_env
 from tests.unit.component.base import BaseComponentTestCase
 
 
@@ -609,9 +609,9 @@ class BaseInputTestCase(BaseConnectorTestCase):
         connector_config.update(preprocessing_config)
         connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
-        os.environ["TEST_ENV_VARIABLE"] = "test_value"
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
+        with mock_env({"TEST_ENV_VARIABLE": "test_value"}):
+            result = connector.get_next(0.01)
         assert result == {"any": "content", "enriched_field": "test_value"}
 
     def test_preprocessing_enriches_by_multiple_env_variables(self):
@@ -623,14 +623,18 @@ class BaseInputTestCase(BaseConnectorTestCase):
                 },
             }
         }
+        env_vars = {
+            "TEST_ENV_VARIABLE_FOO": "test_value_foo",
+            "TEST_ENV_VARIABLE_BAR": "test_value_bar",
+        }
+
         connector_config = deepcopy(self.CONFIG)
         connector_config.update(preprocessing_config)
         connector = Factory.create({"test connector": connector_config})
         test_event = {"any": "content"}
-        os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
-        os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
         connector._get_event = mock.MagicMock(return_value=(test_event, None))
-        result = connector.get_next(0.01)
+        with mock_env(env_vars):
+            result = connector.get_next(0.01)
         assert result == {
             "any": "content",
             "enriched_field1": "test_value_foo",

--- a/tests/unit/connector/test_file_input_default_config.py
+++ b/tests/unit/connector/test_file_input_default_config.py
@@ -14,6 +14,7 @@ import pytest
 
 from logprep.abc.input import FatalInputError
 from logprep.connector.file.input import FileInput
+from logprep.util.environ import ENV_VARS
 from tests.testdata.input_logdata.file_input_logs import (
     test_initial_log_data,
     test_rotated_log_data,
@@ -211,7 +212,7 @@ class TestFileInput(BaseInputTestCase):
             self.object._config.logfile_path
         ), "After Filechange to smaller file the file offset is smaller afterwards"
 
-    @pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS") == "true", reason="sometimes fails on CI")
+    @pytest.mark.skipif(ENV_VARS.get("GITHUB_ACTIONS") == "true", reason="sometimes fails on CI")
     def test_get_unique_logs_after_rotating_filechange_detected_with_filesize_smaller_256(self):
         """it can occur that a logfile is smaller than 256 bytes after rotation,
         in this case every appending file change would act like the detection of a log rotated file

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -22,6 +22,7 @@ from logprep.factory import Factory
 from logprep.factory_error import InvalidConfigurationError
 from logprep.framework.pipeline_manager import ThrottlingQueue
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from tests.conftest import mock_env
 from tests.unit.connector.base import BaseInputTestCase
 
 
@@ -481,9 +482,9 @@ class TestHttpConnector(BaseInputTestCase):
         assert connector_next_msg == expected_event, "Output event with hmac is not as expected"
 
     def test_endpoint_returns_401_if_authorization_not_provided(self, credentials_file_path):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             new_connector.pipeline_index = 1
             new_connector.setup()
@@ -492,9 +493,9 @@ class TestHttpConnector(BaseInputTestCase):
             assert resp.status_code == 401
 
     def test_endpoint_returns_401_on_wrong_authorization(self, credentials_file_path):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             new_connector.pipeline_index = 1
             new_connector.setup()
@@ -506,9 +507,9 @@ class TestHttpConnector(BaseInputTestCase):
     def test_endpoint_returns_200_on_correct_authorization_with_password_from_file(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             assert isinstance(new_connector, HttpInput)
             new_connector.pipeline_index = 1
@@ -522,9 +523,9 @@ class TestHttpConnector(BaseInputTestCase):
     def test_endpoint_returns_200_on_correct_authorization_with_password_within_credentials_file(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             new_connector.pipeline_index = 1
             new_connector.setup()
@@ -534,9 +535,9 @@ class TestHttpConnector(BaseInputTestCase):
             assert resp.status_code == 200
 
     def test_endpoint_returns_200_on_correct_authorization_for_subpath(self, credentials_file_path):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             new_connector.pipeline_index = 1
             new_connector.setup()
@@ -548,9 +549,9 @@ class TestHttpConnector(BaseInputTestCase):
     def test_endpoint_returns_200_on_correct_authorization_for_subpath_and_both_credentials(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             assert isinstance(new_connector, HttpInput)
             new_connector.pipeline_index = 1
@@ -569,9 +570,9 @@ class TestHttpConnector(BaseInputTestCase):
     def test_endpoint_returns_401_on_wrong_authorization_with_second_credential(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = Factory.create({"test connector": self.CONFIG})
             assert isinstance(new_connector, HttpInput)
             new_connector.pipeline_index = 1

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -24,6 +24,7 @@ from logprep.util.configuration import Configuration, MetricsConfig
 from logprep.util.defaults import DEFAULT_LOG_CONFIG, EXITCODES
 from logprep.util.logging import logqueue
 from logprep.util.queue import Queue
+from tests.conftest import mock_env
 from tests.testdata.metadata import path_to_config
 
 
@@ -126,7 +127,7 @@ class TestPipelineManager:
             assert logprep_instance.was_started and logprep_instance.was_stopped
 
     def test_restart_failed_pipelines_calls_prometheus_cleanup_method(self, tmpdir, config_path):
-        with mock.patch("os.environ", new={"PROMETHEUS_MULTIPROC_DIR": str(tmpdir)}):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": str(tmpdir)}):
             failed_pipeline = mock.MagicMock()
             failed_pipeline.is_alive = mock.MagicMock()
             failed_pipeline.is_alive.return_value = False
@@ -152,7 +153,7 @@ class TestPipelineManager:
         assert self.manager.metrics.number_of_failed_pipelines == 1
 
     def test_stop_calls_prometheus_cleanup_method(self, tmpdir, config_path):
-        with mock.patch("os.environ", new={"PROMETHEUS_MULTIPROC_DIR": str(tmpdir)}):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": tmpdir}):
             config = Configuration.from_sources([str(config_path)])
             config.metrics = {"enabled": True, "port": 1234}
             config.process_count = 2

--- a/tests/unit/metrics/test_exporter.py
+++ b/tests/unit/metrics/test_exporter.py
@@ -12,6 +12,7 @@ from prometheus_client import CollectorRegistry
 from logprep.metrics.exporter import PrometheusExporter, make_patched_asgi_app
 from logprep.util import http
 from logprep.util.configuration import MetricsConfig
+from tests.conftest import mock_env
 
 
 @mock.patch(
@@ -50,7 +51,7 @@ class TestPrometheusExporter:
         test_file.touch()
         assert os.path.isfile(test_file)
         assert os.path.isdir(subdir)
-        with mock.patch("os.environ", {"PROMETHEUS_MULTIPROC_DIR": tmp_path}):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": tmp_path}):
             exporter = PrometheusExporter(self.metrics_config)
             exporter.cleanup_prometheus_multiprocess_dir()
         assert not os.path.isfile(test_file)
@@ -66,7 +67,7 @@ class TestPrometheusExporter:
         test_file.touch()
         assert os.path.isfile(test_file)
         assert os.path.isdir(subdir)
-        with mock.patch("os.environ", {"SOME_OTHER_ENV": tmp_path}):
+        with mock_env({"SOME_OTHER_ENV": tmp_path}):
             exporter = PrometheusExporter(self.metrics_config)
             exporter.cleanup_prometheus_multiprocess_dir()
         assert os.path.isfile(test_file)

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -18,6 +18,7 @@ from prometheus_client import (
 
 from logprep.abc.component import Component
 from logprep.metrics.metrics import CounterMetric, GaugeMetric, HistogramMetric, Metric
+from tests.conftest import mock_env
 
 
 class TestMetric:
@@ -367,7 +368,7 @@ class TestComponentMetrics:
         metrics_output = generate_latest(self.metrics.custom_registry).decode("utf-8")
         assert "test_metric_without_label_values" not in metrics_output
 
-    @mock.patch.dict("os.environ", {"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}, clear=True)
+    @mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"})
     def test_measure_time_measures_and_appends_processing_times_but_not_hostname(self):
         @Metric.measure_time(metric_name="test_metric_histogram")
         def decorated_function_append(self, document):
@@ -392,7 +393,7 @@ class TestComponentMetrics:
         assert "test_rule" in document.get("processing_times")
         assert document.get("processing_times").get("test_rule") > 0
 
-    @mock.patch.dict("os.environ", {"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}, clear=True)
+    @mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"})
     def test_measure_time_measures_and_appends_processing_times_two_times(self):
         # simulates consecutive calls from processors that appear two times in
         # the pipeline, more precise two of the same rule_types appear in the
@@ -423,7 +424,7 @@ class TestComponentMetrics:
         assert document.get("processing_times").get("test_rule") > 0
 
     @mock.patch("logprep.metrics.metrics.gethostname", return_value="testhost")
-    @mock.patch.dict("os.environ", {"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}, clear=True)
+    @mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"})
     def test_measure_time_measures_and_appends_pipeline_processing_times_and_hostname(
         self, mock_gethostname
     ):
@@ -476,8 +477,7 @@ class TestComponentMetrics:
 
     @mock.patch("time.perf_counter", side_effect=[1, 2])
     def test_measure_time_measures_but_does_not_append_to_empty_events(self, mock_perf_counter):
-        mock_env = {"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}):
 
             @Metric.measure_time(metric_name="test_metric_histogram")
             def decorated_function_append(self, document):

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -9,7 +9,6 @@
 
 import base64
 import json
-import os
 import re
 import typing
 import zlib
@@ -26,6 +25,7 @@ from logprep.ng.abc.input import Input
 from logprep.ng.abc.output import Output
 from logprep.util.helper import FieldValue, get_dotted_field_value
 from logprep.util.time import TimeParser
+from tests.conftest import mock_env
 from tests.unit.ng.component.base import BaseComponentTestCase
 
 ConnectorTypeT = typing.TypeVar("ConnectorTypeT", bound=Connector)
@@ -641,14 +641,17 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
                 },
             }
         }
+        env_vars = {
+            "TEST_ENV_VARIABLE_FOO": "test_value_foo",
+            "TEST_ENV_VARIABLE_BAR": "test_value_bar",
+        }
         self.object = self._create_test_instance(config_patch=preprocessing_config)
 
-        os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
-        os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
         self.object._get_event = mock.AsyncMock(
             return_value=self._create_log_event({"any": "content"}, b'{"any":"content"}')
         )
-        result = await self.object.get_next(0.01)
+        with mock_env(env_vars):
+            result = await self.object.get_next(0.01)
         assert result.data == {
             "any": "content",
             "enriched_field1": "test_value_foo",

--- a/tests/unit/ng/connector/test_http_input.py
+++ b/tests/unit/ng/connector/test_http_input.py
@@ -26,6 +26,7 @@ from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.connector.http.input import HttpInput
 from logprep.ng.util.workflow.worker import SizeLimitedQueue
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from tests.conftest import mock_env
 from tests.unit.ng.connector.base import BaseInputTestCase
 
 
@@ -382,9 +383,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
         assert connector_next_msg == expected_event, "Output event with hmac is not as expected"
 
     async def test_endpoint_returns_401_if_authorization_not_provided(self, credentials_file_path):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
             async with testing.ASGIConductor(new_connector.app) as client:
@@ -392,9 +393,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
                 assert resp.status_code == 401
 
     async def test_endpoint_returns_401_on_wrong_authorization(self, credentials_file_path):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
             headers = {"Authorization": _basic_auth_str("wrong", "credentials")}
@@ -405,9 +406,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
     async def test_endpoint_returns_200_on_correct_authorization_with_password_from_file(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
             headers = {"Authorization": _basic_auth_str("user", "file_password")}
@@ -418,9 +419,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
     async def test_endpoint_returns_200_on_correct_authorization_for_subpath_and_both_credentials(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
 
@@ -437,9 +438,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
     async def test_endpoint_returns_401_on_wrong_authorization_with_second_credential(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
 
@@ -451,9 +452,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
     async def test_endpoint_returns_200_on_correct_authorization_with_password_within_credentials_file(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
             headers = {"Authorization": _basic_auth_str("user", "secret_password")}
@@ -464,9 +465,9 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
     async def test_endpoint_returns_200_on_correct_authorization_for_subpath(
         self, credentials_file_path
     ):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
+        env_vars = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: credentials_file_path}
         data = {"message": "my log message"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env(env_vars):
             new_connector = self._create_test_instance()
             await new_connector.setup()
             headers = {"Authorization": _basic_auth_str("user", "password")}

--- a/tests/unit/ng/connector/test_json_input.py
+++ b/tests/unit/ng/connector/test_json_input.py
@@ -8,7 +8,6 @@
 
 import base64
 import json
-import os
 import re
 import zlib
 from copy import deepcopy
@@ -21,6 +20,7 @@ from logprep.factory import Factory
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.abc.input import CriticalInputError
 from logprep.util.time import TimeParser
+from tests.conftest import mock_env
 from tests.unit.ng.connector.base import BaseInputTestCase
 
 
@@ -821,16 +821,19 @@ class TestJsonInput(BaseInputTestCase):
                     },
                 }
             }
+            env_vars = {
+                "TEST_ENV_VARIABLE_FOO": "test_value_foo",
+                "TEST_ENV_VARIABLE_BAR": "test_value_bar",
+            }
             connector_config = deepcopy(self.CONFIG)
             connector_config.update(preprocessing_config)
             connector = Factory.create({"test connector": connector_config})
             connector._wait_for_health = mock.MagicMock()
             connector.pipeline_index = 1
             connector.setup()
-            os.environ["TEST_ENV_VARIABLE_FOO"] = "test_value_foo"
-            os.environ["TEST_ENV_VARIABLE_BAR"] = "test_value_bar"
             connector._get_event = mock.MagicMock(return_value=return_value)
-            result = connector.get_next(0.01)
+            with mock_env(env_vars):
+                result = connector.get_next(0.01)
             assert result.data == {
                 "any": "content",
                 "enriched_field1": "test_value_foo",

--- a/tests/unit/ng/processor/base.py
+++ b/tests/unit/ng/processor/base.py
@@ -26,7 +26,7 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.base.rule import Rule
 from logprep.util.defaults import RULE_FILE_EXTENSIONS
-from logprep.util.getter import HttpGetter, RefreshableGetterError
+from logprep.util.getter import RefreshableGetter, RefreshableGetterError
 from tests.unit.ng.component.base import BaseComponentTestCase
 
 yaml = YAML(typ="safe", pure=True)
@@ -248,7 +248,7 @@ class BaseProcessorTestCase(BaseComponentTestCase[ProcessorTypeT], typing.Generi
         config = deepcopy(self.CONFIG)
         config.update({"tree_config": "http://does.not.matter.bla/tree_config.yml"})
         responses.add(responses.GET, "http://does.not.matter.bla/tree_config.yml", status=404)
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
         with pytest.raises(RefreshableGetterError, match="404"):
             Factory.create({"test instance": config})
 

--- a/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
@@ -5,7 +5,6 @@
 import json
 from collections import OrderedDict
 from copy import deepcopy
-from unittest.mock import patch
 
 import pytest
 import responses
@@ -15,7 +14,8 @@ from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.generic_resolver.processor import GenericResolver
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter
+from logprep.util.getter import HttpGetter, RefreshableGetter
+from tests.conftest import mock_env
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 resolve_value_variants = [
@@ -689,13 +689,12 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         responses.add(responses.GET, url, json={"ab": {"new1": "1"}})
         responses.add(responses.GET, url, json={"ab": {"new1": "1", "new2": "2"}})
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             await self._load_rule(rule)
 

--- a/tests/unit/ng/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/ng/processor/list_comparison/test_list_comparison.py
@@ -15,7 +15,13 @@ from logprep.ng.abc.processor import Processor
 from logprep.ng.processor.list_comparison.processor import ListComparison
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter, RefreshableGetterError, refresh_getters
+from logprep.util.getter import (
+    HttpGetter,
+    RefreshableGetter,
+    RefreshableGetterError,
+    refresh_getters,
+)
+from tests.conftest import mock_env
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 
@@ -362,13 +368,12 @@ Heinz
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = typing.cast(Processor, Factory.create({"custom_lister": config}))
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -409,7 +414,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -462,9 +467,9 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
-        with mock.patch.dict("os.environ", environment):
+        with mock_env(environment):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -502,9 +507,9 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
-        with mock.patch.dict("os.environ", {"LIST_TENANT": "acme"}):
+        with mock_env({"LIST_TENANT": "acme"}):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -538,7 +543,7 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -612,7 +617,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -652,7 +657,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenants.0:2}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -695,7 +700,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -704,10 +709,10 @@ Heinz
 
         with mock.patch("logprep.util.getter.time.monotonic", side_effect=[100.0, 125.0]):
             await processor.process(first_log_event)
-            assert HttpGetter._shared[url].last_called == 100.0
+            assert HttpGetter._target_to_data_caches[url].last_called == 100.0
 
             await processor.process(second_log_event)
-            assert HttpGetter._shared[url].last_called == 125.0
+            assert HttpGetter._target_to_data_caches[url].last_called == 125.0
 
         assert len(responses.calls) == 1
         assert first_document["user_results"] == {"in_list": [url]}
@@ -747,7 +752,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -794,7 +799,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -830,7 +835,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenant}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -872,7 +877,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenant}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -927,7 +932,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -941,8 +946,8 @@ Heinz
         assert isinstance(result.warnings[0], ProcessingWarning)
         assert rule.data_error is None
         assert failed_url not in rule.compare_sets
-        assert len(HttpGetter._shared[failed_url].callbacks) == 0
-        assert len(HttpGetter._shared[failed_url].cleanup_callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
 
         await processor.process(successful_log_event)
 
@@ -1051,7 +1056,7 @@ Heinz
             "list_search_base_path": str(file_root_path),
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(Processor, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1097,7 +1102,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         captured_sessions = []
         original_get_requests_session = HttpGetter._get_requests_session
@@ -1178,7 +1183,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(Processor, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1208,7 +1213,7 @@ Heinz
             "user_results": {"in_list": [url]},
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(Processor, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1260,13 +1265,12 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 1}}
         http_getter_conf = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = typing.cast(Processor, Factory.create({"custom_lister": config}))
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)

--- a/tests/unit/ng/processor/network_comparison/test_network_comparison.py
+++ b/tests/unit/ng/processor/network_comparison/test_network_comparison.py
@@ -3,7 +3,6 @@
 import json
 import typing
 from ipaddress import IPv4Network
-from unittest import mock
 
 import pytest
 import responses
@@ -13,7 +12,8 @@ from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.network_comparison.processor import NetworkComparison
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter, RefreshableGetterError
+from logprep.util.getter import HttpGetter, RefreshableGetter, RefreshableGetterError
+from tests.conftest import mock_env
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 
@@ -395,13 +395,12 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = typing.cast(NetworkComparison, Factory.create({"custom_lister": config}))
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -532,7 +531,7 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -546,8 +545,8 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
         assert isinstance(result.warnings[0], ProcessingWarning)
         assert rule.data_error is None
         assert failed_url not in rule.compare_sets
-        assert len(HttpGetter._shared[failed_url].callbacks) == 0
-        assert len(HttpGetter._shared[failed_url].cleanup_callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
 
         await processor.process(successful_log_event)
 
@@ -589,7 +588,7 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(NetworkComparison, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -690,7 +689,7 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(NetworkComparison, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -721,7 +720,7 @@ class TestNetworkComparison(BaseProcessorTestCase[NetworkComparison]):
             "ip_results": {"in_list": [url]},
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = typing.cast(NetworkComparison, Factory.create({"custom_lister": config}))
         rule = processor.rule_class.create_from_dict(rule_dict)

--- a/tests/unit/processor/base.py
+++ b/tests/unit/processor/base.py
@@ -24,7 +24,7 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.base.rule import Rule
 from logprep.util.defaults import RULE_FILE_EXTENSIONS
-from logprep.util.getter import HttpGetter, RefreshableGetterError
+from logprep.util.getter import RefreshableGetter, RefreshableGetterError
 from tests.unit.component.base import BaseComponentTestCase
 
 yaml = YAML(typ="safe", pure=True)
@@ -78,6 +78,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
     def _load_rule(self, rule: dict | Rule):
         assert isinstance(self.object, Processor)
         self.object._rule_tree = RuleTree()
+        assert self.object.rule_class, "a rule_class should never be none for concrete processors"
         rule = self.object.rule_class.create_from_dict(rule) if isinstance(rule, dict) else rule
         self.object._rule_tree.add_rule(rule)
 
@@ -238,7 +239,7 @@ class BaseProcessorTestCase(BaseComponentTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"tree_config": "http://does.not.matter.bla/tree_config.yml"})
         responses.add(responses.GET, "http://does.not.matter.bla/tree_config.yml", status=404)
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
         with pytest.raises(RefreshableGetterError, match="404"):
             Factory.create({"test instance": config})
 

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -2,14 +2,14 @@
 # pylint: disable=protected-access
 import json
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import responses
 
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter
+from logprep.util.getter import HttpGetter, RefreshableGetter
+from tests.conftest import mock_env
 
 
 @pytest.fixture(name="rule_definition")
@@ -138,13 +138,12 @@ class TestGenericAdderRule:
         responses.add(responses.GET, url, json=from_http_2)
         responses.add(responses.GET, url, json=from_http_3)
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             rule = GenericAdderRule.create_from_dict(rule_definition)
             assert rule.add == expected_1

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -6,7 +6,6 @@ import json
 from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import responses
@@ -15,7 +14,8 @@ from logprep.factory import Factory
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.processor.generic_resolver.processor import GenericResolver
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter
+from logprep.util.getter import HttpGetter, RefreshableGetter
+from tests.conftest import mock_env
 from tests.unit.processor.base import BaseProcessorTestCase
 
 resolve_value_variants = [
@@ -689,13 +689,12 @@ class TestGenericResolver(BaseProcessorTestCase):
         responses.add(responses.GET, url, json={"ab": {"new1": "1"}})
         responses.add(responses.GET, url, json={"ab": {"new1": "1", "new2": "2"}})
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             self._load_rule(rule)
 

--- a/tests/unit/processor/generic_resolver/test_generic_resolver_rule.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver_rule.py
@@ -4,7 +4,6 @@
 # pylint: disable=wrong-import-order
 import json
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import responses
@@ -14,7 +13,8 @@ from logprep.processor.generic_resolver.rule import (
     GenericResolverRule,
 )
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter
+from logprep.util.getter import HttpGetter, RefreshableGetter
+from tests.conftest import mock_env
 
 
 @pytest.fixture(name="rule_definition")
@@ -281,13 +281,12 @@ class TestGenericResolverRule:
         responses.add(responses.GET, url, json=from_http_2)
         responses.add(responses.GET, url, json=from_http_3)
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             rule = GenericResolverRule.create_from_dict(rule_definition)
             assert rule.additions == from_http_1

--- a/tests/unit/processor/list_comparison/test_list_comparison.py
+++ b/tests/unit/processor/list_comparison/test_list_comparison.py
@@ -2,25 +2,23 @@
 # pylint: disable=protected-access
 import json
 import time
-from ipaddress import IPv4Network
-from multiprocessing import process
 from pathlib import Path
 from string import Template
 from unittest import mock
 
 import pytest
 import responses
-from _pytest import config
 
 from logprep.factory import Factory
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import (
-    GetterFactory,
     HttpGetter,
+    RefreshableGetter,
     RefreshableGetterError,
     refresh_getters,
 )
+from tests.conftest import mock_env
 from tests.unit.processor.base import BaseProcessorTestCase
 
 NOT_SET = object()
@@ -319,7 +317,7 @@ Hans
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -367,7 +365,7 @@ Hans
             "list_search_base_path": "http://localhost:8080/v2/valuestore/test_4",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -415,7 +413,7 @@ Hans
             "list_search_base_path": str(file_root_path),
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -459,7 +457,7 @@ Hans
             "list_search_base_path": str(file_root_path),
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -502,13 +500,12 @@ Heinz
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -547,7 +544,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -599,9 +596,9 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
-        with mock.patch.dict("os.environ", environment):
+        with mock_env(environment):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -637,9 +634,9 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
-        with mock.patch.dict("os.environ", {"LIST_TENANT": "acme"}):
+        with mock_env({"LIST_TENANT": "acme"}):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -672,7 +669,7 @@ Heinz
             "list_search_base_path": "http://localhost/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -745,7 +742,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -784,7 +781,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenants.0:2}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -825,7 +822,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -834,10 +831,10 @@ Heinz
 
         with mock.patch("logprep.util.getter.time.monotonic", side_effect=[100.0, 125.0]):
             processor.process(first_document)
-            assert HttpGetter._shared[url].last_called == 100.0
+            assert HttpGetter._target_to_data_caches[url].last_called == 100.0
 
             processor.process(second_document)
-            assert HttpGetter._shared[url].last_called == 125.0
+            assert HttpGetter._target_to_data_caches[url].last_called == 125.0
 
         assert len(responses.calls) == 1
         assert first_document["user_results"] == {"in_list": [url]}
@@ -875,7 +872,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -921,7 +918,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -956,7 +953,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenant}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -995,7 +992,7 @@ Heinz
             "list_search_base_path": "http://localhost/${tenant}/${LOGPREP_LIST}",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1048,7 +1045,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1062,8 +1059,8 @@ Heinz
         assert isinstance(result.warnings[0], ProcessingWarning)
         assert rule.data_error is None
         assert failed_url not in rule.compare_sets
-        assert len(HttpGetter._shared[failed_url].callbacks) == 0
-        assert len(HttpGetter._shared[failed_url].cleanup_callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
 
         processor.process(successful_document)
 
@@ -1095,7 +1092,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1106,13 +1103,13 @@ Heinz
             processor.process(document)
 
         assert rule.compare_sets == {url: {"Foo"}}
-        assert url in HttpGetter._shared
+        assert url in HttpGetter._target_to_data_caches
 
         with mock.patch("logprep.util.getter.time.monotonic", return_value=161.1):
             refresh_getters()
 
         assert url not in rule.compare_sets
-        assert url not in HttpGetter._shared
+        assert url not in HttpGetter._target_to_data_caches
 
     def test_list_comparison_does_not_add_duplicates_from_list_source(self):
         document = {"users": ["Franz", "Alpha"]}
@@ -1219,7 +1216,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1269,7 +1266,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         captured_sessions = []
         original_get_requests_session = HttpGetter._get_requests_session
@@ -1350,7 +1347,7 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1380,7 +1377,7 @@ Heinz
             "user_results": {"in_list": [url]},
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -1431,13 +1428,12 @@ Heinz
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)

--- a/tests/unit/processor/network_comparison/test_network_comparison.py
+++ b/tests/unit/processor/network_comparison/test_network_comparison.py
@@ -3,7 +3,6 @@
 import json
 from ipaddress import IPv4Network
 from pathlib import Path
-from unittest import mock
 
 import pytest
 import responses
@@ -11,7 +10,8 @@ import responses
 from logprep.factory import Factory
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter, RefreshableGetterError
+from logprep.util.getter import HttpGetter, RefreshableGetter, RefreshableGetterError
+from tests.conftest import mock_env
 from tests.unit.processor.base import BaseProcessorTestCase
 
 
@@ -374,13 +374,12 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = Factory.create({"custom_lister": config})
             rule = processor.rule_class.create_from_dict(rule_dict)
             processor._rule_tree.add_rule(rule)
@@ -422,13 +421,12 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         getter_file_content = {url1: {"refresh_interval": 10}, url2: {"refresh_interval": 10}}
         http_getter_conf = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             processor = Factory.create({"custom_lister": config})
             processor.setup()
             assert processor.rules[0].compare_sets == {
@@ -544,7 +542,7 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "list_search_base_path": url_template,
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -558,8 +556,8 @@ class TestNetworkComparison(BaseProcessorTestCase):
         assert isinstance(result.warnings[0], ProcessingWarning)
         assert rule.data_error is None
         assert failed_url not in rule.compare_sets
-        assert len(HttpGetter._shared[failed_url].callbacks) == 0
-        assert len(HttpGetter._shared[failed_url].cleanup_callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
 
         processor.process(successful_document)
 
@@ -600,7 +598,7 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -699,7 +697,7 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "list_search_base_path": "http://localhost/tests/testdata/${LOGPREP_LIST}?ref=bla",
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)
@@ -729,7 +727,7 @@ class TestNetworkComparison(BaseProcessorTestCase):
             "ip_results": {"in_list": [url]},
         }
 
-        HttpGetter._shared.clear()
+        RefreshableGetter.reset()
 
         processor = Factory.create({"custom_lister": config})
         rule = processor.rule_class.create_from_dict(rule_dict)

--- a/tests/unit/test_quickstart.py
+++ b/tests/unit/test_quickstart.py
@@ -3,12 +3,13 @@ from unittest import mock
 import pytest
 
 from logprep import run_logprep
+from tests.conftest import mock_env
 
 
 class TestExampleCompose:
     EXAMPLE_CONFIG_PATH = "examples/exampledata/config/pipeline.yml"
 
-    @mock.patch("os.environ", new={"PROMETHEUS_MULTIPROC_DIR": "/tmp"})
+    @mock_env({"PROMETHEUS_MULTIPROC_DIR": "/tmp"})
     def test_example_compose_setup_is_valid(self):
         """ensures the example rules are valid"""
         with mock.patch(

--- a/tests/unit/test_run_logprep.py
+++ b/tests/unit/test_run_logprep.py
@@ -18,6 +18,7 @@ from logprep import run_logprep
 from logprep.run_logprep import cli
 from logprep.util.configuration import Configuration, InvalidConfigurationError
 from logprep.util.defaults import EXITCODES
+from tests.conftest import mock_env
 
 
 @mock.patch("logprep.registry.Registry.set_ng_active", new=lambda _: None)
@@ -187,7 +188,7 @@ class TestRunLogprepCli:
     @responses.activate
     def test_run_version_arg_prints_with_http_config_without_exposing_secret_data(self):
         config_path = "tests/testdata/config/config.yml"
-        mock_env = {
+        env_creds = {
             "LOGPREP_CONFIG_AUTH_USERNAME": "username",
             "LOGPREP_CONFIG_AUTH_PASSWORD": "password",
         }
@@ -197,7 +198,7 @@ class TestRunLogprepCli:
             Path(config_path).read_text(encoding="utf8"),
         )
         args = ["run", "--version", f"http://localhost:32000/{config_path}"]
-        with mock.patch("os.environ", mock_env):
+        with mock_env(env_creds):
             result = self.cli_runner.invoke(cli, args)
         assert result.exit_code == 0
         assert f"python version:          {sys.version.split()[0]}" in result.output

--- a/tests/unit/test_run_ng.py
+++ b/tests/unit/test_run_ng.py
@@ -15,6 +15,7 @@ from logprep import run_ng
 from logprep.ng.util.configuration import Configuration, InvalidConfigurationError
 from logprep.ng.util.defaults import EXITCODES
 from logprep.run_ng import cli
+from tests.conftest import mock_env
 
 
 @pytest.mark.skip("fix: cannot run the event loop while another loop is running")
@@ -126,7 +127,7 @@ class TestRunLogprepNGCli:
     @responses.activate
     async def test_run_version_arg_prints_with_http_config_without_exposing_secret_data(self):
         config_path = "tests/testdata/config/config-ng.yml"
-        mock_env = {
+        env_creds = {
             "LOGPREP_CONFIG_AUTH_USERNAME": "username",
             "LOGPREP_CONFIG_AUTH_PASSWORD": "password",
         }
@@ -136,7 +137,7 @@ class TestRunLogprepNGCli:
             Path(config_path).read_text(encoding="utf8"),
         )
         args = ["run", "--version", f"http://localhost:32000/{config_path}"]
-        with mock.patch("os.environ", mock_env):
+        with mock_env(env_creds):
             result = self.cli_runner.invoke(cli, args)
         assert result.exit_code == 0
         assert f"python version:          {sys.version.split()[0]}" in result.output

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -26,6 +26,7 @@ from logprep.util.configuration import (
 )
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
 from logprep.util.getter import FileGetter, GetterNotFoundError
+from tests.conftest import mock_env
 from tests.testdata.metadata import (
     path_to_config,
     path_to_invalid_config,
@@ -120,7 +121,7 @@ output:
         type: dummy_output
 {attribute}: {second_value}
 """)
-        with mock.patch("os.environ", new={"PROMETHEUS_MULTIPROC_DIR": str(tmp_path)}):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": str(tmp_path)}):
             config = Configuration.from_sources([str(first_config), str(second_config)])
             attribute_from_test = getattr(config, attribute)
             if hasattr(attribute_from_test, "__attrs_attrs__"):
@@ -519,8 +520,7 @@ pipeline:
         with pytest.raises(InvalidConfigurationError, match=expected_msg):
             Configuration.from_sources((str(test_config_path),))
 
-    patch = mock.patch(
-        "os.environ",
+    patch = mock_env(
         {
             "LOGPREP_VERSION": "1",
             "LOGPREP_PROCESS_COUNT": "16",
@@ -1120,7 +1120,7 @@ output:
             mock_run_pending.assert_called_once()
 
     def test_config_with_missing_environment_error(self):
-        with mock.patch("os.environ", {"PROMETHEUS_MULTIPROC_DIR": "DOES/NOT/EXIST"}):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": "DOES/NOT/EXIST"}):
             with pytest.raises(
                 InvalidConfigurationError,
                 match=r"'DOES\/NOT\/EXIST' does not exist",
@@ -1240,7 +1240,7 @@ output:
     ):
         config = Configuration.from_sources([str(config_path)])
         config.metrics = MetricsConfig(enabled=True, port=4242)
-        with mock.patch("os.environ", {}):
+        with mock_env({}):
             with pytest.raises(
                 InvalidConfigurationError,
                 match="Metrics enabled but PROMETHEUS_MULTIPROC_DIR is not set",
@@ -1303,8 +1303,7 @@ endpoints:
         username: test_user
         password: myverysecretpassword
 """)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             with pytest.raises(
                 InvalidConfigurationError,
                 match="Invalid credentials file.* unexpected keyword argument",
@@ -1337,9 +1336,7 @@ output:
   console:
     type: console_output
 """)
-        with mock.patch.dict(
-            "os.environ", {"PROMETHEUS_MULTIPROC_DIR": str(prometheus_multiproc_dir)}
-        ):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": str(prometheus_multiproc_dir)}):
             config1 = Configuration.from_sources(
                 [str(input_config), str(output_config), str(exporter_config)]
             )

--- a/tests/unit/util/test_credentials.py
+++ b/tests/unit/util/test_credentials.py
@@ -24,6 +24,7 @@ from logprep.util.credentials import (
     OAuth2TokenCredentials,
 )
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from tests.conftest import mock_env
 
 
 class TestBasicAuthCredentials:
@@ -966,8 +967,7 @@ getter:
     ):
         credential_file_path = tmp_path / "credentials"
         credential_file_path.write_text(credential_file_content)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             if error is not None:
                 with pytest.raises(error):
                     creds = CredentialsFactory.from_target("https://some.url/configuration")
@@ -984,8 +984,7 @@ input:
             username: test_user
             password: myverysecretpassword
 """)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             creds = CredentialsFactory.from_endpoint("/some/auth/endpoint")
             assert isinstance(creds, BasicAuthCredentials)
             assert "test_user" in creds.username
@@ -1003,14 +1002,12 @@ getter:
         client_id: test
         client_secret: test
 """)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             creds = CredentialsFactory.from_target("http://some.url")
             assert isinstance(creds, OAuth2ClientFlowCredentials)
 
     def test_credentials_is_none_on_invalid_credentials_file_path(self):
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: "this is something useless"}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: "this is something useless"}):
             with pytest.raises(InvalidConfigurationError, match=r"wrong credentials file path"):
                 creds = CredentialsFactory.from_target("https://some.url")
                 assert creds is None
@@ -1062,8 +1059,7 @@ getter:
         {type_of_secret}: {secret_file_path}
 """)
         secret_file_path.write_text(secret_content)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             creds = CredentialsFactory.from_target("http://some.url/configuration")
             assert isinstance(creds, instance), testcase
 
@@ -1084,8 +1080,7 @@ getter:
         secret_file_path_0.write_text("thisismysecretsecretclientsecret")
         secret_file_path_1.write_text("thisismysecorndsecretsecretpasswordsecret")
 
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             creds = CredentialsFactory.from_target("http://some.url/configuration")
             assert isinstance(creds, Credentials)
 
@@ -1114,8 +1109,7 @@ getter:
         username: testuser
         password_file: "thisismysecretsecretclientsecret"
 """)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             with pytest.raises(
                 InvalidConfigurationError,
                 match="Invalid credentials file.* unexpected keyword argument 'http://some.url'",
@@ -1130,8 +1124,7 @@ getter:
         username: testuser
         password_file: "thisismysecretsecretclientsecret"
 """)
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credential_file_path)}):
             with pytest.raises(
                 InvalidConfigurationError,
                 match="Invalid credentials file.* unexpected keyword argument '/some/endpoint'",

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1453,7 +1453,8 @@ class TestHttpGetter:
 
     @mock.patch("logprep.util.getter.HttpGetter._get_from_target", return_value=(b"", None, False))
     def test_update_cache_raises_error_if_empty(self, _):
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
+        http_getter = GetterFactory.from_string("http://something")
+        assert isinstance(http_getter, RefreshableGetter)
         http_getter.cache = None
         with pytest.raises(ValueError, match="HttpGetter cache is empty"):
             http_getter._update_cache()
@@ -1467,19 +1468,19 @@ class TestHttpGetter:
             "{}",
         )
 
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
+        http_getter = GetterFactory.from_string("http://something")
         http_getter.get_collection()
         mock_parse_yaml.assert_called_once()
 
     @mock.patch("logprep.abc.getter.Getter.get_collection", return_value="not a dict")
     def test_get_dict_raises_exception_if_result_not_dict(self, _):
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
-        with pytest.raises(ValueError, match="Value is not a dictionary"):
+        http_getter = GetterFactory.from_string("http://something")
+        with pytest.raises(ValueError, match="Expected a dict"):
             http_getter.get_dict()
 
     @mock.patch("logprep.abc.getter.Getter.get_collection", return_value={"something": "foo"})
     def test_get_dict_returns_if_result_is_dict(self, _):
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
+        http_getter = GetterFactory.from_string("http://something")
         assert http_getter.get_dict() == {"something": "foo"}
 
     @responses.activate
@@ -1491,7 +1492,7 @@ class TestHttpGetter:
             content_type="application/json",
         )
 
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
+        http_getter = GetterFactory.from_string("http://something")
         assert http_getter.get_list() == ["something"]
 
     @responses.activate
@@ -1507,7 +1508,7 @@ class TestHttpGetter:
             "logprep.abc.getter.Getter._resolve_content_by_content_type",
             return_value=None,
         ):
-            http_getter: HttpGetter = GetterFactory.from_string("http://something")
+            http_getter = GetterFactory.from_string("http://something")
 
             with pytest.raises(ValueError, match="Content is not a list"):
                 http_getter.get_list()
@@ -1520,7 +1521,7 @@ class TestHttpGetter:
 
     def test_refresh_interval_for_getter_file_config_always_zero(self, tmp_path):
         target = "something"
-        http_getter: HttpGetter = GetterFactory.from_string(f"http://{target}")
+        http_getter = GetterFactory.from_string(f"http://{target}")
 
         getter_file_content = {target: {"refresh_interval": 10}}
 
@@ -1542,7 +1543,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
         with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
-            http_getter: HttpGetter = GetterFactory.from_string(f"http://{target}")
+            http_getter = GetterFactory.from_string(f"http://{target}")
             with pytest.raises(RefreshableGetterError, match="Test"):
                 http_getter.get_raw()
 
@@ -1552,7 +1553,7 @@ class TestHttpGetter:
     def test_get_raw_without_interval_logs_warning_on_error_with_empty_cache(self, _, caplog):
         caplog.set_level("WARNING")
         target = "something"
-        http_getter: HttpGetter = GetterFactory.from_string(f"http://{target}")
+        http_getter = GetterFactory.from_string(f"http://{target}")
         http_getter.cache = "something"
         http_getter.get_raw()
         assert re.search(r"Not updating .+ cache with URI .+", caplog.text)
@@ -1561,7 +1562,7 @@ class TestHttpGetter:
     def test_get_raw_without_interval_logs_warning_on_empty_cache(self, _):
         target = "something"
         url = f"http://{target}"
-        http_getter: HttpGetter = GetterFactory.from_string(url)
+        http_getter = GetterFactory.from_string(url)
         with pytest.raises(ValueError, match=f"Cache is empty for HttpGetter with URI '{url}'"):
             http_getter.get_raw()
 
@@ -1571,7 +1572,8 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps({target: {"default_return_value": "something"}}))
         with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
-            http_getter: HttpGetter = GetterFactory.from_string(url)
+            http_getter = GetterFactory.from_string(url)
+            assert isinstance(http_getter, RefreshableGetter)
             assert http_getter._get_default_return_value() == b"something"
             http_getter.protocol = "file"
             http_getter.target = str(http_getter_conf)
@@ -1621,8 +1623,8 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
         with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
-            http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
-            http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
+            http_getter_1 = GetterFactory.from_string(url_1)
+            http_getter_2 = GetterFactory.from_string(url_2)
         with mock.patch.object(http_getter_1.scheduler, "run_pending") as mock_run_pending:
             mock_run_pending.assert_not_called()
             refresh_getters()
@@ -1687,7 +1689,7 @@ class TestHttpGetter:
             content_type=content_type,
         )
 
-        http_getter: HttpGetter = GetterFactory.from_string("http://something")
+        http_getter = GetterFactory.from_string("http://something")
         assert http_getter._resolve_content_by_content_type() == expected
 
     def test_http_getter_uri_does_not_duplicate_protocol(self):
@@ -1713,8 +1715,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        moch_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock_env(moch_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -34,6 +34,7 @@ from logprep.util.getter import (
     RefreshableGetterError,
     refresh_getters,
 )
+from tests.conftest import mock_env
 
 yaml = YAML(pure=True, typ="safe")
 
@@ -72,20 +73,20 @@ class TestGetterFactory:
         assert my_getter.protocol == expected_protocol
         assert my_getter.target == expected_target
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TARGET": "the-web-target"})
+    @mock_env({"PYTEST_TEST_TARGET": "the-web-target"})
     def test_getter_expands_from_environment(self):
         url = "https://${PYTEST_TEST_TARGET}"
         my_getter = GetterFactory.from_string(url)
         assert my_getter.target == "https://the-web-target"
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_environment_variables_in_content(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my $PYTEST_TEST_TOKEN")
         my_getter = GetterFactory.from_string(str(testfile))
         assert my_getter.get() == "this is my mytoken"
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_setted_environment_variables_and_missing_to_blank(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my $PYTEST_TEST_TOKEN, and this is my $LOGPREP_MISSING_TOKEN")
@@ -94,14 +95,14 @@ class TestGetterFactory:
         assert "LOGPREP_MISSING_TOKEN" in my_getter.missing_env_vars
         assert len(my_getter.missing_env_vars) == 1
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_only_uppercase_variable_names(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my $PYTEST_TEST_TOKEN, and this is my $pytest_test_token")
         my_getter = GetterFactory.from_string(str(testfile))
         assert my_getter.get() == "this is my mytoken, and this is my $pytest_test_token"
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_setted_environment_variables_and_missing_to_blank_with_braced_variables(
         self, tmp_path
     ):
@@ -112,14 +113,14 @@ class TestGetterFactory:
         my_getter = GetterFactory.from_string(str(testfile))
         assert my_getter.get() == "this is my mytoken, and this is my "
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_only_uppercase_variable_names_with_braced_variables(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my ${PYTEST_TEST_TOKEN}, and this is my ${not_a_token}")
         my_getter = GetterFactory.from_string(str(testfile))
         assert my_getter.get() == "this is my mytoken, and this is my ${not_a_token}"
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_ignores_list_comparison_logprep_list_variable(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my ${PYTEST_TEST_TOKEN}, and this is my ${LOGPREP_LIST}")
@@ -127,7 +128,7 @@ class TestGetterFactory:
         assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
         assert len(my_getter.missing_env_vars) == 0
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken", "LOGPREP_LIST": "foo"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken", "LOGPREP_LIST": "foo"})
     def test_getter_ignores_list_comparison_logprep_list_variable_if_set(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("this is my ${PYTEST_TEST_TOKEN}, and this is my ${LOGPREP_LIST}")
@@ -135,7 +136,7 @@ class TestGetterFactory:
         assert my_getter.get() == "this is my mytoken, and this is my ${LOGPREP_LIST}"
         assert len(my_getter.missing_env_vars) == 0
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_environment_variables_in_yaml_content(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("""---
@@ -154,7 +155,7 @@ dict: {key: value, second_key: $PYTEST_TEST_TOKEN}
         }
         assert my_getter.get_yaml() == expected
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_getter_expands_only_whitelisted_in_yaml_content(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text("""---
@@ -174,7 +175,7 @@ dict: {key: value, second_key: $PYTEST_TEST_TOKEN}
         }
         assert my_getter.get_yaml() == expected
 
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken", "LOGPREP_LIST": "foo"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken", "LOGPREP_LIST": "foo"})
     def test_getter_does_not_reduces_double_dollar_for_unvalid_prefixes(self, tmp_path):
         testfile = tmp_path / "test_getter.json"
         testfile.write_text(
@@ -350,7 +351,7 @@ second_dict:
             ),
         ],
     )
-    @mock.patch.dict("os.environ", {"PYTEST_TEST_TOKEN": "mytoken"})
+    @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
     def test_get_jsonl_parses_json_object_per_line(self, tmp_path, content, expected):
         testfile = tmp_path / "test_getter.jsonl"
         testfile.write_text(content)
@@ -471,9 +472,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        with mock.patch.dict(
-            "os.environ", {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        ):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string("https://does-not-matter/bar")
             assert isinstance(http_getter.credentials, Credentials)
 
@@ -507,9 +506,7 @@ class TestHttpGetter:
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
 
-        with mock.patch.dict(
-            "os.environ", {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        ):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             return_content = http_getter.get_json()
             assert return_content == {"key": "the cooooontent"}
@@ -545,9 +542,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        with mock.patch.dict(
-            "os.environ", {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        ):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             http_getter.get_json()
             return_content = http_getter.get_json()
@@ -584,9 +579,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        with mock.patch.dict(
-            "os.environ", {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        ):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             return_content = http_getter.get_json()
             assert return_content == {"key": "the cooooontent"}
@@ -620,9 +613,8 @@ class TestHttpGetter:
         )
         with pytest.raises(RefreshableGetterError, match="401 Client Error: Unauthorized for url"):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
-            with mock.patch.dict(
-                "os.environ",
-                {ENV_NAME_LOGPREP_CREDENTIALS_FILE: "examples/exampledata/config/credentials.yml"},
+            with mock_env(
+                {ENV_NAME_LOGPREP_CREDENTIALS_FILE: "examples/exampledata/config/credentials.yml"}
             ):
                 http_getter.get_json()
 
@@ -649,8 +641,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             http_getter.get_raw()
             assert isinstance(http_getter.credentials, Credentials)
@@ -682,8 +673,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             http_getter.get_raw()
             assert isinstance(http_getter.credentials, Credentials)
@@ -722,8 +712,7 @@ class TestHttpGetter:
         }
         credentials_file: Path = tmp_path / "credentials.json"
         credentials_file.write_text(json.dumps(credentials_file_content))
-        mock_env = {ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_CREDENTIALS_FILE: str(credentials_file)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"https://{domain}/bar")
             http_getter.get_raw()
             credentials_file_content.popitem()
@@ -780,8 +769,7 @@ class TestHttpGetter:
         getter_file_content = {"${zws}/api/.*": {"refresh_interval": 0}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert http_getter.cache is None
             return_content_1 = http_getter.get_json()
@@ -800,8 +788,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": -1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             with pytest.raises(ValueError, match=r"'refresh_interval' must be >= 0: -1"):
                 GetterFactory.from_string(url)
 
@@ -813,8 +800,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"timeout_interval": -1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             with pytest.raises(ValueError, match=r"'timeout_interval' must be >= 0: -1"):
                 GetterFactory.from_string(url)
 
@@ -827,8 +813,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 100}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert len(http_getter.scheduler.jobs) == 1
             assert http_getter.scheduler.jobs[0].interval == 100
@@ -849,8 +834,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
 
             assert len(http_getter.scheduler.jobs) == 1
@@ -875,8 +859,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 1}}
         http_getter_conf: Path = tmp_path / "http_getter.yaml"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
 
             assert len(http_getter.scheduler.jobs) == 1
@@ -902,8 +885,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert len(http_getter.scheduler.jobs) == 1
             assert http_getter.scheduler.jobs[0].interval == 1
@@ -930,8 +912,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 1}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert len(http_getter.scheduler.jobs) == 1
             assert http_getter.scheduler.jobs[0].interval == 1
@@ -972,8 +953,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url)
             http_getter_2: HttpGetter = GetterFactory.from_string(url)
 
@@ -1013,8 +993,7 @@ class TestHttpGetter:
         }
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
 
@@ -1063,8 +1042,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 0}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert http_getter.hash is None
             response = http_getter.get_json()
@@ -1109,8 +1087,7 @@ class TestHttpGetter:
         getter_file_content = {target_1: {"refresh_interval": 0}, target_2: {"refresh_interval": 0}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
 
@@ -1158,8 +1135,7 @@ class TestHttpGetter:
         getter_file_content = {target: {"refresh_interval": 100}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert http_getter.hash is None
             response = http_getter.get_json()
@@ -1192,8 +1168,7 @@ class TestHttpGetter:
         }
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
 
@@ -1236,8 +1211,7 @@ class TestHttpGetter:
 
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             GetterFactory.from_string(url_ref_1)
             GetterFactory.from_string(url_ref_1)
             GetterFactory.from_string(url_ref_2)
@@ -1267,8 +1241,7 @@ class TestHttpGetter:
         }
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
 
@@ -1328,8 +1301,7 @@ class TestHttpGetter:
         }
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
 
@@ -1373,14 +1345,14 @@ class TestHttpGetter:
             assert self._callback_value == 14
 
     def test_add_callback_for_target_target_share_none(self):
-        HttpGetter._shared["target"] = None
+        HttpGetter._target_to_data_caches["target"] = None
         HttpGetter.add_callback_for_target("target", "test_tag123", lambda: True)
-        assert HttpGetter._shared.get("target") is None
+        assert HttpGetter._target_to_data_caches.get("target") is None
 
     def test_add_callback_for_target_unknown_target_does_not_create_shared_state(self):
         HttpGetter.add_callback_for_target("unknown-target", "test_tag123", lambda: True)
 
-        assert "unknown-target" not in HttpGetter._shared
+        assert "unknown-target" not in HttpGetter._target_to_data_caches
 
     def test_callback_with_duplicate_deduplication_key_is_skipped(self):
         http_getter = HttpGetter(protocol="http", target="http://example.test/resource")
@@ -1554,8 +1526,7 @@ class TestHttpGetter:
 
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             assert http_getter._get_refresh_interval() == 10
             http_getter.protocol = "file"
             http_getter.target = str(http_getter_conf)
@@ -1570,8 +1541,7 @@ class TestHttpGetter:
 
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(f"http://{target}")
             with pytest.raises(RefreshableGetterError, match="Test"):
                 http_getter.get_raw()
@@ -1600,8 +1570,7 @@ class TestHttpGetter:
         url = f"http://{target}"
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps({target: {"default_return_value": "something"}}))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter: HttpGetter = GetterFactory.from_string(url)
             assert http_getter._get_default_return_value() == b"something"
             http_getter.protocol = "file"
@@ -1627,8 +1596,7 @@ class TestHttpGetter:
 
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             ref_no_default = GetterFactory.from_string(url_ref_no_default)
             ref_default = GetterFactory.from_string(url_ref_default)
             no_ref_no_default = GetterFactory.from_string(url_no_ref_no_default)
@@ -1652,8 +1620,7 @@ class TestHttpGetter:
         }
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter_1: HttpGetter = GetterFactory.from_string(url_1)
             http_getter_2: HttpGetter = GetterFactory.from_string(url_2)
         with mock.patch.object(http_getter_1.scheduler, "run_pending") as mock_run_pending:
@@ -1747,7 +1714,7 @@ class TestHttpGetter:
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
         moch_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", moch_env):
+        with mock_env(moch_env):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1762,8 +1729,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1778,8 +1744,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1793,8 +1758,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1809,8 +1773,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1825,8 +1788,7 @@ class TestHttpGetter:
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
 
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         assert isinstance(http_getter, HttpGetter)
@@ -1900,7 +1862,7 @@ class TestHttpGetter:
 
         cleanup_callback.assert_called_once_with("foo", bar="baz")
         scheduler.run_pending.assert_not_called()
-        assert "http://example.test/resource" not in HttpGetter._shared
+        assert "http://example.test/resource" not in HttpGetter._target_to_data_caches
 
     def test_refresh_removes_target_after_configured_timeout_interval(self, tmp_path):
         target = "example.test/resource"
@@ -1908,9 +1870,8 @@ class TestHttpGetter:
         getter_file_content = {target: {"timeout_interval": 120}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
 
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         cleanup_callback = mock.MagicMock()
@@ -1924,7 +1885,7 @@ class TestHttpGetter:
 
         cleanup_callback.assert_called_once()
         scheduler.run_pending.assert_not_called()
-        assert url not in HttpGetter._shared
+        assert url not in HttpGetter._target_to_data_caches
 
     def test_refresh_keeps_active_target_and_runs_scheduler(self):
         http_getter = HttpGetter(protocol="http", target="http://example.test/resource")
@@ -1940,7 +1901,7 @@ class TestHttpGetter:
 
         cleanup_callback.assert_not_called()
         scheduler.run_pending.assert_called_once()
-        assert "http://example.test/resource" in HttpGetter._shared
+        assert "http://example.test/resource" in HttpGetter._target_to_data_caches
 
     def test_refresh_keeps_target_until_configured_timeout_interval(self, tmp_path):
         target = "example.test/resource"
@@ -1948,9 +1909,8 @@ class TestHttpGetter:
         getter_file_content = {target: {"timeout_interval": 120}}
         http_getter_conf: Path = tmp_path / "http_getter.json"
         http_getter_conf.write_text(json.dumps(getter_file_content))
-        mock_env = {ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}
 
-        with mock.patch.dict("os.environ", mock_env):
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             http_getter = GetterFactory.from_string(url)
 
         cleanup_callback = mock.MagicMock()
@@ -1964,4 +1924,4 @@ class TestHttpGetter:
 
         cleanup_callback.assert_not_called()
         scheduler.run_pending.assert_called_once()
-        assert url in HttpGetter._shared
+        assert url in HttpGetter._target_to_data_caches


### PR DESCRIPTION
## Description

* improve env var access performance by using a cached snapshot
* getter: add debug logs
* improve robustness of compose tests

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--996.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->