### PR TITLE
feat: add dynamic url info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
 * introduce API-level support for asynchronous rule processing and I/O capability detection in `ng` processors
+* generic_adder: add support for templated http urls
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
 * introduce API-level support for asynchronous rule processing and I/O capability detection in `ng` processors
-* generic_adder: add support for templated http urls
+* generic_adder: add support for templated http urls & content_field
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -114,9 +114,17 @@ class Getter(ABC):
         content = self._resolve_content(raw)
         return self._parse_json(content)
 
-    def get_collection(self) -> dict | list:
+    def get_collection(self, content_field: str | None = None) -> dict | list:
         """Gets and parses the raw content to yaml or json"""
         content = self._resolve_content_by_content_type()
+
+        if isinstance(content, dict) and content_field is not None:
+            content = content[content_field]
+        elif content_field is not None:
+            raise ValueError(
+                "Expected mapping type, like json object when content_field is set, got %s.",
+                type(content),
+            )
 
         if isinstance(content, str):
             content = self._parse_yaml_or_json(content)

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -118,13 +118,7 @@ class Getter(ABC):
         """Gets and parses the raw content to yaml or json"""
         content = self._resolve_content_by_content_type()
 
-        if isinstance(content, dict) and content_field is not None:
-            content = content[content_field]
-        elif content_field is not None:
-            raise ValueError(
-                "Expected mapping type, like json object when content_field is set, got %s.",
-                type(content),
-            )
+        content = Getter._apply_content_field(content, content_field)
 
         if isinstance(content, str):
             content = self._parse_yaml_or_json(content)
@@ -151,17 +145,25 @@ class Getter(ABC):
         """Helper which tries to convert content to list"""
         return content.splitlines()
 
-    def get_list(self, content_field: str | None = None) -> list:
-        """Gets list and fails otherwise"""
-
-        content = self._resolve_content_by_content_type()
-
+    @staticmethod
+    def _apply_content_field(
+        content: dict | list | str, content_field: str | None = None
+    ) -> dict | list | str:
         if isinstance(content, dict) and content_field is not None:
             content = content[content_field]
         elif content_field is not None:
             raise ValueError(
                 f"Expected mapping type when content_field is set, got {type(content)}"
             )
+
+        return content
+
+    def get_list(self, content_field: str | None = None) -> list:
+        """Gets list and fails otherwise"""
+
+        content = self._resolve_content_by_content_type()
+
+        content = Getter._apply_content_field(content, content_field)
 
         if isinstance(content, str):
             content = self._parse_newline_separated_list(content)

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -118,8 +118,10 @@ class Getter(ABC):
         """Gets and parses the raw content to yaml or json"""
         content = self._resolve_content_by_content_type()
 
-        content = Getter._apply_content_field(content, content_field)
+        if isinstance(content, str):
+            content = self._parse_yaml_or_json(content)
 
+        content = Getter._apply_content_field(content, content_field)
         if isinstance(content, str):
             content = self._parse_yaml_or_json(content)
 

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -133,9 +133,9 @@ class Getter(ABC):
             logger.debug("parsing yaml failed, falling back to json for content: %s", content)
             return self._parse_json(content)
 
-    def get_dict(self) -> dict:
+    def get_dict(self, content_field: str | None = None) -> dict:
         """Gets dict and fails otherwise"""
-        result = self.get_collection()
+        result = self.get_collection(content_field=content_field)
         if not isinstance(result, dict):
             raise ValueError(f"Expected a dict, got {type(result)}")
         return result
@@ -160,9 +160,7 @@ class Getter(ABC):
 
     def get_list(self, content_field: str | None = None) -> list:
         """Gets list and fails otherwise"""
-
         content = self._resolve_content_by_content_type()
-
         content = Getter._apply_content_field(content, content_field)
 
         if isinstance(content, str):

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -163,6 +163,9 @@ class Getter(ABC):
     def get_list(self, content_field: str | None = None) -> list:
         """Gets list and fails otherwise"""
         content = self._resolve_content_by_content_type()
+        if content_field is not None and isinstance(content, str):
+            content = self._parse_yaml_or_json(content)
+
         content = Getter._apply_content_field(content, content_field)
 
         if isinstance(content, str):

--- a/logprep/ng/abc/component.py
+++ b/logprep/ng/abc/component.py
@@ -30,8 +30,7 @@ class NgComponent(Component):
     async def shut_down(self) -> None:  # type: ignore[override]
         """Shut down ng component and cleanup resources."""
         self._is_shut_down = True
-        self._clear_scheduled_jobs()
-        self._clear_properties()
+        self._shut_down()
 
     async def health(self) -> bool:  # type: ignore[override]
         """Check the health of the component.

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -31,8 +31,8 @@ from logprep.ng.abc.processor import Processor
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
-from logprep.util.helper import FieldValue, add_fields_to
 from logprep.util.getter import RefreshableGetter
+from logprep.util.helper import FieldValue, add_fields_to
 
 
 class GenericAdder(Processor):
@@ -40,7 +40,6 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
     @property
     def rules(self) -> Sequence[GenericAdderRule]:
         """Returns all rules"""
@@ -51,7 +50,7 @@ class GenericAdder(Processor):
         for rule in self.rules:
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GenericAdderRule, rule)
 
         try:

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -25,11 +25,13 @@ Processor Configuration
 """
 
 import typing
+from typing import Sequence
 
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.helper import FieldValue, add_fields_to
+from logprep.util.getter import RefreshableGetter
 
 
 class GenericAdder(Processor):
@@ -38,7 +40,22 @@ class GenericAdder(Processor):
     rule_class = GenericAdderRule
 
     async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+    @property
+    def _rules(self) -> Sequence[GenericAdderRule]:
+        """Returns all rules"""
+        return typing.cast(Sequence[GenericAdderRule], self.rules)
+
+    async def setup(self):
+        await super().setup()
+        for rule in self._rules:
+            rule.init_generic_adder(self._job_tag_for_cleanup)
+
+    def _apply_rules(self, event: dict, rule: Rule) -> None:
         rule = typing.cast(GenericAdderRule, rule)
         items_to_add = rule.add(event)
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
+
+    def _shut_down(self) -> None:
+        RefreshableGetter.remove_callbacks_for_tag(self._job_tag_for_cleanup)
+        return super()._shut_down()

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -25,7 +25,7 @@ Processor Configuration
 """
 
 import typing
-from typing import Sequence
+from collections.abc import Sequence
 
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.exceptions import ProcessingWarning
@@ -42,13 +42,13 @@ class GenericAdder(Processor):
 
     async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
     @property
-    def _rules(self) -> Sequence[GenericAdderRule]:
+    def rules(self) -> Sequence[GenericAdderRule]:
         """Returns all rules"""
-        return typing.cast(Sequence[GenericAdderRule], self.rules)
+        return typing.cast(Sequence[GenericAdderRule], super().rules)
 
     async def setup(self):
         await super().setup()
-        for rule in self._rules:
+        for rule in self.rules:
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
     def _apply_rules(self, event: dict, rule: Rule) -> None:

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -28,6 +28,7 @@ import typing
 from typing import Sequence
 
 from logprep.ng.abc.processor import Processor
+from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.helper import FieldValue, add_fields_to
@@ -52,7 +53,11 @@ class GenericAdder(Processor):
 
     def _apply_rules(self, event: dict, rule: Rule) -> None:
         rule = typing.cast(GenericAdderRule, rule)
-        items_to_add = rule.add(event)
+
+        try:
+            items_to_add = rule.add(event)
+        except Exception as error:
+            raise ProcessingWarning(str(error), rule, event) from error
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
 

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -39,6 +39,6 @@ class GenericAdder(Processor):
 
     async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GenericAdderRule, rule)
-        items_to_add = rule.add
+        items_to_add = rule.add(event)
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -55,11 +55,13 @@ class GenericAdder(Processor):
         rule = typing.cast(GenericAdderRule, rule)
 
         try:
-            items_to_add = rule.add(event)
+            for items_to_add in rule.additions(event):
+                if items_to_add:
+                    add_fields_to(
+                        event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target
+                    )
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error
-        if items_to_add:
-            add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
 
     def _shut_down(self) -> None:
         RefreshableGetter.remove_callbacks_for_tag(self._job_tag_for_cleanup)

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -41,7 +41,7 @@ class GenericAdder(Processor):
         super().setup()
         for rule in self.rules:
             rule = typing.cast(GenericAdderRule, rule)
-            rule.set_job_tag(self._job_tag_for_cleanup)
+            rule.init_generic_adder(self._job_tag_for_cleanup)
 
     def _apply_rules(self, event: dict, rule: Rule):
         rule = typing.cast(GenericAdderRule, rule)

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -37,8 +37,14 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
+    def setup(self):
+        super().setup()
+        for rule in self.rules:
+            rule = typing.cast(GenericAdderRule, rule)
+            rule.set_job_tag(self._job_tag_for_cleanup)
+
     def _apply_rules(self, event: dict, rule: Rule):
         rule = typing.cast(GenericAdderRule, rule)
-        items_to_add = rule.add
+        items_to_add = rule.add(event)
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -25,10 +25,11 @@ Processor Configuration
 """
 
 import typing
+from typing import Sequence
 
 from logprep.abc.processor import Processor
-from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
+from logprep.util.getter import RefreshableGetter
 from logprep.util.helper import add_fields_to
 
 
@@ -37,14 +38,21 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
+    @property
+    def _rules(self) -> Sequence[GenericAdderRule]:
+        """Returns all rules"""
+        return typing.cast(Sequence[GenericAdderRule], self.rules)
+
     def setup(self):
         super().setup()
-        for rule in self.rules:
-            rule = typing.cast(GenericAdderRule, rule)
+        for rule in self._rules:
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
-    def _apply_rules(self, event: dict, rule: Rule):
-        rule = typing.cast(GenericAdderRule, rule)
+    def _apply_rules(self, event: dict, rule: GenericAdderRule):
         items_to_add = rule.add(event)
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
+
+    def _shut_down(self) -> None:
+        RefreshableGetter.remove_callbacks_for_tag(self._job_tag_for_cleanup)
+        return super()._shut_down()

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -31,7 +31,7 @@ from logprep.abc.processor import Processor
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.getter import RefreshableGetter
-from logprep.util.helper import add_fields_to
+from logprep.util.helper import FieldValue, add_fields_to
 
 
 class GenericAdder(Processor):
@@ -49,7 +49,7 @@ class GenericAdder(Processor):
         for rule in self.rules:
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
-    def _apply_rules(self, event: dict, rule: GenericAdderRule):
+    def _apply_rules(self, event: dict[str, FieldValue], rule: GenericAdderRule):
         try:
             for items_to_add in rule.additions(event):
                 if items_to_add:

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -28,6 +28,7 @@ import typing
 from typing import Sequence
 
 from logprep.abc.processor import Processor
+from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.generic_adder.rule import GenericAdderRule
 from logprep.util.getter import RefreshableGetter
 from logprep.util.helper import add_fields_to
@@ -49,7 +50,10 @@ class GenericAdder(Processor):
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
     def _apply_rules(self, event: dict, rule: GenericAdderRule):
-        items_to_add = rule.add(event)
+        try:
+            items_to_add = rule.add(event)
+        except Exception as error:
+            raise ProcessingWarning(str(error), rule, event) from error
         if items_to_add:
             add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
 

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -25,7 +25,7 @@ Processor Configuration
 """
 
 import typing
-from typing import Sequence
+from collections.abc import Sequence
 
 from logprep.abc.processor import Processor
 from logprep.processor.base.exceptions import ProcessingWarning
@@ -40,13 +40,13 @@ class GenericAdder(Processor):
     rule_class = GenericAdderRule
 
     @property
-    def _rules(self) -> Sequence[GenericAdderRule]:
+    def rules(self) -> Sequence[GenericAdderRule]:
         """Returns all rules"""
-        return typing.cast(Sequence[GenericAdderRule], self.rules)
+        return typing.cast(Sequence[GenericAdderRule], super().rules)
 
     def setup(self):
         super().setup()
-        for rule in self._rules:
+        for rule in self.rules:
             rule.init_generic_adder(self._job_tag_for_cleanup)
 
     def _apply_rules(self, event: dict, rule: GenericAdderRule):

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -51,11 +51,13 @@ class GenericAdder(Processor):
 
     def _apply_rules(self, event: dict, rule: GenericAdderRule):
         try:
-            items_to_add = rule.add(event)
+            for items_to_add in rule.additions(event):
+                if items_to_add:
+                    add_fields_to(
+                        event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target
+                    )
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error
-        if items_to_add:
-            add_fields_to(event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target)
 
     def _shut_down(self) -> None:
         RefreshableGetter.remove_callbacks_for_tag(self._job_tag_for_cleanup)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -87,9 +87,47 @@ import typing
 
 from attrs import define, field, validators
 
+from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
-from logprep.util.getter import GetterFactory, RefreshableGetter
+from logprep.util.converters import convert_from_dict
+from logprep.util.dotted_template import DottedTemplate
+from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
+from logprep.util.helper import FieldValue, get_dotted_field_value
+
+
+@define(kw_only=True, frozen=True)
+class AddFromUrlConfig:
+    url: str = field(
+        validator=[validators.instance_of(str), validators.matches_re(r"^https?://.+")]
+    )
+
+    target_field: str | None = field(
+        default=None, validator=validators.optional(validators.instance_of(str))
+    )
+
+    target_field_mapping: dict[str, str] | None = field(
+        validator=validators.optional(
+            validators.deep_mapping(
+                key_validator=validators.instance_of(str),
+                value_validator=validators.instance_of(str),
+            )
+        ),
+        default=None,
+    )
+
+    def __attrs_post_init__(self) -> None:
+        if not self.target_field and not self.target_field_mapping:
+            raise ValueError("add_from_url requires target_field or target_field_mapping")
+
+
+def _convert_add_from_url(
+    value: AddFromUrlConfig | dict | None,
+) -> AddFromUrlConfig | None:
+    if value is None:
+        return None
+
+    return convert_from_dict(AddFromUrlConfig, value)
 
 
 class GenericAdderRule(FieldManagerRule):
@@ -113,13 +151,15 @@ class GenericAdderRule(FieldManagerRule):
         """Contains a dictionary of field names and values that should be added.
         If dot notation is being used, then all fields on the path are being
         automatically created."""
-        add_from_file: list = field(
-            validator=[
-                validators.instance_of(list),
-                validators.deep_iterable(member_validator=validators.instance_of(str)),
-            ],
-            converter=lambda x: x if isinstance(x, list) else [x],
-            factory=list,
+        add_from_file: list | None = field(
+            validator=validators.optional(
+                validators.deep_iterable(
+                    iterable_validator=validators.instance_of(list),
+                    member_validator=validators.instance_of(str),
+                )
+            ),
+            converter=lambda x: x if x is None or isinstance(x, list) else [x],
+            default=None,
             eq=False,
         )
         """Contains the path or url to YML file that contains a dictionary of field names
@@ -141,6 +181,19 @@ class GenericAdderRule(FieldManagerRule):
            authenticity and integrity of the loaded values.
 
         """
+
+        add_from_url: AddFromUrlConfig | None = field(
+            default=None,
+            validator=validators.optional(
+                validators.instance_of(AddFromUrlConfig)
+                # validators.deep_iterable(
+                #     iterable_validator=validators.instance_of(list),
+                #     member_validator=validators.instance_of(AddFromUrlConfig),
+                # )
+            ),
+            converter=_convert_add_from_url,
+        )
+
         only_first_existing_file: bool = field(
             validator=validators.instance_of(bool), default=False, eq=False
         )
@@ -160,6 +213,37 @@ class GenericAdderRule(FieldManagerRule):
         def __attrs_post_init__(self):
             self._base_add = copy.deepcopy(self.add)
 
+            if (
+                self.add_from_file is not None or self.add is not None
+            ) and self.add_from_url is not None:
+                raise ValueError(
+                    "only one of add_from_file + add or add_from_url is allowed per GenericAdder rule"
+                )
+
+            if not self.add and self.add_from_file is None and self.add_from_url is None:
+                raise ValueError(
+                    "one of add, add_from_file or add_from_url is neccessary per GenericAdder rule"
+                )
+
+            if (
+                self.add_from_url is not None
+                and self.add_from_url.target_field is not None
+                and self.add_from_url.target_field_mapping is not None
+            ):
+                raise ValueError(
+                    "only one of target_field or target_field_mapping is allowed per GenericAdder rule"
+                )
+
+            if (
+                self.add_from_url is not None
+                and self.add_from_url.target_field is None
+                and self.add_from_url.target_field_mapping is None
+            ):
+                raise ValueError(
+                    "one of target_field or target_field_mapping is neccessary per GenericAdder rule"
+                )
+
+            # Eagerly loaded from file
             if self.add_from_file:
                 for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
                     getter = GetterFactory.from_string(add_file)
@@ -173,6 +257,7 @@ class GenericAdderRule(FieldManagerRule):
         def _add_from_path(self):
             """Reads add fields from file"""
             missing_files = []
+            assert self.add_from_file is not None
             for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
                 try:
                     add_dict = GetterFactory.from_string(add_file).get_yaml()
@@ -195,8 +280,80 @@ class GenericAdderRule(FieldManagerRule):
                     f"The following required files do not exist: '{missing_files}'"
                 )
 
-    @property
-    def add(self) -> dict:
+    def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
+        super().__init__(filter_rule, config, processor_name)
+        self._dynamic_content: dict[str, FieldValue] = {}
+        self._callback_tag = ""
+
+    def set_job_tag(self, job_tag: str) -> None:
+        self._callback_tag = job_tag
+
+    def _dynamic_add_from_url(self, event: dict) -> dict[str, FieldValue]:
+        config = typing.cast(GenericAdderRule.Config, self._config)
+
+        assert config.add_from_url
+
+        dynamic_path_template = DottedTemplate(config.add_from_url.url)
+        key_val = {
+            identifier: get_dotted_field_value(event, identifier)
+            for identifier in dynamic_path_template.get_identifiers()
+        }
+        for identifier, val in key_val.items():
+            if val is None:
+                raise ValueError(
+                    f"missing event field {identifier!r} for dynamic list comparison path"
+                )
+            if not isinstance(val, (str, int)):
+                raise ValueError(
+                    f"value for list comparison field {identifier!r} is not a scalar value"
+                )
+            pass
+
+        dynamic_resolved = dynamic_path_template.substitute(key_val)
+        content: FieldValue | None = None
+        if dynamic_resolved not in self._dynamic_content:
+            http_getter = GetterFactory.from_string(dynamic_resolved)
+            assert isinstance(http_getter, HttpGetter)
+
+            http_getter.keep_alive()
+
+            content = http_getter.get_collection()
+            self._dynamic_content[dynamic_resolved] = content
+
+            # Get tag here
+            # Add update callback
+            # Add cleanup callback
+        else:
+            RefreshableGetter.keep_alive_for_target(dynamic_resolved)
+            content = self._dynamic_content[dynamic_resolved]
+
+        items_to_add: dict[str, FieldValue] = {}
+
+        if config.add_from_url.target_field:
+            items_to_add[config.add_from_url.target_field] = content
+        else:
+            assert config.add_from_url.target_field_mapping is not None
+
+            # TODO: Check this differently, what should this be?
+            assert isinstance(content, dict)
+            for (
+                mapping_source_field,
+                mapping_target_field,
+            ) in config.add_from_url.target_field_mapping.items():
+                # what should happen with missing fields? Right now None is skipped
+                # change this to get_dotted_field_value_with_missing
+                items_to_add[mapping_target_field] = get_dotted_field_value(
+                    content, mapping_source_field
+                )
+
+        return items_to_add
+
+    def add(self, event: dict) -> dict:
         """Returns the fields to add"""
         config = typing.cast(GenericAdderRule.Config, self._config)
-        return config.add
+
+        if config.add_from_file is not None:
+            return config.add
+
+        assert config.add_from_url is not None
+        return self._dynamic_add_from_url(event)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -116,7 +116,7 @@ class AddFromUrlConfig:
 
     def __attrs_post_init__(self) -> None:
         if not self.target_field and not self.target_field_mapping:
-            raise ValueError("add_from_url requires target_field or target_field_mapping")
+            raise ValueError("adding values from url requires target_field or target_field_mapping")
 
 
 def _convert_add_from_url(
@@ -149,15 +149,13 @@ class GenericAdderRule(FieldManagerRule):
         """Contains a dictionary of field names and values that should be added.
         If dot notation is being used, then all fields on the path are being
         automatically created."""
-        add_from_file: list | None = field(
-            validator=validators.optional(
-                validators.deep_iterable(
-                    iterable_validator=validators.instance_of(list),
-                    member_validator=validators.instance_of(str),
-                )
+        add_from_file: list[str] = field(
+            validator=validators.deep_iterable(
+                iterable_validator=validators.instance_of(list),
+                member_validator=validators.instance_of(str),
             ),
-            converter=lambda x: x if x is None or isinstance(x, list) else [x],
-            default=None,
+            converter=lambda x: x if isinstance(x, list) else [x],
+            factory=list,
             eq=False,
         )
         """Contains the path or url to YML file that contains a dictionary of field names
@@ -236,21 +234,18 @@ class GenericAdderRule(FieldManagerRule):
                 )
 
             # Eagerly loaded from file
-            if self.add_from_file:
-                for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
-                    getter = GetterFactory.from_string(add_file)
-                    if isinstance(getter, RefreshableGetter):
-                        # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
-                        getter.add_callback(
-                            f"generic_adder:{self.id}:{add_file}", self._refresh_add
-                        )
-                    self._add_from_path()
+            for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
+                getter = GetterFactory.from_string(add_file)
+                if isinstance(getter, RefreshableGetter):
+                    # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
+                    getter.add_callback(f"generic_adder:{self.id}:{add_file}", self._refresh_add)
+                self._add_from_path()
 
         def _add_from_path(self):
             """Reads add fields from file"""
             missing_files = []
-            assert self.add_from_file is not None
-            for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
+
+            for add_file in self.add_from_file:
                 try:
                     add_dict = GetterFactory.from_string(add_file).get_yaml()
                 except FileNotFoundError:
@@ -343,6 +338,7 @@ class GenericAdderRule(FieldManagerRule):
                 deduplication_key=(tag, dynamic_resolved, id(self)),
                 fnc_args=[dynamic_resolved],
             )
+
         else:
             RefreshableGetter.keep_alive_for_target(dynamic_resolved)
             content = self._dynamic_content[dynamic_resolved]

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -203,22 +203,20 @@ class GenericAdderRule(FieldManagerRule):
         def __attrs_post_init__(self):
             self._base_add = copy.deepcopy(self.add)
 
-            if (
-                self.add_from_file is not None or len(self.add) > 0
-            ) and self.add_from_url is not None:
+            if (self.add_from_file or self.add) and self.add_from_url is not None:
                 raise ValueError(
                     "only one of add_from_file + add or add_from_url is allowed per GenericAdder rule"
                 )
 
-            if not self.add and self.add_from_file is None and self.add_from_url is None:
+            if not self.add and not self.add_from_file and self.add_from_url is None:
                 raise ValueError(
                     "one of add, add_from_file or add_from_url is neccessary per GenericAdder rule"
                 )
 
             if (
                 self.add_from_url is not None
-                and self.add_from_url.target_field is not None
-                and len(self.add_from_url.target_field_mapping) > 0
+                and self.add_from_url.target_field
+                and self.add_from_url.target_field_mapping
             ):
                 raise ValueError(
                     "only one of target_field or target_field_mapping is allowed per GenericAdder rule"
@@ -226,8 +224,8 @@ class GenericAdderRule(FieldManagerRule):
 
             if (
                 self.add_from_url is not None
-                and self.add_from_url.target_field is None
-                and len(self.add_from_url.target_field_mapping) <= 0
+                and not self.add_from_url.target_field
+                and not self.add_from_url.target_field_mapping
             ):
                 raise ValueError(
                     "one of target_field or target_field_mapping is neccessary per GenericAdder rule"
@@ -375,7 +373,7 @@ class GenericAdderRule(FieldManagerRule):
         """Returns the fields to add"""
         config = typing.cast(GenericAdderRule.Config, self._config)
 
-        if config.add_from_file is not None or len(config.add) > 0:
+        if config.add_from_file or config.add:
             return config.add
 
         assert config.add_from_url is not None

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -83,6 +83,7 @@ In the following example two files are being used, but only the first existing f
 # pylint: enable=anomalous-backslash-in-string
 
 import copy
+import os
 import typing
 
 from attrs import define, field, validators
@@ -91,9 +92,8 @@ from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.converters import convert_from_dict
-from logprep.util.dotted_template import DottedTemplate
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
-from logprep.util.helper import FieldValue, get_dotted_field_value
+from logprep.util.helper import DottedTemplate, FieldValue, get_dotted_field_value
 
 
 @define(kw_only=True, frozen=True)
@@ -106,14 +106,12 @@ class AddFromUrlConfig:
         default=None, validator=validators.optional(validators.instance_of(str))
     )
 
-    target_field_mapping: dict[str, str] | None = field(
-        validator=validators.optional(
-            validators.deep_mapping(
-                key_validator=validators.instance_of(str),
-                value_validator=validators.instance_of(str),
-            )
+    target_field_mapping: dict[str, str] = field(
+        validator=validators.deep_mapping(
+            key_validator=validators.instance_of(str),
+            value_validator=validators.instance_of(str),
         ),
-        default=None,
+        factory=dict,
     )
 
     def __attrs_post_init__(self) -> None:
@@ -184,13 +182,7 @@ class GenericAdderRule(FieldManagerRule):
 
         add_from_url: AddFromUrlConfig | None = field(
             default=None,
-            validator=validators.optional(
-                validators.instance_of(AddFromUrlConfig)
-                # validators.deep_iterable(
-                #     iterable_validator=validators.instance_of(list),
-                #     member_validator=validators.instance_of(AddFromUrlConfig),
-                # )
-            ),
+            validator=validators.optional(validators.instance_of(AddFromUrlConfig)),
             converter=_convert_add_from_url,
         )
 
@@ -214,7 +206,7 @@ class GenericAdderRule(FieldManagerRule):
             self._base_add = copy.deepcopy(self.add)
 
             if (
-                self.add_from_file is not None or self.add is not None
+                self.add_from_file is not None or len(self.add) > 0
             ) and self.add_from_url is not None:
                 raise ValueError(
                     "only one of add_from_file + add or add_from_url is allowed per GenericAdder rule"
@@ -228,7 +220,7 @@ class GenericAdderRule(FieldManagerRule):
             if (
                 self.add_from_url is not None
                 and self.add_from_url.target_field is not None
-                and self.add_from_url.target_field_mapping is not None
+                and len(self.add_from_url.target_field_mapping) > 0
             ):
                 raise ValueError(
                     "only one of target_field or target_field_mapping is allowed per GenericAdder rule"
@@ -237,7 +229,7 @@ class GenericAdderRule(FieldManagerRule):
             if (
                 self.add_from_url is not None
                 and self.add_from_url.target_field is None
-                and self.add_from_url.target_field_mapping is None
+                and len(self.add_from_url.target_field_mapping) <= 0
             ):
                 raise ValueError(
                     "one of target_field or target_field_mapping is neccessary per GenericAdder rule"
@@ -284,19 +276,35 @@ class GenericAdderRule(FieldManagerRule):
         super().__init__(filter_rule, config, processor_name)
         self._dynamic_content: dict[str, FieldValue] = {}
         self._callback_tag = ""
+        self._is_dynamic: bool = False
+        self._dynamic_template: DottedTemplate
+        self._dynamic_identifiers: tuple[str, ...] = ()
 
-    def set_job_tag(self, job_tag: str) -> None:
+    def init_generic_adder(self, job_tag: str) -> None:
         self._callback_tag = job_tag
+
+        config = typing.cast(GenericAdderRule.Config, self._config)
+        if config.add_from_file or config.add:
+            return
+
+        assert config.add_from_url is not None
+
+        base_template = DottedTemplate(config.add_from_url.url)
+        resolved_template = DottedTemplate(base_template.safe_substitute({**os.environ}))
+        self._dynamic_template = resolved_template
+        self._dynamic_identifiers = tuple(resolved_template.get_identifiers())
+
+        if len(self._dynamic_identifiers) > 0:
+            self._is_dynamic = True
 
     def _dynamic_add_from_url(self, event: dict) -> dict[str, FieldValue]:
         config = typing.cast(GenericAdderRule.Config, self._config)
 
         assert config.add_from_url
 
-        dynamic_path_template = DottedTemplate(config.add_from_url.url)
         key_val = {
             identifier: get_dotted_field_value(event, identifier)
-            for identifier in dynamic_path_template.get_identifiers()
+            for identifier in self._dynamic_identifiers
         }
         for identifier, val in key_val.items():
             if val is None:
@@ -309,7 +317,7 @@ class GenericAdderRule(FieldManagerRule):
                 )
             pass
 
-        dynamic_resolved = dynamic_path_template.substitute(key_val)
+        dynamic_resolved = self._dynamic_template.substitute(key_val)
         content: FieldValue | None = None
         if dynamic_resolved not in self._dynamic_content:
             http_getter = GetterFactory.from_string(dynamic_resolved)
@@ -320,9 +328,21 @@ class GenericAdderRule(FieldManagerRule):
             content = http_getter.get_collection()
             self._dynamic_content[dynamic_resolved] = content
 
-            # Get tag here
-            # Add update callback
-            # Add cleanup callback
+            tag = self._callback_tag
+
+            http_getter.add_callback(
+                tag,
+                self._update_dynamic_content,
+                deduplication_key=(tag, dynamic_resolved, id(self)),
+                fnc_args=[http_getter, dynamic_resolved],
+            )
+
+            http_getter.add_cleanup_callback(
+                tag,
+                self._cleanup,
+                deduplication_key=(tag, dynamic_resolved, id(self)),
+                fnc_args=[dynamic_resolved],
+            )
         else:
             RefreshableGetter.keep_alive_for_target(dynamic_resolved)
             content = self._dynamic_content[dynamic_resolved]
@@ -348,11 +368,18 @@ class GenericAdderRule(FieldManagerRule):
 
         return items_to_add
 
+    def _update_dynamic_content(self, http_getter: HttpGetter, resolved_uri: str):
+        content = http_getter.get_collection()
+        self._dynamic_content[resolved_uri] = content
+
+    def _cleanup(self, resolved_uri: str):
+        self._dynamic_content.pop(resolved_uri, None)
+
     def add(self, event: dict) -> dict:
         """Returns the fields to add"""
         config = typing.cast(GenericAdderRule.Config, self._config)
 
-        if config.add_from_file is not None:
+        if config.add_from_file is not None or len(config.add) > 0:
             return config.add
 
         assert config.add_from_url is not None

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -80,7 +80,7 @@ In the following example two files are being used, but only the first existing f
 """
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 
 from attrs import define, field, validators
 
@@ -475,12 +475,14 @@ class GenericAdderRule(Rule):
     def _cleanup(self, source: _UriSource, resolved_uri: str) -> None:
         source.content_by_uri.pop(resolved_uri, None)
 
-    def add(self, event: dict) -> dict:
-        """Returns the fields to add"""
-        items_to_add: dict[str, FieldValue] = dict(self.config.add)
+    def additions(self, event: dict) -> Iterator[dict[str, FieldValue]]:
+        if self.config.add:
+            yield self.config.add
 
         for source in self._uri_sources:
             content = self._content_for_source(source, event)
-            items_to_add.update(self._content_to_items_to_add(source.config, content))
+            yield self._content_to_items_to_add(source.config, content)
 
-        return items_to_add
+    def add(self, event: dict) -> dict:
+        """Returns the fields to add"""
+        return {key: value for items in self.additions(event) for key, value in items.items()}

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -247,7 +247,7 @@ class GenericAdderRule(FieldManagerRule):
 
     def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
         super().__init__(filter_rule, config, processor_name)
-        self._chached_add_content: dict[str, FieldValue] = {}
+        self._cached_add_content: dict[str, FieldValue] = {}
         self._callback_tag = ""
         self._is_dynamic: bool = False
         self._dynamic_template: DottedTemplate
@@ -262,7 +262,6 @@ class GenericAdderRule(FieldManagerRule):
             for add_file in self.config.add_from_file:
                 getter = GetterFactory.from_string(add_file)
                 if isinstance(getter, RefreshableGetter):
-                    # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
                     getter.add_callback(
                         job_tag,
                         self.config._refresh_add,
@@ -274,23 +273,23 @@ class GenericAdderRule(FieldManagerRule):
         assert self.config.add_from_url is not None
 
         base_template = DottedTemplate(self.config.add_from_url.url)
-        resolved_template = DottedTemplate(base_template.safe_substitute({**ENV_VARS}))
+        resolved_template = DottedTemplate(base_template.safe_substitute(ENV_VARS))
         self._dynamic_template = resolved_template
         self._dynamic_identifiers = tuple(resolved_template.get_identifiers())
 
         if not self._dynamic_identifiers:
             static_uri = resolved_template.substitute()
-            http_getter = GetterFactory.from_string(static_uri)
+            getter = GetterFactory.from_string(static_uri)
 
-            assert isinstance(http_getter, HttpGetter)
+            assert isinstance(getter, RefreshableGetter)
 
-            self._update_static_content(http_getter, static_uri)
+            self._update_static_content(getter, static_uri)
 
-            http_getter.add_callback(
+            getter.add_callback(
                 self._callback_tag,
                 self._update_static_content,
                 deduplication_key=(self._callback_tag, static_uri, id(self)),
-                fnc_args=[http_getter, static_uri],
+                fnc_args=[getter, static_uri],
             )
 
             self._static_uri = static_uri
@@ -320,25 +319,25 @@ class GenericAdderRule(FieldManagerRule):
 
         dynamic_resolved = self._dynamic_template.substitute(key_val)
         content: FieldValue = None
-        if dynamic_resolved not in self._chached_add_content:
-            http_getter = GetterFactory.from_string(dynamic_resolved)
-            assert isinstance(http_getter, HttpGetter)
+        if dynamic_resolved not in self._cached_add_content:
+            getter = GetterFactory.from_string(dynamic_resolved)
+            assert isinstance(getter, RefreshableGetter)
 
-            http_getter.keep_alive()
+            getter.keep_alive()
 
-            content = http_getter.get_collection()
-            self._chached_add_content[dynamic_resolved] = content
+            content = getter.get_collection()
+            self._cached_add_content[dynamic_resolved] = content
 
             tag = self._callback_tag
 
-            http_getter.add_callback(
+            getter.add_callback(
                 tag,
-                self._update_dynamic_content,
+                self._fetch_and_cache_uri,
                 deduplication_key=(tag, dynamic_resolved, id(self)),
-                fnc_args=[http_getter, dynamic_resolved],
+                fnc_args=[getter, dynamic_resolved],
             )
 
-            http_getter.add_cleanup_callback(
+            getter.add_cleanup_callback(
                 tag,
                 self._cleanup,
                 deduplication_key=(tag, dynamic_resolved, id(self)),
@@ -346,7 +345,7 @@ class GenericAdderRule(FieldManagerRule):
             )
         else:
             RefreshableGetter.keep_alive_for_target(dynamic_resolved)
-            content = self._chached_add_content[dynamic_resolved]
+            content = self._cached_add_content[dynamic_resolved]
 
         return self._content_to_items_to_add(content)
 
@@ -355,20 +354,20 @@ class GenericAdderRule(FieldManagerRule):
 
         return {self.config.add_from_url.target_field: content}
 
-    def _update_dynamic_content(self, http_getter: HttpGetter, resolved_uri: str):
-        content = http_getter.get_collection()
-        self._chached_add_content[resolved_uri] = content
+    def _fetch_and_cache_uri(self, getter: RefreshableGetter, resolved_uri: str):
+        content = getter.get_collection()
+        self._cached_add_content[resolved_uri] = content
 
-    def _update_static_content(self, getter: HttpGetter, uri: str) -> None:
+    def _update_static_content(self, getter: RefreshableGetter, uri: str) -> None:
         try:
-            self._update_dynamic_content(getter, uri)
+            self._fetch_and_cache_uri(getter, uri)
         except Exception as error:
             self.mark_failed(error)
         else:
             self.clear_failed()
 
     def _cleanup(self, resolved_uri: str):
-        self._chached_add_content.pop(resolved_uri, None)
+        self._cached_add_content.pop(resolved_uri, None)
 
     def add(self, event: dict) -> dict:
         """Returns the fields to add"""
@@ -377,7 +376,7 @@ class GenericAdderRule(FieldManagerRule):
 
         if not self._is_dynamic:
             assert self._static_uri
-            return self._content_to_items_to_add(self._chached_add_content[self._static_uri])
+            return self._content_to_items_to_add(self._cached_add_content[self._static_uri])
         else:
             assert self.config.add_from_url is not None
             return self._dynamic_add_from_url(event)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -80,11 +80,8 @@ In the following example two files are being used, but only the first existing f
    :noindex:
 """
 
-# pylint: enable=anomalous-backslash-in-string
-
 import copy
 import logging
-import os
 import typing
 
 from attrs import define, field, validators
@@ -108,13 +105,24 @@ logger = logging.getLogger("GenericAdder")
 
 @define(kw_only=True, frozen=True)
 class AddFromUrlConfig:
+    """Configuration for adding values loaded from an HTTP(S) URL."""
+
     url: str = field(
         validator=[validators.instance_of(str), validators.matches_re(r"^https?://.+")]
     )
+    """The URL to load values from.
+
+    Environment variables and dotted event fields can be inserted with placeholders such as
+    :code:`${TENANT}` and :code:`${tenant.id}`.
+    """
 
     target_field: str | None = field(
         default=None, validator=validators.optional(validators.instance_of(str))
     )
+    """The dotted event field into which the complete response is written.
+
+    This is mutually exclusive with :attr:`target_field_mapping`.
+    """
 
     target_field_mapping: dict[str, str] = field(
         validator=validators.deep_mapping(
@@ -123,6 +131,10 @@ class AddFromUrlConfig:
         ),
         factory=dict,
     )
+    """A mapping of dotted response fields to dotted target fields in the event.
+
+    This is mutually exclusive with :attr:`target_field`.
+    """
 
     def __attrs_post_init__(self) -> None:
         if not self.target_field and not self.target_field_mapping:
@@ -166,6 +178,10 @@ class GenericAdderRule(FieldManagerRule):
             ),
             converter=lambda x: x if isinstance(x, list) else [x],
             factory=list,
+            # Eq false in this case means that this is not taken into account when comparing two Configs,
+            # that is neccessary in this case because on init this will be loaded into add,
+            # and when comparing two rules, we dont care if whats to add came from a file or is written inline
+            # but we do care if whatever gets added is the same
             eq=False,
         )
         """Contains the path or url to YML file that contains a dictionary of field names
@@ -192,7 +208,13 @@ class GenericAdderRule(FieldManagerRule):
             default=None,
             validator=validators.optional(validators.instance_of(AddFromUrlConfig)),
             converter=_convert_add_from_url,
+            # Explicitly set it to true here to show the difference between this and add_from_file
+            eq=True,
         )
+        """Configuration for loading values from an HTTP(S) URL and adding them to the event.
+
+        This is mutually exclusive with :attr:`add` and :attr:`add_from_file`.
+        """
 
         only_first_existing_file: bool = field(
             validator=validators.instance_of(bool), default=False, eq=False
@@ -203,8 +225,6 @@ class GenericAdderRule(FieldManagerRule):
 
         _base_add: dict = field(default={}, eq=False)
         """Stores original add fields (as provided in the config) for future refreshes of getters"""
-
-        # pylint: enable=anomalous-backslash-in-string
 
         def _refresh_add(self):
             self.add = copy.deepcopy(self._base_add)
@@ -242,7 +262,7 @@ class GenericAdderRule(FieldManagerRule):
                 )
 
             # Eagerly loaded from file
-            for add_file in self.add_from_file:  # pylint: disable=not-an-iterable
+            for add_file in self.add_from_file:
                 getter = GetterFactory.from_string(add_file)
                 if isinstance(getter, RefreshableGetter):
                     # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
@@ -277,7 +297,7 @@ class GenericAdderRule(FieldManagerRule):
 
     def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
         super().__init__(filter_rule, config, processor_name)
-        self._dynamic_content: dict[str, FieldValue] = {}
+        self._chached_add_content: dict[str, FieldValue] = {}
         self._callback_tag = ""
         self._is_dynamic: bool = False
         self._dynamic_template: DottedTemplate
@@ -287,21 +307,17 @@ class GenericAdderRule(FieldManagerRule):
     def init_generic_adder(self, job_tag: str) -> None:
         self._callback_tag = job_tag
 
-        config = typing.cast(GenericAdderRule.Config, self._config)
-        if config.add_from_file or config.add:
+        if self.config.add_from_file or self.config.add:
             return
 
-        assert config.add_from_url is not None
+        assert self.config.add_from_url is not None
 
-        base_template = DottedTemplate(config.add_from_url.url)
+        base_template = DottedTemplate(self.config.add_from_url.url)
         resolved_template = DottedTemplate(base_template.safe_substitute({**ENV_VARS}))
         self._dynamic_template = resolved_template
         self._dynamic_identifiers = tuple(resolved_template.get_identifiers())
 
-        if len(self._dynamic_identifiers) > 0:
-            self._is_dynamic = True
-
-        if not self._is_dynamic:
+        if not self._dynamic_identifiers:
             static_uri = resolved_template.substitute()
             http_getter = GetterFactory.from_string(static_uri)
 
@@ -317,12 +333,15 @@ class GenericAdderRule(FieldManagerRule):
             )
 
             self._static_uri = static_uri
+        else:
+            self._is_dynamic = True
 
-    def _dynamic_add_from_url(self, event: dict) -> dict[str, FieldValue]:
-        config = typing.cast(GenericAdderRule.Config, self._config)
+    @property
+    def config(self) -> Config:
+        """Return typed config"""
+        return typing.cast(GenericAdderRule.Config, self._config)
 
-        assert config.add_from_url
-
+    def _dynamic_add_from_url(self, event: dict[str, FieldValue]) -> dict[str, FieldValue]:
         key_val = {
             identifier: get_dotted_field_value(event, identifier)
             for identifier in self._dynamic_identifiers
@@ -340,14 +359,14 @@ class GenericAdderRule(FieldManagerRule):
 
         dynamic_resolved = self._dynamic_template.substitute(key_val)
         content: FieldValue = None
-        if dynamic_resolved not in self._dynamic_content:
+        if dynamic_resolved not in self._chached_add_content:
             http_getter = GetterFactory.from_string(dynamic_resolved)
             assert isinstance(http_getter, HttpGetter)
 
             http_getter.keep_alive()
 
             content = http_getter.get_collection()
-            self._dynamic_content[dynamic_resolved] = content
+            self._chached_add_content[dynamic_resolved] = content
 
             tag = self._callback_tag
 
@@ -366,32 +385,33 @@ class GenericAdderRule(FieldManagerRule):
             )
         else:
             RefreshableGetter.keep_alive_for_target(dynamic_resolved)
-            content = self._dynamic_content[dynamic_resolved]
+            content = self._chached_add_content[dynamic_resolved]
 
         return self._content_to_items_to_add(content)
 
     def _content_to_items_to_add(self, content: FieldValue):
         items_to_add: dict[str, FieldValue] = {}
 
-        config = typing.cast(GenericAdderRule.Config, self._config)
-        assert config.add_from_url
+        assert self.config.add_from_url
 
-        if config.add_from_url.target_field:
-            items_to_add[config.add_from_url.target_field] = content
+        if self.config.add_from_url.target_field:
+            items_to_add[self.config.add_from_url.target_field] = content
         else:
-            assert config.add_from_url.target_field_mapping is not None
+            assert self.config.add_from_url.target_field_mapping is not None
 
             if not isinstance(content, dict):
-                raise ValueError("add_from_url.target_field_mapping requires a mapping response")
+                raise ValueError(
+                    f"add_from_url.target_field_mapping requires a mapping response, got {content}"
+                )
 
             for (
                 mapping_source_field,
                 mapping_target_field,
-            ) in config.add_from_url.target_field_mapping.items():
+            ) in self.config.add_from_url.target_field_mapping.items():
                 item = get_dotted_field_value_with_missing(content, mapping_source_field)
                 if item is MISSING:
                     logger.warning(
-                        "could not add source_field: %s for target_field: %s because was missing",
+                        "could not add source_field %s for target_field %s because it is missing",
                         mapping_source_field,
                         mapping_target_field,
                     )
@@ -403,7 +423,7 @@ class GenericAdderRule(FieldManagerRule):
 
     def _update_dynamic_content(self, http_getter: HttpGetter, resolved_uri: str):
         content = http_getter.get_collection()
-        self._dynamic_content[resolved_uri] = content
+        self._chached_add_content[resolved_uri] = content
 
     def _update_static_content(self, getter: HttpGetter, uri: str) -> None:
         try:
@@ -414,18 +434,16 @@ class GenericAdderRule(FieldManagerRule):
             self.clear_failed()
 
     def _cleanup(self, resolved_uri: str):
-        self._dynamic_content.pop(resolved_uri, None)
+        self._chached_add_content.pop(resolved_uri, None)
 
     def add(self, event: dict) -> dict:
         """Returns the fields to add"""
-        config = typing.cast(GenericAdderRule.Config, self._config)
-
-        if config.add_from_file or config.add:
-            return config.add
+        if self.config.add:
+            return self.config.add
 
         if not self._is_dynamic:
             assert self._static_uri
-            return self._content_to_items_to_add(self._dynamic_content[self._static_uri])
-
-        assert config.add_from_url is not None
-        return self._dynamic_add_from_url(event)
+            return self._content_to_items_to_add(self._chached_add_content[self._static_uri])
+        else:
+            assert self.config.add_from_url is not None
+            return self._dynamic_add_from_url(event)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -241,7 +241,7 @@ class GenericAdderRule(Rule):
 
     def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
         super().__init__(filter_rule, config, processor_name)
-        self._callback_tag = ""
+        self._callback_tag: str | None = None
         self._uri_sources: list[_UriSource] = []
 
     def init_generic_adder(self, job_tag: str) -> None:
@@ -275,6 +275,10 @@ class GenericAdderRule(Rule):
 
             try:
                 self._init_static_source(source)
+                if source.error is not None:
+                    raise InvalidRuleDefinitionError(
+                        f"Could not load generic-adder URI {spec!r}: {source.error}"
+                    ) from source.error
             except InvalidRuleDefinitionError as error:
                 self._uri_sources.pop()
 

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -99,7 +99,10 @@ from logprep.util.helper import (
 
 @define(kw_only=True, frozen=True)
 class UriConfig:
-    """Configuration for adding values loaded from an URI, which can be HTTP(S) URLs or file paths"""
+    """
+    Configuration for adding values loaded from an URI,
+    which can be HTTP(S) URLs or file paths
+    """
 
     uri: str = field(validator=validators.and_(validators.instance_of(str), validators.min_len(1)))
     """The URI to load values from.
@@ -320,25 +323,15 @@ class GenericAdderRule(Rule):
                     f"only_first_existing_file does not support event-dependent paths: {config!r}"
                 )
 
-            self._uri_sources.append(source)
-
             try:
                 self._init_static_source(source, raise_on_error=True)
-                if source.error is not None:
-                    raise InvalidRuleDefinitionError(
-                        f"Could not load generic_adder URI {config.uri!r}: {source.error}"
-                    ) from source.error
             except InvalidRuleDefinitionError as error:
-                self._uri_sources.pop()
-
                 if isinstance(error.__cause__, FileNotFoundError):
                     missing_files.append(config.uri)
                     continue
-
                 raise
-
+            self._uri_sources.append(source)
             return
-
         raise InvalidRuleDefinitionError(f"None of the configured files exist: {missing_files!r}")
 
     def _create_uri_source(self, config: UriConfig) -> _UriSource:
@@ -354,23 +347,23 @@ class GenericAdderRule(Rule):
         )
 
     def _init_static_source(self, source: _UriSource, raise_on_error: bool):
-        resolved_uri = source.template.substitute()
-        getter = GetterFactory.from_string(resolved_uri)
+        assert source.static_uri is not None
+        getter = GetterFactory.from_string(source.static_uri)
 
         assert self._callback_tag
 
-        self._update_static_content(source, getter, resolved_uri)
+        self._update_static_content(source, getter, source.static_uri)
         if source.error and raise_on_error:
             raise InvalidRuleDefinitionError(
-                f"Could not load generic_adder URI {resolved_uri!r}: {source.error}"
+                f"Could not load generic_adder URI {source.static_uri!r}: {source.error}"
             ) from source.error
 
         if isinstance(getter, RefreshableGetter):
             getter.add_callback(
                 self._callback_tag,
                 self._update_static_content,
-                deduplication_key=(self._callback_tag, resolved_uri, id(source)),
-                fnc_args=[source, getter, resolved_uri],
+                deduplication_key=(self._callback_tag, source.static_uri, id(source)),
+                fnc_args=[source, getter, source.static_uri],
             )
 
     def _get_cached_or_dynamic_content(
@@ -389,7 +382,6 @@ class GenericAdderRule(Rule):
                 raise ValueError(
                     f"value for generic adder field {identifier!r} is not a scalar value"
                 )
-            pass
 
         resolved_uri = source.template.substitute(values)
 
@@ -442,20 +434,18 @@ class GenericAdderRule(Rule):
         if isinstance(content, dict):
             return content
 
-        raise ValueError(
-            f"URI source {config.uri!r} without target_field must contain a mapping, got {type(content).__name__}"
-        )
+        raise ValueError(f"""URI source {config.uri!r} without target_field must contain a mapping,
+            got {type(content).__name__}""")
 
     def _fetch_and_cache_uri(self, source: _UriSource, getter: Getter, resolved_uri: str):
         content = getter.get_collection(content_field=self.config.content_field)
-
         source.content_by_uri[resolved_uri] = content
         return content
 
     def _update_static_content(self, source: _UriSource, getter: Getter, uri: str) -> None:
         try:
             self._fetch_and_cache_uri(source, getter, uri)
-        except Exception as error:
+        except Exception as error:  # pylint: disable=broad-except
             source.error = error
         else:
             source.error = None
@@ -470,12 +460,12 @@ class GenericAdderRule(Rule):
         elif len(errors) == 1:
             self.mark_failed(errors[0])
         else:
-            self.mark_failed(ExceptionGroup("generic-adder URI loading failed", errors))
+            self.mark_failed(ExceptionGroup("generic_adder URI loading failed", errors))
 
     def _cleanup(self, source: _UriSource, resolved_uri: str) -> None:
         source.content_by_uri.pop(resolved_uri, None)
 
-    def additions(self, event: dict) -> Iterator[dict[str, FieldValue]]:
+    def additions(self, event: dict[str, FieldValue]) -> Iterator[dict[str, FieldValue]]:
         if self.config.add:
             yield self.config.add
 
@@ -483,6 +473,6 @@ class GenericAdderRule(Rule):
             content = self._content_for_source(source, event)
             yield self._content_to_items_to_add(source.config, content)
 
-    def add(self, event: dict) -> dict:
+    def add(self, event: dict[str, FieldValue]) -> dict[str, FieldValue]:
         """Returns the fields to add"""
         return {key: value for items in self.additions(event) for key, value in items.items()}

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -93,6 +93,7 @@ from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.converters import convert_from_dict
+from logprep.util.environ import ENV_VARS
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
 from logprep.util.helper import (
     MISSING,
@@ -281,6 +282,7 @@ class GenericAdderRule(FieldManagerRule):
         self._is_dynamic: bool = False
         self._dynamic_template: DottedTemplate
         self._dynamic_identifiers: tuple[str, ...] = ()
+        self._static_uri: str | None = None
 
     def init_generic_adder(self, job_tag: str) -> None:
         self._callback_tag = job_tag
@@ -292,12 +294,29 @@ class GenericAdderRule(FieldManagerRule):
         assert config.add_from_url is not None
 
         base_template = DottedTemplate(config.add_from_url.url)
-        resolved_template = DottedTemplate(base_template.safe_substitute({**os.environ}))
+        resolved_template = DottedTemplate(base_template.safe_substitute({**ENV_VARS}))
         self._dynamic_template = resolved_template
         self._dynamic_identifiers = tuple(resolved_template.get_identifiers())
 
         if len(self._dynamic_identifiers) > 0:
             self._is_dynamic = True
+
+        if not self._is_dynamic:
+            static_uri = resolved_template.substitute()
+            http_getter = GetterFactory.from_string(static_uri)
+
+            assert isinstance(http_getter, HttpGetter)
+
+            self._update_static_content(http_getter, static_uri)
+
+            http_getter.add_callback(
+                self._callback_tag,
+                self._update_static_content,
+                deduplication_key=(self._callback_tag, static_uri, id(self)),
+                fnc_args=[http_getter, static_uri],
+            )
+
+            self._static_uri = static_uri
 
     def _dynamic_add_from_url(self, event: dict) -> dict[str, FieldValue]:
         config = typing.cast(GenericAdderRule.Config, self._config)
@@ -311,16 +330,16 @@ class GenericAdderRule(FieldManagerRule):
         for identifier, val in key_val.items():
             if val is None:
                 raise ValueError(
-                    f"missing event field {identifier!r} for dynamic list comparison path"
+                    f"missing event field {identifier!r} for dynamic generic adder path"
                 )
             if not isinstance(val, (str, int)):
                 raise ValueError(
-                    f"value for list comparison field {identifier!r} is not a scalar value"
+                    f"value for generic adder field {identifier!r} is not a scalar value"
                 )
             pass
 
         dynamic_resolved = self._dynamic_template.substitute(key_val)
-        content: FieldValue | None = None
+        content: FieldValue = None
         if dynamic_resolved not in self._dynamic_content:
             http_getter = GetterFactory.from_string(dynamic_resolved)
             assert isinstance(http_getter, HttpGetter)
@@ -345,20 +364,26 @@ class GenericAdderRule(FieldManagerRule):
                 deduplication_key=(tag, dynamic_resolved, id(self)),
                 fnc_args=[dynamic_resolved],
             )
-
         else:
             RefreshableGetter.keep_alive_for_target(dynamic_resolved)
             content = self._dynamic_content[dynamic_resolved]
 
+        return self._content_to_items_to_add(content)
+
+    def _content_to_items_to_add(self, content: FieldValue):
         items_to_add: dict[str, FieldValue] = {}
+
+        config = typing.cast(GenericAdderRule.Config, self._config)
+        assert config.add_from_url
 
         if config.add_from_url.target_field:
             items_to_add[config.add_from_url.target_field] = content
         else:
             assert config.add_from_url.target_field_mapping is not None
 
-            # TODO: Check this differently, what should this be?
-            assert isinstance(content, dict)
+            if not isinstance(content, dict):
+                raise ValueError("add_from_url.target_field_mapping requires a mapping response")
+
             for (
                 mapping_source_field,
                 mapping_target_field,
@@ -380,6 +405,14 @@ class GenericAdderRule(FieldManagerRule):
         content = http_getter.get_collection()
         self._dynamic_content[resolved_uri] = content
 
+    def _update_static_content(self, getter: HttpGetter, uri: str) -> None:
+        try:
+            self._update_dynamic_content(getter, uri)
+        except Exception as error:
+            self.mark_failed(error)
+        else:
+            self.clear_failed()
+
     def _cleanup(self, resolved_uri: str):
         self._dynamic_content.pop(resolved_uri, None)
 
@@ -389,6 +422,10 @@ class GenericAdderRule(FieldManagerRule):
 
         if config.add_from_file or config.add:
             return config.add
+
+        if not self._is_dynamic:
+            assert self._static_uri
+            return self._content_to_items_to_add(self._dynamic_content[self._static_uri])
 
         assert config.add_from_url is not None
         return self._dynamic_add_from_url(event)

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -80,17 +80,17 @@ In the following example two files are being used, but only the first existing f
    :noindex:
 """
 
-import copy
 import typing
+from collections.abc import Sequence
 
 from attrs import define, field, validators
 
+from logprep.abc.getter import Getter
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import InvalidRuleDefinitionError, Rule
-from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.converters import convert_from_dict
 from logprep.util.environ import ENV_VARS
-from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
+from logprep.util.getter import GetterFactory, RefreshableGetter
 from logprep.util.helper import (
     DottedTemplate,
     FieldValue,
@@ -99,29 +99,46 @@ from logprep.util.helper import (
 
 
 @define(kw_only=True, frozen=True)
-class AddFromUrlConfig:
+class UriTargetConfig:
     """Configuration for adding values loaded from an HTTP(S) URL."""
 
-    url: str = field(
-        validator=[validators.instance_of(str), validators.matches_re(r"^https?://.+")]
-    )
+    uri: str = field(validator=validators.and_(validators.instance_of(str), validators.min_len(1)))
     """The URL to load values from.
 
     Environment variables and dotted event fields can be inserted with placeholders such as
     :code:`${TENANT}` and :code:`${tenant.id}`.
     """
 
-    target_field: str = field(validator=validators.instance_of(str))
+    target_field: str = field(
+        validator=validators.and_(validators.instance_of(str), validators.min_len(1))
+    )
     """The dotted event field into which the complete response is written."""
 
 
-def _convert_add_from_url(
-    value: AddFromUrlConfig | dict | None,
-) -> AddFromUrlConfig | None:
-    if value is None:
-        return None
+UriSpec = str | UriTargetConfig
 
-    return convert_from_dict(AddFromUrlConfig, value)
+
+def _convert_uri_specs(
+    value: UriSpec | dict | Sequence[UriSpec | dict],
+) -> tuple[UriSpec, ...]:
+    if isinstance(value, (str, UriTargetConfig, dict)):
+        values: tuple[UriSpec | dict, ...] = (value,)
+    else:
+        values = tuple(value)
+
+    return tuple(
+        convert_from_dict(UriTargetConfig, item) if isinstance(item, dict) else item
+        for item in values
+    )
+
+
+@define(kw_only=True)
+class _UriSource:
+    spec: UriSpec
+    template: DottedTemplate
+    identifiers: tuple[str, ...]
+    content_by_uri: dict[str, FieldValue] = field(factory=dict)
+    error: Exception | None = None
 
 
 class GenericAdderRule(Rule):
@@ -144,7 +161,7 @@ class GenericAdderRule(Rule):
                 key_validator=validators.instance_of(str),
                 value_validator=validators.instance_of((str, bool, list, dict, int, float)),
             ),
-            default={},
+            factory=dict,
         )
         """Contains a dictionary of field names and values that should be added.
         If dot notation is being used, then all fields on the path are being
@@ -183,16 +200,19 @@ class GenericAdderRule(Rule):
 
         """
 
-        add_from_url: AddFromUrlConfig | None = field(
-            default=None,
-            validator=validators.optional(validators.instance_of(AddFromUrlConfig)),
-            converter=_convert_add_from_url,
+        add_from_uri: tuple[UriSpec, ...] = field(
+            factory=tuple,
+            converter=_convert_uri_specs,
+            validator=validators.deep_iterable(
+                iterable_validator=validators.instance_of(tuple),
+                member_validator=validators.instance_of((str, UriTargetConfig)),
+            ),
             # Explicitly set it to true here to show the difference between this and add_from_file
             eq=True,
         )
         """Configuration for loading values from an HTTP(S) URL and adding them to the event.
 
-        This is mutually exclusive with :attr:`add` and :attr:`add_from_file`.
+        This is mutually exclusive with :attr:`add_from_file`.
         """
 
         only_first_existing_file: bool = field(
@@ -202,102 +222,100 @@ class GenericAdderRule(Rule):
         first existing file by setting :code:`generic_adder.only_first_existing_file: true`.
         In that case, only one file must exist."""
 
-        _base_add: dict = field(default={}, eq=False)
-        """Stores original add fields (as provided in the config) for future refreshes of getters"""
-
-        def _refresh_add(self):
-            self.add = copy.deepcopy(self._base_add)
-            self._add_from_path()
-
         def __attrs_post_init__(self):
-            self._base_add = copy.deepcopy(self.add)
-
-            if (self.add_from_file or self.add) and self.add_from_url is not None:
+            if self.add_from_file and self.add_from_uri:
                 raise ValueError(
-                    "only one of add_from_file + add or add_from_url is allowed per GenericAdder rule"
+                    "Deprecated add_from_file and new add_from_uri cannot both be configured"
                 )
 
-            if not self.add and not self.add_from_file and self.add_from_url is None:
+            if self.add_from_file:
+                self.add_from_uri = tuple(self.add_from_file)
+
+            if self.only_first_existing_file and not self.add_from_file:
                 raise ValueError(
-                    "one of add, add_from_file or add_from_url is neccessary per GenericAdder rule"
+                    "only_first_existing_file is only supported with deprecated add_from_file"
                 )
 
-        def _add_from_path(self):
-            """Reads add fields from file"""
-            missing_files = []
-
-            for add_file in self.add_from_file:
-                try:
-                    add_dict = GetterFactory.from_string(add_file).get_yaml()
-                except FileNotFoundError:
-                    missing_files.append(add_file)
-                    continue
-                if isinstance(add_dict, dict) and all(
-                    isinstance(value, (str, bool, list, int, float)) for value in add_dict.values()
-                ):
-                    self.add = {**self.add, **add_dict}
-                else:
-                    error_msg = (
-                        f"Additions file '{add_file}' must be a dictionary with string values!"
-                    )
-                    raise InvalidRuleDefinitionError(error_msg)
-                if self.only_first_existing_file:
-                    break
-            if missing_files and not self.only_first_existing_file:
-                raise InvalidRuleDefinitionError(
-                    f"The following required files do not exist: '{missing_files}'"
-                )
+            if not self.add and not self.add_from_uri:
+                raise ValueError("one of add or add_from_uri must be configured")
 
     def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
         super().__init__(filter_rule, config, processor_name)
-        self._cached_add_content: dict[str, FieldValue] = {}
         self._callback_tag = ""
-        self._is_dynamic: bool = False
-        self._dynamic_template: DottedTemplate
-        self._dynamic_identifiers: tuple[str, ...] = ()
-        self._static_uri: str | None = None
+        self._uri_sources: list[_UriSource] = []
 
     def init_generic_adder(self, job_tag: str) -> None:
         self._callback_tag = job_tag
+        self._uri_sources.clear()
 
-        if self.config.add_from_file or self.config.add:
-            # Eagerly loaded from file
-            for add_file in self.config.add_from_file:
-                getter = GetterFactory.from_string(add_file)
-                if isinstance(getter, RefreshableGetter):
-                    getter.add_callback(
-                        job_tag,
-                        self.config._refresh_add,
-                        deduplication_key=(self._callback_tag, add_file, id(self)),
-                    )
-                self.config._add_from_path()
+        if self.config.only_first_existing_file:
+            self._init_first_existing_file()
             return
 
-        assert self.config.add_from_url is not None
+        for spec in self.config.add_from_uri:
+            source = self._create_uri_source(spec)
+            self._uri_sources.append(source)
 
-        base_template = DottedTemplate(self.config.add_from_url.url)
-        resolved_template = DottedTemplate(base_template.safe_substitute(ENV_VARS))
-        self._dynamic_template = resolved_template
-        self._dynamic_identifiers = tuple(resolved_template.get_identifiers())
+            if not source.identifiers:
+                self._init_static_source(source)
 
-        if not self._dynamic_identifiers:
-            static_uri = resolved_template.substitute()
-            getter = GetterFactory.from_string(static_uri)
+    def _init_first_existing_file(self) -> None:
+        missing_files: list[str] = []
 
-            assert isinstance(getter, RefreshableGetter)
+        for spec in self.config.add_from_uri:
+            assert isinstance(spec, str)
 
-            self._update_static_content(getter, static_uri)
+            source = self._create_uri_source(spec)
+            if source.identifiers:
+                raise InvalidRuleDefinitionError(
+                    f"only_first_existing_file does not support event-dependent paths: {spec!r}"
+                )
 
+            self._uri_sources.append(source)
+
+            try:
+                self._init_static_source(source)
+            except InvalidRuleDefinitionError as error:
+                self._uri_sources.pop()
+
+                if isinstance(error.__cause__, FileNotFoundError):
+                    missing_files.append(spec)
+                    continue
+
+                raise
+
+            return
+
+        raise InvalidRuleDefinitionError(f"None of the configured files exist: {missing_files!r}")
+
+    def _create_uri_source(self, spec: UriSpec) -> _UriSource:
+        uri = spec.uri if isinstance(spec, UriTargetConfig) else spec
+        template = DottedTemplate(DottedTemplate(uri).safe_substitute(ENV_VARS))
+
+        return _UriSource(
+            spec=spec, template=template, identifiers=tuple(template.get_identifiers())
+        )
+
+    def _init_static_source(self, source: _UriSource):
+        resolved_uri = source.template.substitute()
+        getter = GetterFactory.from_string(resolved_uri)
+
+        if isinstance(getter, RefreshableGetter):
+            self._update_static_content(source, getter, resolved_uri)
             getter.add_callback(
                 self._callback_tag,
                 self._update_static_content,
-                deduplication_key=(self._callback_tag, static_uri, id(self)),
-                fnc_args=[getter, static_uri],
+                deduplication_key=(self._callback_tag, resolved_uri, id(source)),
+                fnc_args=[source, getter, resolved_uri],
             )
+            return
 
-            self._static_uri = static_uri
-        else:
-            self._is_dynamic = True
+        try:
+            self._fetch_and_cache_uri(source, getter, resolved_uri)
+        except (FileNotFoundError, ValueError) as error:
+            raise InvalidRuleDefinitionError(
+                f"Could not load generic-adder URI {resolved_uri!r}: {error}"
+            ) from error
 
     @property
     def overwrite_target(self) -> bool:
@@ -314,15 +332,15 @@ class GenericAdderRule(Rule):
         """Return typed config"""
         return typing.cast(GenericAdderRule.Config, self._config)
 
-    def _dynamic_add_from_url(self, event: dict[str, FieldValue]) -> dict[str, FieldValue]:
-        key_val = {
+    def _dynamic_content(self, source: _UriSource, event: dict[str, FieldValue]) -> FieldValue:
+        values = {
             identifier: get_dotted_field_value(event, identifier)
-            for identifier in self._dynamic_identifiers
+            for identifier in source.identifiers
         }
-        for identifier, val in key_val.items():
+        for identifier, val in values.items():
             if val is None:
                 raise ValueError(
-                    f"missing event field {identifier!r} for dynamic generic adder path"
+                    f"missing event field {identifier!r} for dynamic generic adder URI"
                 )
             if not isinstance(val, (str, int)):
                 raise ValueError(
@@ -330,66 +348,91 @@ class GenericAdderRule(Rule):
                 )
             pass
 
-        dynamic_resolved = self._dynamic_template.substitute(key_val)
-        content: FieldValue = None
-        if dynamic_resolved not in self._cached_add_content:
-            getter = GetterFactory.from_string(dynamic_resolved)
-            assert isinstance(getter, RefreshableGetter)
+        resolved_uri = source.template.substitute(values)
 
-            getter.keep_alive()
+        if resolved_uri in source.content_by_uri:
+            RefreshableGetter.keep_alive_for_target(resolved_uri)
+            return source.content_by_uri[resolved_uri]
 
-            content = getter.get_collection()
-            self._cached_add_content[dynamic_resolved] = content
+        getter = GetterFactory.from_string(resolved_uri)
+        if not isinstance(getter, RefreshableGetter):
+            return getter.get_collection()
 
-            tag = self._callback_tag
+        getter.keep_alive()
+        content = self._fetch_and_cache_uri(source, getter, resolved_uri)
 
-            getter.add_callback(
-                tag,
-                self._fetch_and_cache_uri,
-                deduplication_key=(tag, dynamic_resolved, id(self)),
-                fnc_args=[getter, dynamic_resolved],
-            )
+        key = (self._callback_tag, resolved_uri, id(source))
 
-            getter.add_cleanup_callback(
-                tag,
-                self._cleanup,
-                deduplication_key=(tag, dynamic_resolved, id(self)),
-                fnc_args=[dynamic_resolved],
-            )
-        else:
-            RefreshableGetter.keep_alive_for_target(dynamic_resolved)
-            content = self._cached_add_content[dynamic_resolved]
+        getter.add_callback(
+            self._callback_tag,
+            self._fetch_and_cache_uri,
+            deduplication_key=key,
+            fnc_args=[source, getter, resolved_uri],
+        )
 
-        return self._content_to_items_to_add(content)
+        getter.add_cleanup_callback(
+            self._callback_tag,
+            self._cleanup,
+            deduplication_key=key,
+            fnc_args=[source, resolved_uri],
+        )
 
-    def _content_to_items_to_add(self, content: FieldValue):
-        assert self.config.add_from_url
+        return content
 
-        return {self.config.add_from_url.target_field: content}
+    def _content_for_source(self, source: _UriSource, event: dict[str, FieldValue]) -> FieldValue:
+        if source.identifiers:
+            return self._dynamic_content(source, event)
 
-    def _fetch_and_cache_uri(self, getter: RefreshableGetter, resolved_uri: str):
+        resolved_uri = source.template.substitute()
+        return source.content_by_uri[resolved_uri]
+
+    def _content_to_items_to_add(self, uri: UriSpec, content: FieldValue) -> dict[str, FieldValue]:
+        if isinstance(uri, UriTargetConfig):
+            return {uri.target_field: content}
+
+        if isinstance(content, dict):
+            return dict(content)
+
+        raise ValueError(
+            f"URI source {uri!r} without target_field must contain a mapping, got {type(content).__name__}"
+        )
+
+    def _fetch_and_cache_uri(self, source: _UriSource, getter: Getter, resolved_uri: str):
         content = getter.get_collection()
-        self._cached_add_content[resolved_uri] = content
 
-    def _update_static_content(self, getter: RefreshableGetter, uri: str) -> None:
+        self._content_to_items_to_add(source.spec, content)
+        source.content_by_uri[resolved_uri] = content
+        return content
+
+    def _update_static_content(self, source: _UriSource, getter: Getter, uri: str) -> None:
         try:
-            self._fetch_and_cache_uri(getter, uri)
+            self._fetch_and_cache_uri(source, getter, uri)
         except Exception as error:
-            self.mark_failed(error)
+            source.error = error
         else:
-            self.clear_failed()
+            source.error = None
 
-    def _cleanup(self, resolved_uri: str):
-        self._cached_add_content.pop(resolved_uri, None)
+        self._recompute_failure_state()
+
+    def _recompute_failure_state(self) -> None:
+        errors = [source.error for source in self._uri_sources if source.error is not None]
+
+        if not errors:
+            self.clear_failed()
+        elif len(errors) == 1:
+            self.mark_failed(errors[0])
+        else:
+            self.mark_failed(ExceptionGroup("generic-adder URI loading failed", errors))
+
+    def _cleanup(self, source: _UriSource, resolved_uri: str) -> None:
+        source.content_by_uri.pop(resolved_uri, None)
 
     def add(self, event: dict) -> dict:
         """Returns the fields to add"""
-        if self.config.add:
-            return self.config.add
+        items_to_add: dict[str, FieldValue] = dict(self.config.add)
 
-        if not self._is_dynamic:
-            assert self._static_uri
-            return self._content_to_items_to_add(self._cached_add_content[self._static_uri])
-        else:
-            assert self.config.add_from_url is not None
-            return self._dynamic_add_from_url(event)
+        for source in self._uri_sources:
+            content = self._content_for_source(source, event)
+            items_to_add.update(self._content_to_items_to_add(source.spec, content))
+
+        return items_to_add

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -123,7 +123,7 @@ def _convert_uri_config(
     values: Sequence[str | dict[str, object] | UriConfig]
 
     if isinstance(value, (str, dict, UriConfig)):
-        values = (value,)
+        values = [value]
     else:
         values = value
 
@@ -137,7 +137,8 @@ def _convert_uri_config(
 class _UriSource:
     config: UriConfig
     template: DottedTemplate
-    identifiers: tuple[str, ...]
+    static_uri: str | None
+    identifiers: Sequence[str]
     content_by_uri: dict[str, FieldValue] = field(factory=dict)
     error: Exception | None = None
 
@@ -307,7 +308,7 @@ class GenericAdderRule(Rule):
             self._uri_sources.append(source)
 
             if not source.identifiers:
-                self._init_static_source(source)
+                self._init_static_source(source, raise_on_error=True)
 
     def _init_first_existing_file(self) -> None:
         missing_files: list[str] = []
@@ -322,10 +323,10 @@ class GenericAdderRule(Rule):
             self._uri_sources.append(source)
 
             try:
-                self._init_static_source(source)
+                self._init_static_source(source, raise_on_error=True)
                 if source.error is not None:
                     raise InvalidRuleDefinitionError(
-                        f"Could not load generic-adder URI {config.uri!r}: {source.error}"
+                        f"Could not load generic_adder URI {config.uri!r}: {source.error}"
                     ) from source.error
             except InvalidRuleDefinitionError as error:
                 self._uri_sources.pop()
@@ -343,32 +344,34 @@ class GenericAdderRule(Rule):
     def _create_uri_source(self, config: UriConfig) -> _UriSource:
         template = DottedTemplate(DottedTemplate(config.uri).safe_substitute(ENV_VARS))
 
+        identifiers = template.get_identifiers()
+
         return _UriSource(
-            config=config, template=template, identifiers=tuple(template.get_identifiers())
+            config=config,
+            template=template,
+            identifiers=tuple(identifiers),
+            static_uri=None if identifiers else template.substitute(),
         )
 
-    def _init_static_source(self, source: _UriSource):
+    def _init_static_source(self, source: _UriSource, raise_on_error: bool):
         resolved_uri = source.template.substitute()
         getter = GetterFactory.from_string(resolved_uri)
 
         assert self._callback_tag
 
+        self._update_static_content(source, getter, resolved_uri)
+        if source.error and raise_on_error:
+            raise InvalidRuleDefinitionError(
+                f"Could not load generic_adder URI {resolved_uri!r}: {source.error}"
+            ) from source.error
+
         if isinstance(getter, RefreshableGetter):
-            self._update_static_content(source, getter, resolved_uri)
             getter.add_callback(
                 self._callback_tag,
                 self._update_static_content,
                 deduplication_key=(self._callback_tag, resolved_uri, id(source)),
                 fnc_args=[source, getter, resolved_uri],
             )
-            return
-
-        try:
-            self._fetch_and_cache_uri(source, getter, resolved_uri)
-        except (FileNotFoundError, ValueError) as error:
-            raise InvalidRuleDefinitionError(
-                f"Could not load generic-adder URI {resolved_uri!r}: {error}"
-            ) from error
 
     def _get_cached_or_dynamic_content(
         self, source: _UriSource, event: dict[str, FieldValue]
@@ -396,7 +399,9 @@ class GenericAdderRule(Rule):
 
         getter = GetterFactory.from_string(resolved_uri)
         if not isinstance(getter, RefreshableGetter):
-            return getter.get_collection()
+            raise InvalidRuleDefinitionError(
+                f"Dynamic file URIs are not supported, uri {resolved_uri!r}"
+            )
 
         getter.keep_alive()
         content = self._fetch_and_cache_uri(source, getter, resolved_uri)
@@ -425,8 +430,8 @@ class GenericAdderRule(Rule):
         if source.identifiers:
             return self._get_cached_or_dynamic_content(source, event)
 
-        resolved_uri = source.template.substitute()
-        return source.content_by_uri[resolved_uri]
+        assert source.static_uri
+        return source.content_by_uri[source.static_uri]
 
     def _content_to_items_to_add(
         self, config: UriConfig, content: FieldValue
@@ -435,7 +440,7 @@ class GenericAdderRule(Rule):
             return {config.target_field: content}
 
         if isinstance(content, dict):
-            return dict(content)
+            return content
 
         raise ValueError(
             f"URI source {config.uri!r} without target_field must contain a mapping, got {type(content).__name__}"
@@ -444,7 +449,6 @@ class GenericAdderRule(Rule):
     def _fetch_and_cache_uri(self, source: _UriSource, getter: Getter, resolved_uri: str):
         content = getter.get_collection(content_field=self.config.content_field)
 
-        self._content_to_items_to_add(source.config, content)
         source.content_by_uri[resolved_uri] = content
         return content
 

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -231,6 +231,8 @@ class GenericAdderRule(FieldManagerRule):
             self._add_from_path()
 
         def __attrs_post_init__(self):
+            super().__attrs_post_init__()
+
             self._base_add = copy.deepcopy(self.add)
 
             if (self.add_from_file or self.add) and self.add_from_url is not None:
@@ -260,14 +262,6 @@ class GenericAdderRule(FieldManagerRule):
                 raise ValueError(
                     "one of target_field or target_field_mapping is neccessary per GenericAdder rule"
                 )
-
-            # Eagerly loaded from file
-            for add_file in self.add_from_file:
-                getter = GetterFactory.from_string(add_file)
-                if isinstance(getter, RefreshableGetter):
-                    # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
-                    getter.add_callback(f"generic_adder:{self.id}:{add_file}", self._refresh_add)
-                self._add_from_path()
 
         def _add_from_path(self):
             """Reads add fields from file"""
@@ -308,6 +302,17 @@ class GenericAdderRule(FieldManagerRule):
         self._callback_tag = job_tag
 
         if self.config.add_from_file or self.config.add:
+            # Eagerly loaded from file
+            for add_file in self.config.add_from_file:
+                getter = GetterFactory.from_string(add_file)
+                if isinstance(getter, RefreshableGetter):
+                    # TODO: This never gets cleaned up, Memory leak on a lot of new generic adders / generic resolvers
+                    getter.add_callback(
+                        job_tag,
+                        self.config._refresh_add,
+                        deduplication_key=(self._callback_tag, add_file, id(self)),
+                    )
+                self.config._add_from_path()
             return
 
         assert self.config.add_from_url is not None

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -83,6 +83,7 @@ In the following example two files are being used, but only the first existing f
 # pylint: enable=anomalous-backslash-in-string
 
 import copy
+import logging
 import os
 import typing
 
@@ -93,7 +94,15 @@ from logprep.processor.base.rule import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.converters import convert_from_dict
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
-from logprep.util.helper import DottedTemplate, FieldValue, get_dotted_field_value
+from logprep.util.helper import (
+    MISSING,
+    DottedTemplate,
+    FieldValue,
+    get_dotted_field_value,
+    get_dotted_field_value_with_missing,
+)
+
+logger = logging.getLogger("GenericAdder")
 
 
 @define(kw_only=True, frozen=True)
@@ -354,11 +363,16 @@ class GenericAdderRule(FieldManagerRule):
                 mapping_source_field,
                 mapping_target_field,
             ) in config.add_from_url.target_field_mapping.items():
-                # what should happen with missing fields? Right now None is skipped
-                # change this to get_dotted_field_value_with_missing
-                items_to_add[mapping_target_field] = get_dotted_field_value(
-                    content, mapping_source_field
-                )
+                item = get_dotted_field_value_with_missing(content, mapping_source_field)
+                if item is MISSING:
+                    logger.warning(
+                        "could not add source_field: %s for target_field: %s because was missing",
+                        mapping_source_field,
+                        mapping_target_field,
+                    )
+                    continue
+
+                items_to_add[mapping_target_field] = item
 
         return items_to_add
 

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -86,7 +86,7 @@ import typing
 from attrs import define, field, validators
 
 from logprep.filter.expression.filter_expression import FilterExpression
-from logprep.processor.base.rule import InvalidRuleDefinitionError
+from logprep.processor.base.rule import InvalidRuleDefinitionError, Rule
 from logprep.processor.field_manager.rule import FieldManagerRule
 from logprep.util.converters import convert_from_dict
 from logprep.util.environ import ENV_VARS
@@ -124,17 +124,21 @@ def _convert_add_from_url(
     return convert_from_dict(AddFromUrlConfig, value)
 
 
-class GenericAdderRule(FieldManagerRule):
+class GenericAdderRule(Rule):
     """Check if documents match a filter and initialize the fields and values can be added."""
 
     @define(kw_only=True)
-    class Config(FieldManagerRule.Config):
+    class Config(Rule.Config):
         """Config for GenericAdderRule"""
+
+        overwrite_target: bool = field(validator=validators.instance_of(bool), default=False)
+        """Overwrite the target field value if exists. Defaults to :code:`False`"""
 
         merge_with_target: bool = field(validator=validators.instance_of(bool), default=False)
         """If the target field exists and is a list, the list will be extended with the values
         of the source fields.
         """
+
         add: dict = field(
             validator=validators.deep_mapping(
                 key_validator=validators.instance_of(str),
@@ -145,6 +149,7 @@ class GenericAdderRule(FieldManagerRule):
         """Contains a dictionary of field names and values that should be added.
         If dot notation is being used, then all fields on the path are being
         automatically created."""
+
         add_from_file: list[str] = field(
             validator=validators.deep_iterable(
                 iterable_validator=validators.instance_of(list),
@@ -205,8 +210,6 @@ class GenericAdderRule(FieldManagerRule):
             self._add_from_path()
 
         def __attrs_post_init__(self):
-            super().__attrs_post_init__()
-
             self._base_add = copy.deepcopy(self.add)
 
             if (self.add_from_file or self.add) and self.add_from_url is not None:
@@ -295,6 +298,16 @@ class GenericAdderRule(FieldManagerRule):
             self._static_uri = static_uri
         else:
             self._is_dynamic = True
+
+    @property
+    def overwrite_target(self) -> bool:
+        """Returns the nested config overwrite_target"""
+        return self.config.overwrite_target
+
+    @property
+    def merge_with_target(self) -> bool:
+        """Returns the nested config merge_with_target"""
+        return self.config.merge_with_target
 
     @property
     def config(self) -> Config:

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -81,7 +81,6 @@ In the following example two files are being used, but only the first existing f
 """
 
 import copy
-import logging
 import typing
 
 from attrs import define, field, validators
@@ -93,14 +92,10 @@ from logprep.util.converters import convert_from_dict
 from logprep.util.environ import ENV_VARS
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
 from logprep.util.helper import (
-    MISSING,
     DottedTemplate,
     FieldValue,
     get_dotted_field_value,
-    get_dotted_field_value_with_missing,
 )
-
-logger = logging.getLogger("GenericAdder")
 
 
 @define(kw_only=True, frozen=True)
@@ -116,29 +111,8 @@ class AddFromUrlConfig:
     :code:`${TENANT}` and :code:`${tenant.id}`.
     """
 
-    target_field: str | None = field(
-        default=None, validator=validators.optional(validators.instance_of(str))
-    )
-    """The dotted event field into which the complete response is written.
-
-    This is mutually exclusive with :attr:`target_field_mapping`.
-    """
-
-    target_field_mapping: dict[str, str] = field(
-        validator=validators.deep_mapping(
-            key_validator=validators.instance_of(str),
-            value_validator=validators.instance_of(str),
-        ),
-        factory=dict,
-    )
-    """A mapping of dotted response fields to dotted target fields in the event.
-
-    This is mutually exclusive with :attr:`target_field`.
-    """
-
-    def __attrs_post_init__(self) -> None:
-        if not self.target_field and not self.target_field_mapping:
-            raise ValueError("adding values from url requires target_field or target_field_mapping")
+    target_field: str = field(validator=validators.instance_of(str))
+    """The dotted event field into which the complete response is written."""
 
 
 def _convert_add_from_url(
@@ -243,24 +217,6 @@ class GenericAdderRule(FieldManagerRule):
             if not self.add and not self.add_from_file and self.add_from_url is None:
                 raise ValueError(
                     "one of add, add_from_file or add_from_url is neccessary per GenericAdder rule"
-                )
-
-            if (
-                self.add_from_url is not None
-                and self.add_from_url.target_field
-                and self.add_from_url.target_field_mapping
-            ):
-                raise ValueError(
-                    "only one of target_field or target_field_mapping is allowed per GenericAdder rule"
-                )
-
-            if (
-                self.add_from_url is not None
-                and not self.add_from_url.target_field
-                and not self.add_from_url.target_field_mapping
-            ):
-                raise ValueError(
-                    "one of target_field or target_field_mapping is neccessary per GenericAdder rule"
                 )
 
         def _add_from_path(self):
@@ -395,36 +351,9 @@ class GenericAdderRule(FieldManagerRule):
         return self._content_to_items_to_add(content)
 
     def _content_to_items_to_add(self, content: FieldValue):
-        items_to_add: dict[str, FieldValue] = {}
-
         assert self.config.add_from_url
 
-        if self.config.add_from_url.target_field:
-            items_to_add[self.config.add_from_url.target_field] = content
-        else:
-            assert self.config.add_from_url.target_field_mapping is not None
-
-            if not isinstance(content, dict):
-                raise ValueError(
-                    f"add_from_url.target_field_mapping requires a mapping response, got {content}"
-                )
-
-            for (
-                mapping_source_field,
-                mapping_target_field,
-            ) in self.config.add_from_url.target_field_mapping.items():
-                item = get_dotted_field_value_with_missing(content, mapping_source_field)
-                if item is MISSING:
-                    logger.warning(
-                        "could not add source_field %s for target_field %s because it is missing",
-                        mapping_source_field,
-                        mapping_target_field,
-                    )
-                    continue
-
-                items_to_add[mapping_target_field] = item
-
-        return items_to_add
+        return {self.config.add_from_url.target_field: content}
 
     def _update_dynamic_content(self, http_getter: HttpGetter, resolved_uri: str):
         content = http_getter.get_collection()

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -1,4 +1,3 @@
-# pylint: disable=anomalous-backslash-in-string
 """
 Rule Configuration
 ^^^^^^^^^^^^^^^^^^
@@ -99,42 +98,44 @@ from logprep.util.helper import (
 
 
 @define(kw_only=True, frozen=True)
-class UriTargetConfig:
-    """Configuration for adding values loaded from an HTTP(S) URL."""
+class UriConfig:
+    """Configuration for adding values loaded from an URI, which can be HTTP(S) URLs or file paths"""
 
     uri: str = field(validator=validators.and_(validators.instance_of(str), validators.min_len(1)))
-    """The URL to load values from.
+    """The URI to load values from.
 
     Environment variables and dotted event fields can be inserted with placeholders such as
-    :code:`${TENANT}` and :code:`${tenant.id}`.
+    :code:`${LOGPREP_DATA_API}` and :code:`${tenant.id}`.
     """
 
-    target_field: str = field(
-        validator=validators.and_(validators.instance_of(str), validators.min_len(1))
+    target_field: str | None = field(
+        default=None,
+        validator=validators.optional(
+            validators.and_(validators.instance_of(str), validators.min_len(1))
+        ),
     )
     """The dotted event field into which the complete response is written."""
 
 
-UriSpec = str | UriTargetConfig
+def _convert_uri_config(
+    value: str | dict | UriConfig | Sequence[str | dict | UriConfig],
+) -> list[UriConfig]:
+    values: Sequence[str | dict[str, object] | UriConfig]
 
-
-def _convert_uri_specs(
-    value: UriSpec | dict | Sequence[UriSpec | dict],
-) -> tuple[UriSpec, ...]:
-    if isinstance(value, (str, UriTargetConfig, dict)):
-        values: tuple[UriSpec | dict, ...] = (value,)
+    if isinstance(value, (str, dict, UriConfig)):
+        values = (value,)
     else:
-        values = tuple(value)
+        values = value
 
-    return tuple(
-        convert_from_dict(UriTargetConfig, item) if isinstance(item, dict) else item
+    return [
+        UriConfig(uri=item) if isinstance(item, str) else convert_from_dict(UriConfig, item)
         for item in values
-    )
+    ]
 
 
 @define(kw_only=True)
 class _UriSource:
-    spec: UriSpec
+    config: UriConfig
     template: DottedTemplate
     identifiers: tuple[str, ...]
     content_by_uri: dict[str, FieldValue] = field(factory=dict)
@@ -174,10 +175,8 @@ class GenericAdderRule(Rule):
             ),
             converter=lambda x: x if isinstance(x, list) else [x],
             factory=list,
-            # Eq false in this case means that this is not taken into account when comparing two Configs,
-            # that is neccessary in this case because on init this will be loaded into add,
-            # and when comparing two rules, we dont care if whats to add came from a file or is written inline
-            # but we do care if whatever gets added is the same
+            # Eq false because add_from_file gets normalized into add_from_uri
+            # and should not affect equality
             eq=False,
         )
         """Contains the path or url to YML file that contains a dictionary of field names
@@ -200,19 +199,55 @@ class GenericAdderRule(Rule):
 
         """
 
-        add_from_uri: tuple[UriSpec, ...] = field(
-            factory=tuple,
-            converter=_convert_uri_specs,
+        add_from_uri: Sequence[UriConfig] = field(
+            factory=list,
+            converter=_convert_uri_config,
             validator=validators.deep_iterable(
-                iterable_validator=validators.instance_of(tuple),
-                member_validator=validators.instance_of((str, UriTargetConfig)),
+                member_validator=validators.instance_of(UriConfig),
             ),
-            # Explicitly set it to true here to show the difference between this and add_from_file
-            eq=True,
         )
-        """Configuration for loading values from an HTTP(S) URL and adding them to the event.
+        """Configuration for loading values from URIs and adding them to the event.
 
         This is mutually exclusive with :attr:`add_from_file`.
+        """
+
+        content_field: str | None = field(
+            default=None,
+            validator=validators.optional(validators.instance_of(str)),
+            converter=lambda x: x if x != "" else None,
+        )
+        """
+        Optional JSON key used to extract the list values from loaded content.
+
+        Example:
+            Given the following JSON content:
+
+            .. code-block:: json
+
+               {
+                   "content": ["Jane", "Julia"]
+               }
+
+            Set ``content_field`` to ``"content"`` to use the value of this key
+            as the comparison list.
+
+        Note:
+            Setting ``content_field`` requires mapping-like JSON content. Non-JSON
+            content, or JSON content that does not resolve to a mapping, fails with an
+            error.
+
+            An empty ``content_field`` is treated as unset, so the list is expected at
+            the root of the JSON content.
+
+            Examples:
+                ``content_field: ""``
+                    Is converted to ``None`` and reads the list from the JSON root.
+
+                ``content_field: null``
+                    Is treated as ``None`` and reads the list from the JSON root.
+
+                ``content_field: "content"``
+                    Reads the list from the ``"content"`` key of the JSON object.
         """
 
         only_first_existing_file: bool = field(
@@ -229,7 +264,7 @@ class GenericAdderRule(Rule):
                 )
 
             if self.add_from_file:
-                self.add_from_uri = tuple(self.add_from_file)
+                self.add_from_uri = _convert_uri_config(self.add_from_file)
 
             if self.only_first_existing_file and not self.add_from_file:
                 raise ValueError(
@@ -239,14 +274,29 @@ class GenericAdderRule(Rule):
             if not self.add and not self.add_from_uri:
                 raise ValueError("one of add or add_from_uri must be configured")
 
+    @property
+    def overwrite_target(self) -> bool:
+        """Returns the nested config overwrite_target"""
+        return self.config.overwrite_target
+
+    @property
+    def merge_with_target(self) -> bool:
+        """Returns the nested config merge_with_target"""
+        return self.config.merge_with_target
+
+    @property
+    def config(self) -> Config:
+        """Return typed config"""
+        return typing.cast(GenericAdderRule.Config, self._config)
+
     def __init__(self, filter_rule: FilterExpression, config: Config, processor_name: str):
         super().__init__(filter_rule, config, processor_name)
         self._callback_tag: str | None = None
         self._uri_sources: list[_UriSource] = []
 
     def init_generic_adder(self, job_tag: str) -> None:
+        """Initializes the generic adder and assignes the job_tag for callback cleanup"""
         self._callback_tag = job_tag
-        self._uri_sources.clear()
 
         if self.config.only_first_existing_file:
             self._init_first_existing_file()
@@ -262,13 +312,11 @@ class GenericAdderRule(Rule):
     def _init_first_existing_file(self) -> None:
         missing_files: list[str] = []
 
-        for spec in self.config.add_from_uri:
-            assert isinstance(spec, str)
-
-            source = self._create_uri_source(spec)
+        for config in self.config.add_from_uri:
+            source = self._create_uri_source(config)
             if source.identifiers:
                 raise InvalidRuleDefinitionError(
-                    f"only_first_existing_file does not support event-dependent paths: {spec!r}"
+                    f"only_first_existing_file does not support event-dependent paths: {config!r}"
                 )
 
             self._uri_sources.append(source)
@@ -277,13 +325,13 @@ class GenericAdderRule(Rule):
                 self._init_static_source(source)
                 if source.error is not None:
                     raise InvalidRuleDefinitionError(
-                        f"Could not load generic-adder URI {spec!r}: {source.error}"
+                        f"Could not load generic-adder URI {config.uri!r}: {source.error}"
                     ) from source.error
             except InvalidRuleDefinitionError as error:
                 self._uri_sources.pop()
 
                 if isinstance(error.__cause__, FileNotFoundError):
-                    missing_files.append(spec)
+                    missing_files.append(config.uri)
                     continue
 
                 raise
@@ -292,17 +340,18 @@ class GenericAdderRule(Rule):
 
         raise InvalidRuleDefinitionError(f"None of the configured files exist: {missing_files!r}")
 
-    def _create_uri_source(self, spec: UriSpec) -> _UriSource:
-        uri = spec.uri if isinstance(spec, UriTargetConfig) else spec
-        template = DottedTemplate(DottedTemplate(uri).safe_substitute(ENV_VARS))
+    def _create_uri_source(self, config: UriConfig) -> _UriSource:
+        template = DottedTemplate(DottedTemplate(config.uri).safe_substitute(ENV_VARS))
 
         return _UriSource(
-            spec=spec, template=template, identifiers=tuple(template.get_identifiers())
+            config=config, template=template, identifiers=tuple(template.get_identifiers())
         )
 
     def _init_static_source(self, source: _UriSource):
         resolved_uri = source.template.substitute()
         getter = GetterFactory.from_string(resolved_uri)
+
+        assert self._callback_tag
 
         if isinstance(getter, RefreshableGetter):
             self._update_static_content(source, getter, resolved_uri)
@@ -321,22 +370,9 @@ class GenericAdderRule(Rule):
                 f"Could not load generic-adder URI {resolved_uri!r}: {error}"
             ) from error
 
-    @property
-    def overwrite_target(self) -> bool:
-        """Returns the nested config overwrite_target"""
-        return self.config.overwrite_target
-
-    @property
-    def merge_with_target(self) -> bool:
-        """Returns the nested config merge_with_target"""
-        return self.config.merge_with_target
-
-    @property
-    def config(self) -> Config:
-        """Return typed config"""
-        return typing.cast(GenericAdderRule.Config, self._config)
-
-    def _dynamic_content(self, source: _UriSource, event: dict[str, FieldValue]) -> FieldValue:
+    def _get_cached_or_dynamic_content(
+        self, source: _UriSource, event: dict[str, FieldValue]
+    ) -> FieldValue:
         values = {
             identifier: get_dotted_field_value(event, identifier)
             for identifier in source.identifiers
@@ -365,6 +401,8 @@ class GenericAdderRule(Rule):
         getter.keep_alive()
         content = self._fetch_and_cache_uri(source, getter, resolved_uri)
 
+        assert self._callback_tag
+
         key = (self._callback_tag, resolved_uri, id(source))
 
         getter.add_callback(
@@ -385,26 +423,28 @@ class GenericAdderRule(Rule):
 
     def _content_for_source(self, source: _UriSource, event: dict[str, FieldValue]) -> FieldValue:
         if source.identifiers:
-            return self._dynamic_content(source, event)
+            return self._get_cached_or_dynamic_content(source, event)
 
         resolved_uri = source.template.substitute()
         return source.content_by_uri[resolved_uri]
 
-    def _content_to_items_to_add(self, uri: UriSpec, content: FieldValue) -> dict[str, FieldValue]:
-        if isinstance(uri, UriTargetConfig):
-            return {uri.target_field: content}
+    def _content_to_items_to_add(
+        self, config: UriConfig, content: FieldValue
+    ) -> dict[str, FieldValue]:
+        if config.target_field is not None:
+            return {config.target_field: content}
 
         if isinstance(content, dict):
             return dict(content)
 
         raise ValueError(
-            f"URI source {uri!r} without target_field must contain a mapping, got {type(content).__name__}"
+            f"URI source {config.uri!r} without target_field must contain a mapping, got {type(content).__name__}"
         )
 
     def _fetch_and_cache_uri(self, source: _UriSource, getter: Getter, resolved_uri: str):
-        content = getter.get_collection()
+        content = getter.get_collection(content_field=self.config.content_field)
 
-        self._content_to_items_to_add(source.spec, content)
+        self._content_to_items_to_add(source.config, content)
         source.content_by_uri[resolved_uri] = content
         return content
 
@@ -437,6 +477,6 @@ class GenericAdderRule(Rule):
 
         for source in self._uri_sources:
             content = self._content_for_source(source, event)
-            items_to_add.update(self._content_to_items_to_add(source.spec, content))
+            items_to_add.update(self._content_to_items_to_add(source.config, content))
 
         return items_to_add

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -77,6 +77,12 @@ In the following example two files are being used, but only the first existing f
    :undoc-members:
    :inherited-members:
    :noindex:
+
+Examples for generic_adder:
+---------------------------
+
+.. datatemplate:import-module:: tests.unit.processor.generic_adder.test_generic_adder
+   :template: testcase-renderer.tmpl
 """
 
 import typing

--- a/tests/testdata/unit/generic_adder/additions_list_1.yml
+++ b/tests/testdata/unit/generic_adder/additions_list_1.yml
@@ -1,0 +1,1 @@
+- first_uri_value

--- a/tests/testdata/unit/generic_adder/additions_list_2.yml
+++ b/tests/testdata/unit/generic_adder/additions_list_2.yml
@@ -1,0 +1,1 @@
+- second_uri_value

--- a/tests/testdata/unit/generic_adder/additions_merge_1.yml
+++ b/tests/testdata/unit/generic_adder/additions_merge_1.yml
@@ -1,0 +1,2 @@
+shared_field:
+  from_first_source: true

--- a/tests/testdata/unit/generic_adder/additions_merge_2.yml
+++ b/tests/testdata/unit/generic_adder/additions_merge_2.yml
@@ -1,0 +1,2 @@
+shared_field:
+  from_second_source: true

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -95,7 +95,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
         log_event = LogEvent(event, original=b"", input_meta=InputMeta())
         await instance.process(log_event)
 
-        rule_add = instance.rules[0].add
+        rule_add = instance.rules[0].add({})
 
         assert event["some_list_field"] == ["some_value"]
         assert event["some_list_field"] is not rule_add["some_list_field"], "only copies in events"

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -9,6 +9,7 @@ import re
 from copy import deepcopy
 
 import pytest
+import responses
 
 from logprep.factory import Factory
 from logprep.ng.abc.event import InputMeta, LogEvent
@@ -102,3 +103,35 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
 
         assert event["some_dict_field"] == {"some_key": "some_value"}
         assert event["some_dict_field"] is not rule_add["some_dict_field"], "only copies in events"
+
+    @responses.activate
+    async def test_adds_response_from_event_templated_url(self):
+        resolved_url = "https://values.example/acme"
+        response_content = {"user": {"name": "Alice"}, "risk": {"score": 7}}
+        responses.add(responses.GET, resolved_url, json=response_content)
+        processor = self._create_test_instance(
+            {
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_url": {
+                                "url": "https://values.example/${tenant.id}",
+                                "target_field": "enrichment",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        await processor.setup()
+        event = {"tenant": {"id": "acme"}}
+
+        result = await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
+
+        assert result.errors == []
+        assert event == {
+            "tenant": {"id": "acme"},
+            "enrichment": response_content,
+        }
+        assert responses.calls[0].request.url == resolved_url

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -18,7 +18,7 @@ from logprep.processor.base.exceptions import (
     InvalidRuleDefinitionError,
     ProcessingWarning,
 )
-from logprep.util.getter import HttpGetter, RefreshableGetter
+from logprep.util.getter import HttpGetter
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (
     failure_test_cases as non_ng_failure_test_cases,
@@ -147,7 +147,6 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
         successful_url = "https://values.example/beta"
         responses.add(responses.GET, failed_url, status=500)
         responses.add(responses.GET, successful_url, json={"risk": {"score": 7}})
-        RefreshableGetter.reset()
         processor = self._create_test_instance(
             {
                 "rules": [

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -221,38 +221,3 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
             "message": "preserved",
             "tags": ["_generic_adder_failure"],
         }
-
-    @responses.activate
-    async def test_mapping_response_type_error_adds_warning_without_clearing_event(self):
-        url = "https://values.example/acme"
-        responses.add(responses.GET, url, json=["not", "a", "mapping"])
-        RefreshableGetter.reset()
-        processor = self._create_test_instance(
-            {
-                "rules": [
-                    {
-                        "filter": "*",
-                        "generic_adder": {
-                            "add_from_url": {
-                                "url": "https://values.example/${tenant}",
-                                "target_field_mapping": {
-                                    "risk.score": "enrichment.score",
-                                },
-                            }
-                        },
-                    }
-                ]
-            }
-        )
-        await processor.setup()
-        event = {"tenant": "acme"}
-
-        result = await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
-
-        assert result.errors == []
-        assert len(result.warnings) == 1
-        assert "target_field_mapping requires a mapping response" in str(result.warnings[0])
-        assert event == {
-            "tenant": "acme",
-            "tags": ["_generic_adder_failure"],
-        }

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -21,6 +21,9 @@ from logprep.processor.base.exceptions import (
 from logprep.util.getter import HttpGetter
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (
+    dynamic_uri_failure_test_cases as non_ng_dynamic_uri_failure_test_cases,
+)
+from tests.unit.processor.generic_adder.test_generic_adder import (
     failure_test_cases as non_ng_failure_test_cases,
 )
 from tests.unit.processor.generic_adder.test_generic_adder import (
@@ -34,6 +37,7 @@ RULES_DIR_FIRST_EXISTING = "tests/testdata/unit/generic_adder/rules_first_existi
 
 test_cases = deepcopy(non_ng_test_cases)
 failure_test_cases = deepcopy(non_ng_failure_test_cases)
+dynamic_uri_failure_test_cases = deepcopy(non_ng_dynamic_uri_failure_test_cases)
 
 
 class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
@@ -61,6 +65,19 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
         assert len(result.warnings) == 1
         assert re.match(rf".*FieldExistsWarning.*{error_message}", str(result.warnings[0]))
         assert event == expected
+
+    @pytest.mark.parametrize("rule, event, error_message", dynamic_uri_failure_test_cases)
+    async def test_dynamic_uri_failure_handling(self, rule, event, error_message):
+        await self._load_rule(rule)
+        await self.object.setup()
+        log_event = LogEvent(event, original=b"", input_meta=InputMeta())
+
+        result = await self.object.process(log_event)
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert error_message in str(result.warnings[0])
+        assert event["tags"] == ["_generic_adder_failure"]
 
     async def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
         with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic_adder URI"):
@@ -144,6 +161,39 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
             "enrichment": response_content,
         }
         assert responses.calls[0].request.url == resolved_url
+
+    @responses.activate
+    async def test_shutdown_removes_dynamic_uri_callbacks(self):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json={"value": 1})
+        processor = self._create_test_instance(
+            {
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_uri": {
+                                "uri": "https://values.example/${tenant}",
+                                "target_field": "enrichment",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        await processor.setup()
+        event = {"tenant": "acme"}
+
+        await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
+
+        shared = HttpGetter._target_to_data_caches[url]
+        assert len(shared.callbacks) == 1
+        assert len(shared.cleanup_callbacks) == 1
+
+        await processor.shut_down()
+
+        assert shared.callbacks == []
+        assert shared.cleanup_callbacks == []
 
     @responses.activate
     async def test_dynamic_url_failure_is_event_scoped(self):

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -14,7 +14,10 @@ import responses
 from logprep.factory import Factory
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.generic_adder.processor import GenericAdder
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError, ProcessingWarning
+from logprep.processor.base.exceptions import (
+    InvalidRuleDefinitionError,
+    ProcessingWarning,
+)
 from logprep.util.getter import HttpGetter, RefreshableGetter
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -63,21 +63,25 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
         assert event == expected
 
     async def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
-        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic-adder URI"):
+        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic_adder URI"):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
             await Factory.create(configuration).setup()
 
     async def test_add_generic_fields_from_file_invalid(self):
-        with pytest.raises(
-            InvalidRuleDefinitionError,
-            match=r"without target_field must contain a mapping",
-        ):
-            config = deepcopy(self.CONFIG)
-            config["rules"] = [RULES_DIR_INVALID]
-            configuration = {"test processor": config}
-            await Factory.create(configuration).setup()
+        config = deepcopy(self.CONFIG)
+        config["rules"] = [RULES_DIR_INVALID]
+        configuration = {"test processor": config}
+        processor = Factory.create(configuration)
+        await processor.setup()
+
+        event = {"add_list_invalid_generic_test": True}
+        result = await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
+
+        assert len(result.warnings) == 1
+        assert isinstance(result.warnings[0], ProcessingWarning)
+        assert "without target_field must contain a mapping" in str(result.warnings[0])
 
     async def test_add_only_copies(self):
         instance = self._create_test_instance(

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -63,7 +63,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
         assert event == expected
 
     async def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
-        with pytest.raises(InvalidRuleDefinitionError, match=r"files do not exist"):
+        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic-adder URI"):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
@@ -72,7 +72,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
     async def test_add_generic_fields_from_file_invalid(self):
         with pytest.raises(
             InvalidRuleDefinitionError,
-            match=r"must be a dictionary with string values",
+            match=r"without target_field must contain a mapping",
         ):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_INVALID]
@@ -120,8 +120,8 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
                     {
                         "filter": "*",
                         "generic_adder": {
-                            "add_from_url": {
-                                "url": "https://values.example/${tenant.id}",
+                            "add_from_uri": {
+                                "uri": "https://values.example/${tenant.id}",
                                 "target_field": "enrichment",
                             }
                         },
@@ -154,8 +154,8 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
                     {
                         "filter": "*",
                         "generic_adder": {
-                            "add_from_url": {
-                                "url": "https://values.example/${tenant}",
+                            "add_from_uri": {
+                                "uri": "https://values.example/${tenant}",
                                 "target_field": "enrichment",
                             }
                         },
@@ -200,8 +200,8 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
                     {
                         "filter": "*",
                         "generic_adder": {
-                            "add_from_url": {
-                                "url": "https://values.example/${tenant.id}",
+                            "add_from_uri": {
+                                "uri": "https://values.example/${tenant.id}",
                                 "target_field": "enrichment",
                             }
                         },

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -14,7 +14,8 @@ import responses
 from logprep.factory import Factory
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.generic_adder.processor import GenericAdder
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError, ProcessingWarning
+from logprep.util.getter import HttpGetter, RefreshableGetter
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (
     failure_test_cases as non_ng_failure_test_cases,
@@ -135,3 +136,119 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
             "enrichment": response_content,
         }
         assert responses.calls[0].request.url == resolved_url
+
+    @responses.activate
+    async def test_dynamic_url_failure_is_event_scoped(self):
+        failed_url = "https://values.example/acme"
+        successful_url = "https://values.example/beta"
+        responses.add(responses.GET, failed_url, status=500)
+        responses.add(responses.GET, successful_url, json={"risk": {"score": 7}})
+        RefreshableGetter.reset()
+        processor = self._create_test_instance(
+            {
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_url": {
+                                "url": "https://values.example/${tenant}",
+                                "target_field": "enrichment",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        await processor.setup()
+        rule = processor.rules[0]
+        failed_event = {"tenant": "acme"}
+        successful_event = {"tenant": "beta"}
+
+        failed_result = await processor.process(
+            LogEvent(failed_event, original=b"", input_meta=InputMeta())
+        )
+        successful_result = await processor.process(
+            LogEvent(successful_event, original=b"", input_meta=InputMeta())
+        )
+
+        assert failed_result.errors == []
+        assert len(failed_result.warnings) == 1
+        assert isinstance(failed_result.warnings[0], ProcessingWarning)
+        assert failed_event == {
+            "tenant": "acme",
+            "tags": ["_generic_adder_failure"],
+        }
+        assert rule.data_error is None
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
+
+        assert successful_result.errors == []
+        assert successful_result.warnings == []
+        assert successful_event == {
+            "tenant": "beta",
+            "enrichment": {"risk": {"score": 7}},
+        }
+
+    async def test_missing_dynamic_url_field_adds_warning_without_clearing_event(self):
+        processor = self._create_test_instance(
+            {
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_url": {
+                                "url": "https://values.example/${tenant.id}",
+                                "target_field": "enrichment",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        await processor.setup()
+        event = {"message": "preserved"}
+
+        result = await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert "missing event field 'tenant.id'" in str(result.warnings[0])
+        assert event == {
+            "message": "preserved",
+            "tags": ["_generic_adder_failure"],
+        }
+
+    @responses.activate
+    async def test_mapping_response_type_error_adds_warning_without_clearing_event(self):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json=["not", "a", "mapping"])
+        RefreshableGetter.reset()
+        processor = self._create_test_instance(
+            {
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_url": {
+                                "url": "https://values.example/${tenant}",
+                                "target_field_mapping": {
+                                    "risk.score": "enrichment.score",
+                                },
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        await processor.setup()
+        event = {"tenant": "acme"}
+
+        result = await processor.process(LogEvent(event, original=b"", input_meta=InputMeta()))
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert "target_field_mapping requires a mapping response" in str(result.warnings[0])
+        assert event == {
+            "tenant": "acme",
+            "tags": ["_generic_adder_failure"],
+        }

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -46,6 +46,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
     @pytest.mark.parametrize("rule, event, expected", test_cases)
     async def test_generic_adder_testcases(self, rule, event, expected):
         await self._load_rule(rule)
+        await self.object.setup()
         log_event = LogEvent(event, original=b"", input_meta=InputMeta())
         await self.object.process(log_event)
         assert event == expected
@@ -66,7 +67,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
-            Factory.create(configuration)
+            await Factory.create(configuration).setup()
 
     async def test_add_generic_fields_from_file_invalid(self):
         with pytest.raises(
@@ -76,7 +77,7 @@ class TestGenericAdder(BaseProcessorTestCase[GenericAdder]):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_INVALID]
             configuration = {"test processor": config}
-            Factory.create(configuration)
+            await Factory.create(configuration).setup()
 
     async def test_add_only_copies(self):
         instance = self._create_test_instance(

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -303,8 +303,8 @@ test_cases = [  # testcase, rule, event, expected
             "comp\\lex.field": "value",
             "comp\\lex.nested": {"field": 42},
             "nested": {"comp\\lex.field": 1337},
-            "\\u\\0\\1\\x\y": 1338,  # pylint: disable=anomalous-backslash-in-string
-            "\\u\\0\\1\\x\z": "whatever",  # pylint: disable=anomalous-backslash-in-string
+            "\\u\\0\\1\\x\\y": 1338,  # pylint: disable=anomalous-backslash-in-string
+            "\\u\\0\\1\\x\\z": "whatever",  # pylint: disable=anomalous-backslash-in-string
         },
         id="Add from rule definition with escaping",
     ),
@@ -454,7 +454,7 @@ class TestGenericAdder(BaseProcessorTestCase):
         event = {}
         instance.process(event)
 
-        rule_add = instance.rules[0].add
+        rule_add = instance.rules[0].add({})
 
         assert event["some_list_field"] == ["some_value"]
         assert event["some_list_field"] is not rule_add["some_list_field"], "only copies in events"

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -7,11 +7,14 @@ import typing
 from copy import deepcopy
 
 import pytest
+import responses
 
 from logprep.factory import Factory
 from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.generic_adder.processor import GenericAdder
+from logprep.util.getter import RefreshableGetter
 from tests.unit.processor.base import BaseProcessorTestCase
+from tests.conftest import mock_env
 
 RULES_DIR_MISSING = "tests/testdata/unit/generic_adder/rules_missing"
 RULES_DIR_INVALID = "tests/testdata/unit/generic_adder/rules_invalid"
@@ -461,3 +464,56 @@ class TestGenericAdder(BaseProcessorTestCase):
 
         assert event["some_dict_field"] == {"some_key": "some_value"}
         assert event["some_dict_field"] is not rule_add["some_dict_field"], "only copies in events"
+
+    @responses.activate
+    def test_adds_mapped_response_fields_from_event_templated_url(self):
+        resolved_url = "https://values.example/acme"
+        responses.add(
+            responses.GET,
+            resolved_url,
+            json={
+                "user": {"name": "Alice"},
+                "risk": {"score": 7},
+            },
+        )
+        configuration = {
+            "dynamic_generic_adder": {
+                "type": "generic_adder",
+                "rules": [
+                    {
+                        "filter": "*",
+                        "generic_adder": {
+                            "add_from_url": {
+                                "url": "https://${GENERIC_ADDER_HOST}/${tenant.id}",
+                                "target_field_mapping": {
+                                    "user.name": "enrichment.user",
+                                    "risk.score": "enrichment.score",
+                                },
+                            }
+                        },
+                    }
+                ],
+            }
+        }
+
+        RefreshableGetter.reset()
+        with mock_env({"GENERIC_ADDER_HOST": "values.example"}):
+            processor = typing.cast(GenericAdder, self._create_test_instance(configuration))
+            processor.setup()
+
+            first_event = {"tenant": {"id": "acme"}}
+            second_event = {"tenant": {"id": "acme"}}
+            first_result = processor.process(first_event)
+            second_result = processor.process(second_event)
+
+            processor.shut_down()
+
+        assert first_result.errors == []
+        assert second_result.errors == []
+        assert first_event == {
+            "tenant": {"id": "acme"},
+            "enrichment": {"user": "Alice", "score": 7},
+        }
+        assert second_event == first_event
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == resolved_url

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -295,7 +295,7 @@ test_cases = [  # testcase, rule, event, expected
         {
             "add_generic_test": "Test",
             "event_id": 123,
-            "\\u\\0\\1\\x\\z": "whatever",  # pylint: disable=anomalous-backslash-in-string
+            "\\u\\0\\1\\x\\z": "whatever",
         },
         {
             "add_generic_test": "Test",
@@ -303,8 +303,8 @@ test_cases = [  # testcase, rule, event, expected
             "comp\\lex.field": "value",
             "comp\\lex.nested": {"field": 42},
             "nested": {"comp\\lex.field": 1337},
-            "\\u\\0\\1\\x\\y": 1338,  # pylint: disable=anomalous-backslash-in-string
-            "\\u\\0\\1\\x\\z": "whatever",  # pylint: disable=anomalous-backslash-in-string
+            "\\u\\0\\1\\x\\y": 1338,
+            "\\u\\0\\1\\x\\z": "whatever",
         },
         id="Add from rule definition with escaping",
     ),

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -10,11 +10,14 @@ import pytest
 import responses
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError, ProcessingWarning
+from logprep.processor.base.exceptions import (
+    InvalidRuleDefinitionError,
+    ProcessingWarning,
+)
 from logprep.processor.generic_adder.processor import GenericAdder
 from logprep.util.getter import HttpGetter, RefreshableGetter
-from tests.unit.processor.base import BaseProcessorTestCase
 from tests.conftest import mock_env
+from tests.unit.processor.base import BaseProcessorTestCase
 
 RULES_DIR_MISSING = "tests/testdata/unit/generic_adder/rules_missing"
 RULES_DIR_INVALID = "tests/testdata/unit/generic_adder/rules_invalid"

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -406,6 +406,7 @@ class TestGenericAdder(BaseProcessorTestCase):
     @pytest.mark.parametrize("rule, event, expected", test_cases)
     def test_generic_adder_testcases(self, rule, event, expected):
         self._load_rule(rule)
+        self.object.setup()
         self.object.process(event)
         assert event == expected
 
@@ -422,7 +423,7 @@ class TestGenericAdder(BaseProcessorTestCase):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
-            Factory.create(configuration)
+            Factory.create(configuration).setup()
 
     def test_add_generic_fields_from_file_invalid(self):
         with pytest.raises(
@@ -432,7 +433,7 @@ class TestGenericAdder(BaseProcessorTestCase):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_INVALID]
             configuration = {"test processor": config}
-            Factory.create(configuration)
+            Factory.create(configuration).setup()
 
     def test_add_only_copies(self):
         instance = typing.cast(

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -419,21 +419,24 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert event == expected
 
     def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
-        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic-adder URI"):
+        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic_adder URI"):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
             Factory.create(configuration).setup()
 
     def test_add_generic_fields_from_file_invalid(self):
-        with pytest.raises(
-            InvalidRuleDefinitionError,
-            match=r"without target_field must contain a mapping",
-        ):
-            config = deepcopy(self.CONFIG)
-            config["rules"] = [RULES_DIR_INVALID]
-            configuration = {"test processor": config}
-            Factory.create(configuration).setup()
+        config = deepcopy(self.CONFIG)
+        config["rules"] = [RULES_DIR_INVALID]
+        configuration = {"test processor": config}
+        processor = Factory.create(configuration)
+        processor.setup()
+
+        result = processor.process({"add_list_invalid_generic_test": True})
+
+        assert len(result.warnings) == 1
+        assert isinstance(result.warnings[0], ProcessingWarning)
+        assert "without target_field must contain a mapping" in str(result.warnings[0])
 
     def test_add_only_copies(self):
         instance = typing.cast(

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -15,7 +15,7 @@ from logprep.processor.base.exceptions import (
     ProcessingWarning,
 )
 from logprep.processor.generic_adder.processor import GenericAdder
-from logprep.util.getter import HttpGetter, RefreshableGetter
+from logprep.util.getter import HttpGetter
 from tests.conftest import mock_env
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -491,7 +491,6 @@ class TestGenericAdder(BaseProcessorTestCase):
             }
         }
 
-        RefreshableGetter.reset()
         with mock_env({"GENERIC_ADDER_HOST": "values.example"}):
             processor = typing.cast(GenericAdder, self._create_test_instance(configuration))
             processor.setup()
@@ -519,7 +518,6 @@ class TestGenericAdder(BaseProcessorTestCase):
         successful_url = "https://values.example/beta"
         responses.add(responses.GET, failed_url, status=500)
         responses.add(responses.GET, successful_url, json={"risk": {"score": 7}})
-        RefreshableGetter.reset()
         processor = typing.cast(
             GenericAdder,
             self._create_test_instance(

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -10,9 +10,9 @@ import pytest
 import responses
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError, ProcessingWarning
 from logprep.processor.generic_adder.processor import GenericAdder
-from logprep.util.getter import RefreshableGetter
+from logprep.util.getter import HttpGetter, RefreshableGetter
 from tests.unit.processor.base import BaseProcessorTestCase
 from tests.conftest import mock_env
 
@@ -517,3 +517,137 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert second_event == first_event
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == resolved_url
+
+    @responses.activate
+    def test_dynamic_url_failure_is_event_scoped(self):
+        failed_url = "https://values.example/acme"
+        successful_url = "https://values.example/beta"
+        responses.add(responses.GET, failed_url, status=500)
+        responses.add(responses.GET, successful_url, json={"risk": {"score": 7}})
+        RefreshableGetter.reset()
+        processor = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "dynamic_generic_adder": {
+                        "type": "generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add_from_url": {
+                                        "url": "https://values.example/${tenant}",
+                                        "target_field": "enrichment",
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+        processor.setup()
+        rule = processor.rules[0]
+        failed_event = {"tenant": "acme"}
+        successful_event = {"tenant": "beta"}
+
+        failed_result = processor.process(failed_event)
+        successful_result = processor.process(successful_event)
+
+        assert failed_result.errors == []
+        assert len(failed_result.warnings) == 1
+        assert isinstance(failed_result.warnings[0], ProcessingWarning)
+        assert failed_event == {
+            "tenant": "acme",
+            "tags": ["_generic_adder_failure"],
+        }
+        assert rule.data_error is None
+        assert len(HttpGetter._target_to_data_caches[failed_url].callbacks) == 0
+        assert len(HttpGetter._target_to_data_caches[failed_url].cleanup_callbacks) == 0
+
+        assert successful_result.errors == []
+        assert successful_result.warnings == []
+        assert successful_event == {
+            "tenant": "beta",
+            "enrichment": {"risk": {"score": 7}},
+        }
+
+        processor.shut_down()
+
+    def test_missing_dynamic_url_field_adds_warning_without_clearing_event(self):
+        processor = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "dynamic_generic_adder": {
+                        "type": "generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add_from_url": {
+                                        "url": "https://values.example/${tenant.id}",
+                                        "target_field": "enrichment",
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+        processor.setup()
+        event = {"message": "preserved"}
+
+        result = processor.process(event)
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert "missing event field 'tenant.id'" in str(result.warnings[0])
+        assert event == {
+            "message": "preserved",
+            "tags": ["_generic_adder_failure"],
+        }
+
+    @responses.activate
+    def test_mapping_response_type_error_adds_warning_without_clearing_event(self):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json=["not", "a", "mapping"])
+        RefreshableGetter.reset()
+        processor = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "dynamic_generic_adder": {
+                        "type": "generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add_from_url": {
+                                        "url": "https://values.example/${tenant}",
+                                        "target_field_mapping": {
+                                            "risk.score": "enrichment.score",
+                                        },
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+        processor.setup()
+        event = {"tenant": "acme"}
+
+        result = processor.process(event)
+
+        processor.shut_down()
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert "target_field_mapping requires a mapping response" in str(result.warnings[0])
+        assert event == {
+            "tenant": "acme",
+            "tags": ["_generic_adder_failure"],
+        }

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -419,7 +419,7 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert event == expected
 
     def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
-        with pytest.raises(InvalidRuleDefinitionError, match=r"files do not exist"):
+        with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic-adder URI"):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_MISSING]
             configuration = {"test_instance_name": config}
@@ -428,7 +428,7 @@ class TestGenericAdder(BaseProcessorTestCase):
     def test_add_generic_fields_from_file_invalid(self):
         with pytest.raises(
             InvalidRuleDefinitionError,
-            match=r"must be a dictionary with string values",
+            match=r"without target_field must contain a mapping",
         ):
             config = deepcopy(self.CONFIG)
             config["rules"] = [RULES_DIR_INVALID]
@@ -481,8 +481,8 @@ class TestGenericAdder(BaseProcessorTestCase):
                     {
                         "filter": "*",
                         "generic_adder": {
-                            "add_from_url": {
-                                "url": "https://${GENERIC_ADDER_HOST}/${tenant.id}",
+                            "add_from_uri": {
+                                "uri": "https://${GENERIC_ADDER_HOST}/${tenant.id}",
                                 "target_field": "enrichment",
                             }
                         },
@@ -530,8 +530,8 @@ class TestGenericAdder(BaseProcessorTestCase):
                             {
                                 "filter": "*",
                                 "generic_adder": {
-                                    "add_from_url": {
-                                        "url": "https://values.example/${tenant}",
+                                    "add_from_uri": {
+                                        "uri": "https://values.example/${tenant}",
                                         "target_field": "enrichment",
                                     }
                                 },
@@ -580,8 +580,8 @@ class TestGenericAdder(BaseProcessorTestCase):
                             {
                                 "filter": "*",
                                 "generic_adder": {
-                                    "add_from_url": {
-                                        "url": "https://values.example/${tenant.id}",
+                                    "add_from_uri": {
+                                        "uri": "https://values.example/${tenant.id}",
                                         "target_field": "enrichment",
                                     }
                                 },

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -26,6 +26,139 @@ RULES_DIR_FIRST_EXISTING = "tests/testdata/unit/generic_adder/rules_first_existi
 test_cases = [  # testcase, rule, event, expected
     pytest.param(
         {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_uri": {
+                    "uri": "tests/testdata/unit/generic_adder/additions_file.yml",
+                    "target_field": "uri_content",
+                }
+            },
+        },
+        {"event_id": 123},
+        {
+            "event_id": 123,
+            "uri_content": {
+                "some_added_field": "some value",
+                "another_added_field": "another_value",
+                "dotted.added.field": "yet_another_value",
+            },
+        },
+        id="Add from URI to target field",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_uri": {
+                    "uri": "tests/testdata/unit/generic_adder/additions_list_1.yml",
+                    "target_field": "enrichment.values",
+                }
+            },
+        },
+        {},
+        {"enrichment": {"values": ["first_uri_value"]}},
+        id="Add non-mapping URI response to dotted target field",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add": {"shared_field": {"from_inline_add": True}},
+                "add_from_file": "tests/testdata/unit/generic_adder/additions_merge_1.yml",
+                "merge_with_target": True,
+            },
+        },
+        {},
+        {
+            "shared_field": {
+                "from_inline_add": True,
+                "from_first_source": True,
+            }
+        },
+        id="Merge same field from add and add_from_file",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add": {"shared_field": {"from_inline_add": True}},
+                "add_from_uri": "tests/testdata/unit/generic_adder/additions_merge_1.yml",
+                "merge_with_target": True,
+            },
+        },
+        {},
+        {
+            "shared_field": {
+                "from_inline_add": True,
+                "from_first_source": True,
+            }
+        },
+        id="Merge same field from add and add_from_uri",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_file": [
+                    "tests/testdata/unit/generic_adder/additions_merge_1.yml",
+                    "tests/testdata/unit/generic_adder/additions_merge_2.yml",
+                ],
+                "merge_with_target": True,
+            },
+        },
+        {},
+        {
+            "shared_field": {
+                "from_first_source": True,
+                "from_second_source": True,
+            }
+        },
+        id="Merge same field from two add_from_file sources",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_uri": [
+                    "tests/testdata/unit/generic_adder/additions_merge_1.yml",
+                    "tests/testdata/unit/generic_adder/additions_merge_2.yml",
+                ],
+                "merge_with_target": True,
+            },
+        },
+        {},
+        {
+            "shared_field": {
+                "from_first_source": True,
+                "from_second_source": True,
+            }
+        },
+        id="Merge same field from two add_from_uri sources",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add": {"shared_list": ["inline_value"]},
+                "add_from_uri": [
+                    {
+                        "uri": "tests/testdata/unit/generic_adder/additions_list_1.yml",
+                        "target_field": "shared_list",
+                    },
+                    {
+                        "uri": "tests/testdata/unit/generic_adder/additions_list_2.yml",
+                        "target_field": "shared_list",
+                    },
+                ],
+                "merge_with_target": True,
+            },
+        },
+        {},
+        {"shared_list": ["inline_value", "first_uri_value", "second_uri_value"]},
+        id="Merge lists from inline add and ordered URI sources",
+    ),
+    pytest.param(
+        {
             "filter": "add_list_generic_test",
             "generic_adder": {
                 "add_from_file": "tests/testdata/unit/generic_adder/additions_file.yml"
@@ -395,6 +528,37 @@ failure_test_cases = [
     ),
 ]
 
+dynamic_uri_failure_test_cases = [
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_uri": {
+                    "uri": "https://values.example/${tenant}",
+                    "target_field": "enrichment",
+                }
+            },
+        },
+        {"tenant": ["not", "scalar"]},
+        "value for generic adder field 'tenant' is not a scalar value",
+        id="Reject non-scalar dynamic URI field",
+    ),
+    pytest.param(
+        {
+            "filter": "*",
+            "generic_adder": {
+                "add_from_uri": {
+                    "uri": "tests/testdata/unit/generic_adder/${filename}.yml",
+                    "target_field": "enrichment",
+                }
+            },
+        },
+        {"filename": "additions_file"},
+        "Dynamic file URIs are not supported",
+        id="Reject dynamic file URI",
+    ),
+]
+
 
 class TestGenericAdder(BaseProcessorTestCase):
 
@@ -417,6 +581,18 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert len(result.warnings) == 1
         assert re.match(rf".*FieldExistsWarning.*{error_message}", str(result.warnings[0]))
         assert event == expected
+
+    @pytest.mark.parametrize("rule, event, error_message", dynamic_uri_failure_test_cases)
+    def test_dynamic_uri_failure_handling(self, rule, event, error_message):
+        self._load_rule(rule)
+        self.object.setup()
+
+        result = self.object.process(event)
+
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        assert error_message in str(result.warnings[0])
+        assert event["tags"] == ["_generic_adder_failure"]
 
     def test_add_generic_fields_from_file_missing_and_existing_with_all_required(self):
         with pytest.raises(InvalidRuleDefinitionError, match=r"Could not load generic_adder URI"):
@@ -514,6 +690,44 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert second_event == first_event
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == resolved_url
+
+    @responses.activate
+    def test_shutdown_removes_dynamic_uri_callbacks(self):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json={"value": 1})
+        processor = typing.cast(
+            GenericAdder,
+            self._create_test_instance(
+                {
+                    "dynamic_generic_adder": {
+                        "type": "generic_adder",
+                        "rules": [
+                            {
+                                "filter": "*",
+                                "generic_adder": {
+                                    "add_from_uri": {
+                                        "uri": "https://values.example/${tenant}",
+                                        "target_field": "enrichment",
+                                    }
+                                },
+                            }
+                        ],
+                    }
+                }
+            ),
+        )
+        processor.setup()
+
+        processor.process({"tenant": "acme"})
+
+        shared = HttpGetter._target_to_data_caches[url]
+        assert len(shared.callbacks) == 1
+        assert len(shared.cleanup_callbacks) == 1
+
+        processor.shut_down()
+
+        assert shared.callbacks == []
+        assert shared.cleanup_callbacks == []
 
     @responses.activate
     def test_dynamic_url_failure_is_event_scoped(self):

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -470,16 +470,10 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert event["some_dict_field"] is not rule_add["some_dict_field"], "only copies in events"
 
     @responses.activate
-    def test_adds_mapped_response_fields_from_event_templated_url(self):
+    def test_adds_response_from_event_templated_url(self):
         resolved_url = "https://values.example/acme"
-        responses.add(
-            responses.GET,
-            resolved_url,
-            json={
-                "user": {"name": "Alice"},
-                "risk": {"score": 7},
-            },
-        )
+        response_content = {"user": {"name": "Alice"}, "risk": {"score": 7}}
+        responses.add(responses.GET, resolved_url, json=response_content)
         configuration = {
             "dynamic_generic_adder": {
                 "type": "generic_adder",
@@ -489,10 +483,7 @@ class TestGenericAdder(BaseProcessorTestCase):
                         "generic_adder": {
                             "add_from_url": {
                                 "url": "https://${GENERIC_ADDER_HOST}/${tenant.id}",
-                                "target_field_mapping": {
-                                    "user.name": "enrichment.user",
-                                    "risk.score": "enrichment.score",
-                                },
+                                "target_field": "enrichment",
                             }
                         },
                     }
@@ -516,7 +507,7 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert second_result.errors == []
         assert first_event == {
             "tenant": {"id": "acme"},
-            "enrichment": {"user": "Alice", "score": 7},
+            "enrichment": response_content,
         }
         assert second_event == first_event
         assert len(responses.calls) == 1
@@ -610,48 +601,5 @@ class TestGenericAdder(BaseProcessorTestCase):
         assert "missing event field 'tenant.id'" in str(result.warnings[0])
         assert event == {
             "message": "preserved",
-            "tags": ["_generic_adder_failure"],
-        }
-
-    @responses.activate
-    def test_mapping_response_type_error_adds_warning_without_clearing_event(self):
-        url = "https://values.example/acme"
-        responses.add(responses.GET, url, json=["not", "a", "mapping"])
-        RefreshableGetter.reset()
-        processor = typing.cast(
-            GenericAdder,
-            self._create_test_instance(
-                {
-                    "dynamic_generic_adder": {
-                        "type": "generic_adder",
-                        "rules": [
-                            {
-                                "filter": "*",
-                                "generic_adder": {
-                                    "add_from_url": {
-                                        "url": "https://values.example/${tenant}",
-                                        "target_field_mapping": {
-                                            "risk.score": "enrichment.score",
-                                        },
-                                    }
-                                },
-                            }
-                        ],
-                    }
-                }
-            ),
-        )
-        processor.setup()
-        event = {"tenant": "acme"}
-
-        result = processor.process(event)
-
-        processor.shut_down()
-
-        assert result.errors == []
-        assert len(result.warnings) == 1
-        assert "target_field_mapping requires a mapping response" in str(result.warnings[0])
-        assert event == {
-            "tenant": "acme",
             "tags": ["_generic_adder_failure"],
         }

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -101,7 +101,7 @@ class TestGenericAdderRule:
             "generic_adder": {"add": {"added_bool_field": True}},
         }
         rule = GenericAdderRule.create_from_dict(rule_definition)
-        assert isinstance(rule.add.get("added_bool_field"), bool)
+        assert isinstance(rule.add({}).get("added_bool_field"), bool)
 
     @responses.activate
     def test_rule_callback_updates_additions_and_preserves_original_add(self, tmp_path):
@@ -146,11 +146,11 @@ class TestGenericAdderRule:
         with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             rule = GenericAdderRule.create_from_dict(rule_definition)
-            assert rule.add == expected_1
+            assert rule.add({}) == expected_1
             HttpGetter.refresh()
-            assert rule.add == expected_1
+            assert rule.add({}) == expected_1
             scheduler.run_all()
-            assert rule.add == expected_2
-            assert rule.add == expected_2
+            assert rule.add({}) == expected_2
+            assert rule.add({}) == expected_2
             scheduler.run_all()
-            assert rule.add == expected_3
+            assert rule.add({}) == expected_3

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -1,12 +1,13 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 import json
+import typing
 from pathlib import Path
 
 import pytest
 import responses
 
-from logprep.processor.generic_adder.rule import GenericAdderRule
+from logprep.processor.generic_adder.rule import AddFromUrlConfig, GenericAdderRule
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import HttpGetter, RefreshableGetter
 from tests.conftest import mock_env
@@ -28,6 +29,117 @@ def fixture_rule_definition():
 
 
 class TestGenericAdderRule:
+    @pytest.mark.parametrize(
+        ("url_config", "expected_target_field", "expected_target_field_mapping"),
+        [
+            pytest.param(
+                {
+                    "url": "https://values.example/${tenant.id}",
+                    "target_field": "enrichment",
+                },
+                "enrichment",
+                {},
+                id="whole-response",
+            ),
+            pytest.param(
+                {
+                    "url": "https://values.example/${tenant.id}",
+                    "target_field_mapping": {
+                        "user.name": "enrichment.user",
+                        "risk.score": "enrichment.score",
+                    },
+                },
+                None,
+                {
+                    "user.name": "enrichment.user",
+                    "risk.score": "enrichment.score",
+                },
+                id="field-mapping",
+            ),
+        ],
+    )
+    def test_converts_add_from_url_configuration(
+        self, url_config, expected_target_field, expected_target_field_mapping
+    ):
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {"add_from_url": url_config},
+            }
+        )
+
+        config = typing.cast(GenericAdderRule.Config, rule._config)
+
+        assert isinstance(config.add_from_url, AddFromUrlConfig)
+        assert config.add_from_url.target_field == expected_target_field
+        assert config.add_from_url.target_field_mapping == expected_target_field_mapping
+
+    @pytest.mark.parametrize(
+        ("url_config", "error_message"),
+        [
+            pytest.param(
+                {"url": "https://values.example/${tenant}"},
+                "requires target_field or target_field_mapping",
+                id="missing-target",
+            ),
+            pytest.param(
+                {
+                    "url": "https://values.example/${tenant}",
+                    "target_field": "enrichment",
+                    "target_field_mapping": {"risk": "enrichment.risk"},
+                },
+                "only one of target_field or target_field_mapping",
+                id="ambiguous-target",
+            ),
+        ],
+    )
+    def test_rejects_invalid_add_from_url_target_configuration(self, url_config, error_message):
+        with pytest.raises(ValueError, match=error_message):
+            GenericAdderRule.create_from_dict(
+                {
+                    "filter": "*",
+                    "generic_adder": {"add_from_url": url_config},
+                }
+            )
+
+    def test_rejects_rule_without_addition_source(self):
+        with pytest.raises(
+            ValueError,
+            match="one of add, add_from_file or add_from_url",
+        ):
+            GenericAdderRule.create_from_dict(
+                {
+                    "filter": "*",
+                    "generic_adder": {},
+                }
+            )
+
+    @responses.activate
+    def test_resolves_dotted_event_field_and_adds_complete_response(self):
+        resolved_url = "https://values.example/acme"
+        response_content = {
+            "user": {"name": "Alice"},
+            "risk": {"score": 7},
+        }
+        responses.add(responses.GET, resolved_url, json=response_content)
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_url": {
+                        "url": "https://values.example/${tenant.id}",
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+        rule.init_generic_adder("generic-adder-test")
+
+        additions = rule.add({"tenant": {"id": "acme"}})
+
+        assert additions == {"enrichment": response_content}
+        assert responses.calls[0].request.url == resolved_url
+
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",
         [

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import responses
 
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.generic_adder.rule import GenericAdderRule, UriConfig
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
@@ -229,12 +230,9 @@ class TestGenericAdderRule:
         assert rule.add({"tenant": "acme"}) == {"enrichment": response_content["payload"]}
 
     @responses.activate
-    def test_static_url_recovers_after_failed_initial_load(self, tmp_path):
+    def test_static_url_failed_initial_load_raises(self):
         url = "https://values.example/static"
-        response_content = {"risk": {"score": 7}}
         responses.add(responses.GET, url, status=500)
-        getter_config = tmp_path / "http_getter.json"
-        getter_config.write_text(json.dumps({url: {"refresh_interval": 1}}))
         rule = GenericAdderRule.create_from_dict(
             {
                 "filter": "*",
@@ -247,21 +245,11 @@ class TestGenericAdderRule:
             }
         )
 
-        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(getter_config)}):
+        with pytest.raises(
+            InvalidRuleDefinitionError,
+            match=r"Could not load generic_adder URI 'https://values.example/static'",
+        ):
             rule.init_generic_adder("generic-adder-test")
-            getter = GetterFactory.from_string(url)
-            assert isinstance(getter, HttpGetter)
-            assert getter.scheduler is not None
-
-            assert rule.data_error is not None
-            assert len(getter.shared.callbacks) == 1
-            assert len(getter.shared.cleanup_callbacks) == 0
-
-            responses.replace(responses.GET, url, json=response_content)
-            getter.scheduler.run_all()
-
-        assert rule.data_error is None
-        assert rule.add({}) == {"enrichment": response_content}
 
     def test_merges_inline_and_ordered_file_uri_sources(self, tmp_path):
         first_file = tmp_path / "first.json"

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import responses
 
-from logprep.processor.generic_adder.rule import AddFromUrlConfig, GenericAdderRule
+from logprep.processor.generic_adder.rule import GenericAdderRule, UriTargetConfig
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
 from tests.conftest import mock_env
@@ -29,13 +29,13 @@ def fixture_rule_definition():
 
 
 class TestGenericAdderRule:
-    def test_converts_add_from_url_configuration(self):
+    def test_converts_add_from_uri_configuration(self):
         rule = GenericAdderRule.create_from_dict(
             {
                 "filter": "*",
                 "generic_adder": {
-                    "add_from_url": {
-                        "url": "https://values.example/${tenant.id}",
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant.id}",
                         "target_field": "enrichment",
                     }
                 },
@@ -44,22 +44,77 @@ class TestGenericAdderRule:
 
         config = typing.cast(GenericAdderRule.Config, rule._config)
 
-        assert isinstance(config.add_from_url, AddFromUrlConfig)
-        assert config.add_from_url.target_field == "enrichment"
+        assert len(config.add_from_uri) == 1
+        assert isinstance(config.add_from_uri[0], UriTargetConfig)
+        assert config.add_from_uri[0].target_field == "enrichment"
 
-    def test_rejects_add_from_url_without_target_field(self):
+    def test_converts_mixed_add_from_uri_configuration(self):
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": [
+                        "tests/testdata/unit/generic_adder/additions_file.yml",
+                        {
+                            "uri": "https://values.example/${tenant.id}",
+                            "target_field": "enrichment",
+                        },
+                    ]
+                },
+            }
+        )
+
+        config = typing.cast(GenericAdderRule.Config, rule._config)
+
+        assert config.add_from_uri[0] == ("tests/testdata/unit/generic_adder/additions_file.yml")
+        assert config.add_from_uri[1] == UriTargetConfig(
+            uri="https://values.example/${tenant.id}",
+            target_field="enrichment",
+        )
+
+    def test_rejects_add_from_uri_without_target_field(self):
         with pytest.raises(TypeError, match="missing.*target_field"):
             GenericAdderRule.create_from_dict(
                 {
                     "filter": "*",
-                    "generic_adder": {"add_from_url": {"url": "https://values.example/${tenant}"}},
+                    "generic_adder": {"add_from_uri": {"uri": "https://values.example/${tenant}"}},
+                }
+            )
+
+    def test_rejects_deprecated_and_new_uri_configuration_together(self):
+        with pytest.raises(
+            ValueError,
+            match="add_from_file and new add_from_uri cannot both be configured",
+        ):
+            GenericAdderRule.create_from_dict(
+                {
+                    "filter": "*",
+                    "generic_adder": {
+                        "add_from_file": "legacy.yml",
+                        "add_from_uri": "new.yml",
+                    },
+                }
+            )
+
+    def test_rejects_only_first_existing_file_for_new_uri_configuration(self):
+        with pytest.raises(
+            ValueError,
+            match="only_first_existing_file is only supported with deprecated add_from_file",
+        ):
+            GenericAdderRule.create_from_dict(
+                {
+                    "filter": "*",
+                    "generic_adder": {
+                        "add_from_uri": ["first.yml", "second.yml"],
+                        "only_first_existing_file": True,
+                    },
                 }
             )
 
     def test_rejects_rule_without_addition_source(self):
         with pytest.raises(
             ValueError,
-            match="one of add, add_from_file or add_from_url",
+            match="one of add or add_from_uri",
         ):
             GenericAdderRule.create_from_dict(
                 {
@@ -80,8 +135,8 @@ class TestGenericAdderRule:
             {
                 "filter": "*",
                 "generic_adder": {
-                    "add_from_url": {
-                        "url": "https://values.example/${tenant.id}",
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant.id}",
                         "target_field": "enrichment",
                     }
                 },
@@ -104,8 +159,8 @@ class TestGenericAdderRule:
             {
                 "filter": "*",
                 "generic_adder": {
-                    "add_from_url": {
-                        "url": url,
+                    "add_from_uri": {
+                        "uri": url,
                         "target_field": "enrichment",
                     }
                 },
@@ -132,8 +187,8 @@ class TestGenericAdderRule:
             {
                 "filter": "*",
                 "generic_adder": {
-                    "add_from_url": {
-                        "url": url,
+                    "add_from_uri": {
+                        "uri": url,
                         "target_field": "enrichment",
                     }
                 },
@@ -155,6 +210,114 @@ class TestGenericAdderRule:
 
         assert rule.data_error is None
         assert rule.add({}) == {"enrichment": response_content}
+
+    def test_merges_inline_and_ordered_file_uri_sources(self, tmp_path):
+        first_file = tmp_path / "first.json"
+        second_file = tmp_path / "second.json"
+        first_file.write_text(json.dumps({"first": True, "shared": "first"}))
+        second_file.write_text(json.dumps({"second": True, "shared": "second"}))
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add": {"inline": True, "shared": "inline"},
+                    "add_from_uri": [str(first_file), str(second_file)],
+                },
+            }
+        )
+
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({}) == {
+            "inline": True,
+            "first": True,
+            "second": True,
+            "shared": "second",
+        }
+
+    @responses.activate
+    def test_same_uri_can_add_content_to_multiple_target_fields(self):
+        url = "https://values.example/shared"
+        response_content = {"risk": {"score": 7}}
+        responses.add(responses.GET, url, json=response_content)
+        responses.add(responses.GET, url, json=response_content)
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": [
+                        {"uri": url, "target_field": "first"},
+                        {"uri": url, "target_field": "second"},
+                    ]
+                },
+            }
+        )
+
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({}) == {
+            "first": response_content,
+            "second": response_content,
+        }
+        assert len(HttpGetter._target_to_data_caches[url].callbacks) == 2
+
+    @responses.activate
+    def test_dynamic_uri_caches_each_resolved_uri_independently(self):
+        first_url = "https://values.example/first"
+        second_url = "https://values.example/second"
+        responses.add(responses.GET, first_url, json={"value": 1})
+        responses.add(responses.GET, second_url, json={"value": 2})
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant}",
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({"tenant": "first"}) == {"enrichment": {"value": 1}}
+        assert rule.add({"tenant": "second"}) == {"enrichment": {"value": 2}}
+        assert rule.add({"tenant": "first"}) == {"enrichment": {"value": 1}}
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_dynamic_uri_refreshes_and_cleans_up_its_source_cache(self, tmp_path):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json={"value": 1})
+        getter_config = tmp_path / "http_getter.json"
+        getter_config.write_text(json.dumps({url: {"refresh_interval": 1, "timeout_interval": 1}}))
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant}",
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(getter_config)}):
+            rule.init_generic_adder("generic-adder-test")
+            assert rule.add({"tenant": "acme"}) == {"enrichment": {"value": 1}}
+            source = rule._uri_sources[0]
+            getter = GetterFactory.from_string(url)
+            assert isinstance(getter, HttpGetter)
+            assert getter.scheduler is not None
+
+            responses.replace(responses.GET, url, json={"value": 2})
+            getter.scheduler.run_all()
+
+            assert rule.add({"tenant": "acme"}) == {"enrichment": {"value": 2}}
+            RefreshableGetter.reset(cleanup=True)
+
+        assert source.content_by_uri == {}
 
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",
@@ -201,14 +364,14 @@ class TestGenericAdderRule:
                 False,
             ),
             (
-                "Should be equal cause file value results in same add values",
+                "Should not be equal because URI configuration is part of rule identity",
                 {
                     "filter": "add_generic_test",
                     "generic_adder": {
                         "add_from_file": "tests/testdata/unit/generic_adder/additions_file.yml"
                     },
                 },
-                True,
+                False,
             ),
         ],
     )

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -288,6 +288,8 @@ class TestGenericAdderRule:
     ):
         rule1 = GenericAdderRule.create_from_dict(rule_definition)
         rule2 = GenericAdderRule.create_from_dict(other_rule_definition)
+        rule1.init_generic_adder("generic-adder-test")
+        rule2.init_generic_adder("generic-adder-test")
         assert (rule1 == rule2) == is_equal, testcase
 
     def test_rule_accepts_bool_type(self):
@@ -341,6 +343,7 @@ class TestGenericAdderRule:
         with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(http_getter_conf)}):
             scheduler = HttpGetter(protocol="http", target=url).scheduler
             rule = GenericAdderRule.create_from_dict(rule_definition)
+            rule.init_generic_adder("generic-adder-test")
             assert rule.add({}) == expected_1
             HttpGetter.refresh()
             assert rule.add({}) == expected_1

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -154,7 +154,6 @@ class TestGenericAdderRule:
         url = "https://values.example/static"
         response_content = {"risk": {"score": 7}}
         responses.add(responses.GET, url, json=response_content)
-        RefreshableGetter.reset()
         rule = GenericAdderRule.create_from_dict(
             {
                 "filter": "*",
@@ -180,7 +179,6 @@ class TestGenericAdderRule:
         url = "https://values.example/static"
         response_content = {"risk": {"score": 7}}
         responses.add(responses.GET, url, status=500)
-        RefreshableGetter.reset()
         getter_config = tmp_path / "http_getter.json"
         getter_config.write_text(json.dumps({url: {"refresh_interval": 1}}))
         rule = GenericAdderRule.create_from_dict(
@@ -430,8 +428,6 @@ class TestGenericAdderRule:
         responses.add(responses.GET, url, json=from_http_1)
         responses.add(responses.GET, url, json=from_http_2)
         responses.add(responses.GET, url, json=from_http_3)
-
-        RefreshableGetter.reset()
 
         getter_file_content = {url: {"refresh_interval": 10}}
         http_getter_conf: Path = tmp_path / "http_getter.json"

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -359,6 +359,112 @@ class TestGenericAdderRule:
 
         assert source.content_by_uri == {}
 
+    @responses.activate
+    def test_dynamic_uri_refresh_failure_keeps_last_value_and_later_recovers(self, tmp_path):
+        url = "https://values.example/acme"
+        responses.add(responses.GET, url, json={"value": 1})
+        getter_config = tmp_path / "http_getter.json"
+        getter_config.write_text(json.dumps({url: {"refresh_interval": 1}}))
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant}",
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(getter_config)}):
+            rule.init_generic_adder("generic-adder-test")
+            assert rule.add({"tenant": "acme"}) == {"enrichment": {"value": 1}}
+            getter = GetterFactory.from_string(url)
+            assert isinstance(getter, HttpGetter)
+            assert getter.scheduler is not None
+
+            responses.replace(responses.GET, url, status=500)
+            getter.scheduler.run_all()
+
+            assert rule.add({"tenant": "acme"}) == {"enrichment": {"value": 1}}
+            assert rule.data_error is None
+
+            responses.replace(responses.GET, url, json={"value": 2})
+            getter.scheduler.run_all()
+
+            assert rule.add({"tenant": "acme"}) == {"enrichment": {"value": 2}}
+            assert rule.data_error is None
+
+    @responses.activate
+    def test_static_uri_refresh_failures_are_aggregated_and_recover(self, tmp_path):
+        first_url = "https://values.example/first"
+        second_url = "https://values.example/second"
+        responses.add(responses.GET, first_url, json={"value": 1})
+        responses.add(responses.GET, second_url, json={"value": 2})
+        getter_config = tmp_path / "http_getter.json"
+        getter_config.write_text(
+            json.dumps(
+                {
+                    first_url: {"refresh_interval": 1},
+                    second_url: {"refresh_interval": 1},
+                }
+            )
+        )
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": [
+                        {"uri": first_url, "target_field": "first"},
+                        {"uri": second_url, "target_field": "second"},
+                    ]
+                },
+            }
+        )
+
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(getter_config)}):
+            rule.init_generic_adder("generic-adder-test")
+            first_getter = GetterFactory.from_string(first_url)
+            second_getter = GetterFactory.from_string(second_url)
+            assert isinstance(first_getter, HttpGetter)
+            assert isinstance(second_getter, HttpGetter)
+            assert first_getter.scheduler is not None
+            assert second_getter.scheduler is not None
+
+            responses.replace(
+                responses.GET,
+                first_url,
+                body="{invalid",
+                content_type="application/json",
+            )
+            responses.replace(
+                responses.GET,
+                second_url,
+                body="{invalid",
+                content_type="application/json",
+            )
+            first_getter.scheduler.run_all()
+            second_getter.scheduler.run_all()
+
+            assert isinstance(rule.data_error, ExceptionGroup)
+            assert len(rule.data_error.exceptions) == 2
+
+            responses.replace(responses.GET, first_url, json={"value": 3})
+            first_getter.scheduler.run_all()
+
+            assert rule.data_error is not None
+            assert not isinstance(rule.data_error, ExceptionGroup)
+
+            responses.replace(responses.GET, second_url, json={"value": 4})
+            second_getter.scheduler.run_all()
+
+            assert rule.data_error is None
+            assert rule.add({}) == {
+                "first": {"value": 3},
+                "second": {"value": 4},
+            }
+
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",
         [

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -29,76 +29,30 @@ def fixture_rule_definition():
 
 
 class TestGenericAdderRule:
-    @pytest.mark.parametrize(
-        ("url_config", "expected_target_field", "expected_target_field_mapping"),
-        [
-            pytest.param(
-                {
-                    "url": "https://values.example/${tenant.id}",
-                    "target_field": "enrichment",
-                },
-                "enrichment",
-                {},
-                id="whole-response",
-            ),
-            pytest.param(
-                {
-                    "url": "https://values.example/${tenant.id}",
-                    "target_field_mapping": {
-                        "user.name": "enrichment.user",
-                        "risk.score": "enrichment.score",
-                    },
-                },
-                None,
-                {
-                    "user.name": "enrichment.user",
-                    "risk.score": "enrichment.score",
-                },
-                id="field-mapping",
-            ),
-        ],
-    )
-    def test_converts_add_from_url_configuration(
-        self, url_config, expected_target_field, expected_target_field_mapping
-    ):
+    def test_converts_add_from_url_configuration(self):
         rule = GenericAdderRule.create_from_dict(
             {
                 "filter": "*",
-                "generic_adder": {"add_from_url": url_config},
+                "generic_adder": {
+                    "add_from_url": {
+                        "url": "https://values.example/${tenant.id}",
+                        "target_field": "enrichment",
+                    }
+                },
             }
         )
 
         config = typing.cast(GenericAdderRule.Config, rule._config)
 
         assert isinstance(config.add_from_url, AddFromUrlConfig)
-        assert config.add_from_url.target_field == expected_target_field
-        assert config.add_from_url.target_field_mapping == expected_target_field_mapping
+        assert config.add_from_url.target_field == "enrichment"
 
-    @pytest.mark.parametrize(
-        ("url_config", "error_message"),
-        [
-            pytest.param(
-                {"url": "https://values.example/${tenant}"},
-                "requires target_field or target_field_mapping",
-                id="missing-target",
-            ),
-            pytest.param(
-                {
-                    "url": "https://values.example/${tenant}",
-                    "target_field": "enrichment",
-                    "target_field_mapping": {"risk": "enrichment.risk"},
-                },
-                "only one of target_field or target_field_mapping",
-                id="ambiguous-target",
-            ),
-        ],
-    )
-    def test_rejects_invalid_add_from_url_target_configuration(self, url_config, error_message):
-        with pytest.raises(ValueError, match=error_message):
+    def test_rejects_add_from_url_without_target_field(self):
+        with pytest.raises(TypeError, match="missing.*target_field"):
             GenericAdderRule.create_from_dict(
                 {
                     "filter": "*",
-                    "generic_adder": {"add_from_url": url_config},
+                    "generic_adder": {"add_from_url": {"url": "https://values.example/${tenant}"}},
                 }
             )
 
@@ -201,27 +155,6 @@ class TestGenericAdderRule:
 
         assert rule.data_error is None
         assert rule.add({}) == {"enrichment": response_content}
-
-    def test_target_field_mapping_skips_missing_values_but_preserves_none(self, caplog):
-        rule = GenericAdderRule.create_from_dict(
-            {
-                "filter": "*",
-                "generic_adder": {
-                    "add_from_url": {
-                        "url": "https://values.example/${tenant}",
-                        "target_field_mapping": {
-                            "present": "enrichment.present",
-                            "missing": "enrichment.missing",
-                        },
-                    }
-                },
-            }
-        )
-
-        additions = rule._content_to_items_to_add({"present": None})
-
-        assert additions == {"enrichment.present": None}
-        assert "source_field missing" in caplog.text
 
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import responses
 
-from logprep.processor.generic_adder.rule import GenericAdderRule, UriTargetConfig
+from logprep.processor.generic_adder.rule import GenericAdderRule, UriConfig
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
 from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
 from tests.conftest import mock_env
@@ -45,7 +45,7 @@ class TestGenericAdderRule:
         config = typing.cast(GenericAdderRule.Config, rule._config)
 
         assert len(config.add_from_uri) == 1
-        assert isinstance(config.add_from_uri[0], UriTargetConfig)
+        assert isinstance(config.add_from_uri[0], UriConfig)
         assert config.add_from_uri[0].target_field == "enrichment"
 
     def test_converts_mixed_add_from_uri_configuration(self):
@@ -66,20 +66,25 @@ class TestGenericAdderRule:
 
         config = typing.cast(GenericAdderRule.Config, rule._config)
 
-        assert config.add_from_uri[0] == ("tests/testdata/unit/generic_adder/additions_file.yml")
-        assert config.add_from_uri[1] == UriTargetConfig(
+        assert config.add_from_uri[0] == UriConfig(
+            uri="tests/testdata/unit/generic_adder/additions_file.yml"
+        )
+        assert config.add_from_uri[1] == UriConfig(
             uri="https://values.example/${tenant.id}",
             target_field="enrichment",
         )
 
-    def test_rejects_add_from_uri_without_target_field(self):
-        with pytest.raises(TypeError, match="missing.*target_field"):
-            GenericAdderRule.create_from_dict(
-                {
-                    "filter": "*",
-                    "generic_adder": {"add_from_uri": {"uri": "https://values.example/${tenant}"}},
-                }
-            )
+    def test_accepts_add_from_uri_without_target_field(self):
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {"add_from_uri": {"uri": "https://values.example/${tenant}"}},
+            }
+        )
+
+        config = typing.cast(GenericAdderRule.Config, rule._config)
+
+        assert config.add_from_uri == [UriConfig(uri="https://values.example/${tenant}")]
 
     def test_rejects_deprecated_and_new_uri_configuration_together(self):
         with pytest.raises(
@@ -173,6 +178,55 @@ class TestGenericAdderRule:
         assert len(responses.calls) == 1
         assert len(HttpGetter._target_to_data_caches[url].callbacks) == 1
         assert len(HttpGetter._target_to_data_caches[url].cleanup_callbacks) == 0
+
+    @responses.activate
+    def test_content_field_is_applied_to_static_http_uri(self):
+        url = "https://values.example/static"
+        response_content = {
+            "payload": {"risk": {"score": 7}},
+            "metadata": {"version": 1},
+        }
+        responses.add(responses.GET, url, json=response_content)
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": {
+                        "uri": url,
+                        "target_field": "enrichment",
+                    },
+                    "content_field": "payload",
+                },
+            }
+        )
+
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({}) == {"enrichment": response_content["payload"]}
+
+    @responses.activate
+    def test_content_field_is_applied_to_dynamic_http_uri(self):
+        resolved_url = "https://values.example/acme"
+        response_content = {
+            "payload": {"risk": {"score": 7}},
+            "metadata": {"version": 1},
+        }
+        responses.add(responses.GET, resolved_url, json=response_content)
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_uri": {
+                        "uri": "https://values.example/${tenant}",
+                        "target_field": "enrichment",
+                    },
+                    "content_field": "payload",
+                },
+            }
+        )
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({"tenant": "acme"}) == {"enrichment": response_content["payload"]}
 
     @responses.activate
     def test_static_url_recovers_after_failed_initial_load(self, tmp_path):

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -9,7 +9,7 @@ import responses
 
 from logprep.processor.generic_adder.rule import AddFromUrlConfig, GenericAdderRule
 from logprep.util.defaults import ENV_NAME_LOGPREP_GETTER_CONFIG
-from logprep.util.getter import HttpGetter, RefreshableGetter
+from logprep.util.getter import GetterFactory, HttpGetter, RefreshableGetter
 from tests.conftest import mock_env
 
 
@@ -139,6 +139,89 @@ class TestGenericAdderRule:
 
         assert additions == {"enrichment": response_content}
         assert responses.calls[0].request.url == resolved_url
+
+    @responses.activate
+    def test_static_url_loads_during_setup_and_registers_only_refresh_callback(self):
+        url = "https://values.example/static"
+        response_content = {"risk": {"score": 7}}
+        responses.add(responses.GET, url, json=response_content)
+        RefreshableGetter.reset()
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_url": {
+                        "url": url,
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+
+        rule.init_generic_adder("generic-adder-test")
+
+        assert rule.add({}) == {"enrichment": response_content}
+        assert rule.add({}) == {"enrichment": response_content}
+        assert len(responses.calls) == 1
+        assert len(HttpGetter._target_to_data_caches[url].callbacks) == 1
+        assert len(HttpGetter._target_to_data_caches[url].cleanup_callbacks) == 0
+
+    @responses.activate
+    def test_static_url_recovers_after_failed_initial_load(self, tmp_path):
+        url = "https://values.example/static"
+        response_content = {"risk": {"score": 7}}
+        responses.add(responses.GET, url, status=500)
+        RefreshableGetter.reset()
+        getter_config = tmp_path / "http_getter.json"
+        getter_config.write_text(json.dumps({url: {"refresh_interval": 1}}))
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_url": {
+                        "url": url,
+                        "target_field": "enrichment",
+                    }
+                },
+            }
+        )
+
+        with mock_env({ENV_NAME_LOGPREP_GETTER_CONFIG: str(getter_config)}):
+            rule.init_generic_adder("generic-adder-test")
+            getter = GetterFactory.from_string(url)
+            assert isinstance(getter, HttpGetter)
+            assert getter.scheduler is not None
+
+            assert rule.data_error is not None
+            assert len(getter.shared.callbacks) == 1
+            assert len(getter.shared.cleanup_callbacks) == 0
+
+            responses.replace(responses.GET, url, json=response_content)
+            getter.scheduler.run_all()
+
+        assert rule.data_error is None
+        assert rule.add({}) == {"enrichment": response_content}
+
+    def test_target_field_mapping_skips_missing_values_but_preserves_none(self, caplog):
+        rule = GenericAdderRule.create_from_dict(
+            {
+                "filter": "*",
+                "generic_adder": {
+                    "add_from_url": {
+                        "url": "https://values.example/${tenant}",
+                        "target_field_mapping": {
+                            "present": "enrichment.present",
+                            "missing": "enrichment.missing",
+                        },
+                    }
+                },
+            }
+        )
+
+        additions = rule._content_to_items_to_add({"present": None})
+
+        assert additions == {"enrichment.present": None}
+        assert "source_field: missing" in caplog.text
 
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",

--- a/tests/unit/processor/generic_adder/test_generic_adder_rule.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder_rule.py
@@ -221,7 +221,7 @@ class TestGenericAdderRule:
         additions = rule._content_to_items_to_add({"present": None})
 
         assert additions == {"enrichment.present": None}
-        assert "source_field: missing" in caplog.text
+        assert "source_field missing" in caplog.text
 
     @pytest.mark.parametrize(
         "testcase, other_rule_definition, is_equal",

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1472,6 +1472,31 @@ class TestHttpGetter:
         http_getter.get_collection()
         mock_parse_yaml.assert_called_once()
 
+    @responses.activate
+    def test_get_collection_extracts_content_field(self):
+        responses.add(
+            responses.GET,
+            "http://something",
+            json={"payload": {"answer": 42}},
+        )
+
+        http_getter = GetterFactory.from_string("http://something")
+
+        assert http_getter.get_collection("payload") == {"answer": 42}
+
+    @responses.activate
+    def test_get_collection_rejects_content_field_for_non_mapping_content(self):
+        responses.add(
+            responses.GET,
+            "http://something",
+            json=["one", "two"],
+        )
+
+        http_getter = GetterFactory.from_string("http://something")
+
+        with pytest.raises(ValueError, match="Expected mapping type when content_field is set"):
+            http_getter.get_collection("payload")
+
     @mock.patch("logprep.abc.getter.Getter.get_collection", return_value="not a dict")
     def test_get_dict_raises_exception_if_result_not_dict(self, _):
         http_getter = GetterFactory.from_string("http://something")


### PR DESCRIPTION
## Description

* Briefly summarize your changes in a few bullet points (can and should correspond to [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md))
* Relates to #XXX (insert issue number here), if there is a corresponding GH issue

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* Ran tests

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--998.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->
!-- readthedocs-preview logprep end -->

<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--998.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->