### PR TITLE
feat: processors async apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming Changes
 ### Breaking
 * restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
+* handle non-string `concatenator` source fields with `ProcessingWarning` instead of `ProcessingCriticalError`
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
-* add support for asynchronous rule processing and I/O capability detection to `ng` processors
+* introduce API-level support for asynchronous rule processing and I/O capability detection in `ng` processors
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
+* add support for asynchronous rule processing and I/O capability detection to `ng` processors
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -135,50 +135,50 @@ class Processor(Component):
         self._event = event
         logger.debug("%s processing event %s", self.description, event)
         if self._bypass_rule_tree:
-            self._process_all_rules(event.data)
+            await self._process_all_rules(event.data)
             return self._event
-        self._process_rule_tree(event.data, self._rule_tree)
+        await self._process_rule_tree(event.data, self._rule_tree)
         return self._event
 
-    @Metric.measure_time(self_arg=1)
-    def _process_rule(self, rule, event):
-        self._apply_rules_wrapper(event, rule)
+    @Metric.measure_time_async(self_arg=1)
+    async def _process_rule(self, rule, event):
+        await self._apply_rules_wrapper(event, rule)
         rule.metrics.number_of_processed_events += 1
         return event
 
-    def _process_rule_tree_multiple_times(self, tree: RuleTree, event: dict) -> None:
+    async def _process_rule_tree_multiple_times(self, tree: RuleTree, event: dict) -> None:
         applied_rules = set()
         matching_rules: Iterable[Rule] = tree.get_matching_rules(event)
         while matching_rules:
             for rule in matching_rules:
-                self._process_rule(rule, event)
+                await self._process_rule(rule, event)
                 applied_rules.add(rule)
             matching_rules = set(tree.get_matching_rules(event)).difference(applied_rules)
 
-    def _process_rule_tree_once(self, tree: RuleTree, event: dict) -> None:
+    async def _process_rule_tree_once(self, tree: RuleTree, event: dict) -> None:
         matching_rules = tree.get_matching_rules(event)
         for rule in matching_rules:
-            self._process_rule(rule, event)
+            await self._process_rule(rule, event)
 
-    def _process_rule_tree(self, event: dict, tree: RuleTree) -> None:
+    async def _process_rule_tree(self, event: dict, tree: RuleTree) -> None:
         if self.config.apply_multiple_times:
-            self._process_rule_tree_multiple_times(tree, event)
+            await self._process_rule_tree_multiple_times(tree, event)
         else:
-            self._process_rule_tree_once(tree, event)
+            await self._process_rule_tree_once(tree, event)
 
-    def _process_all_rules(self, event: dict) -> None:
+    async def _process_all_rules(self, event: dict) -> None:
         for rule in self.rules:
             if rule.matches(event):
-                self._process_rule(rule, event)
+                await self._process_rule(rule, event)
 
-    def _apply_rules_wrapper(self, event: dict[str, FieldValue], rule: "Rule") -> None:
+    async def _apply_rules_wrapper(self, event: dict[str, FieldValue], rule: "Rule") -> None:
         try:
             data_error = rule.data_error
             if data_error is not None:
                 self._handle_warning_error(event=event, rule=rule, error=data_error)
                 return
 
-            self._apply_rules(event, rule)
+            await self._apply_rules(event, rule)
         except ProcessingWarning as error:
             self._handle_warning_error(event, rule, error)
         except ProcessingCriticalError as error:
@@ -196,7 +196,7 @@ class Processor(Component):
                 pop_dotted_field_value(self._event.data, dotted_field)
 
     @abstractmethod
-    def _apply_rules(self, event: dict, rule: "Rule"): ...  # pragma: no cover
+    async def _apply_rules(self, event: dict, rule: "Rule"): ...  # pragma: no cover
 
     def test_rules(self) -> dict | None:
         """Perform custom rule tests.

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -4,7 +4,7 @@ import logging
 import typing
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Type
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from attrs import define, field, validators
 
@@ -76,7 +76,7 @@ class Processor(Component):
         "_bypass_rule_tree",
     ]
 
-    rule_class: ClassVar[Type["Rule"] | None] = None
+    rule_class: ClassVar[type[Rule] | None] = None
     _event: LogEvent
     _rule_tree: RuleTree
     _strategy = None
@@ -115,6 +115,11 @@ class Processor(Component):
             "type": self.config.type,
             "name": self.name,
         }
+
+    async def has_asyncio(self) -> bool:
+        """Return whether the processor performs asynchronous I/O operations."""
+
+        return False
 
     async def process(self, event: LogEvent) -> LogEvent:
         """Process a log event.
@@ -227,7 +232,7 @@ class Processor(Component):
     def _handle_warning_error(
         self,
         event: dict[str, FieldValue],
-        rule: "Rule",
+        rule: Rule,
         error: Exception,
         failure_tags: list[str] | None = None,
     ) -> None:

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -4,7 +4,7 @@ import logging
 import typing
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from attrs import define, field, validators
 
@@ -13,6 +13,7 @@ from logprep.metrics.metrics import Metric
 from logprep.ng.abc.component import NgComponent as Component
 from logprep.ng.abc.event import LogEvent
 from logprep.processor.base.exceptions import ProcessingCriticalError, ProcessingWarning
+from logprep.processor.base.rule import Rule
 from logprep.util.environ import ENV_VARS
 from logprep.util.helper import (
     FieldValue,
@@ -23,9 +24,6 @@ from logprep.util.helper import (
     pop_dotted_field_value,
 )
 from logprep.util.rule_loader import RuleLoader
-
-if TYPE_CHECKING:
-    from logprep.processor.base.rule import Rule  # pragma: no cover
 
 
 @define

--- a/logprep/ng/processor/amides/processor.py
+++ b/logprep/ng/processor/amides/processor.py
@@ -100,7 +100,7 @@ from logprep.processor.amides.normalize import CommandLineNormalizer
 from logprep.processor.amides.rule import AmidesRule
 from logprep.processor.base.rule import Rule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 
 logger = logging.getLogger("Amides")
 
@@ -229,7 +229,7 @@ class Amides(FieldManager):
 
         return models
 
-    def _apply_rules(self, event: dict, rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
         rule = typing.cast(AmidesRule, rule)
         cmdline = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [cmdline]):

--- a/logprep/ng/processor/amides/processor.py
+++ b/logprep/ng/processor/amides/processor.py
@@ -229,7 +229,7 @@ class Amides(FieldManager):
 
         return models
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(AmidesRule, rule)
         cmdline = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [cmdline]):

--- a/logprep/ng/processor/calculator/processor.py
+++ b/logprep/ng/processor/calculator/processor.py
@@ -34,7 +34,7 @@ from logprep.processor.base.rule import Rule
 from logprep.processor.calculator.fourFn import BNF
 from logprep.processor.calculator.rule import CalculatorRule
 from logprep.util.decorators import timeout
-from logprep.util.helper import get_source_fields_dict, resolve_template
+from logprep.util.helper import FieldValue, get_source_fields_dict, resolve_template
 
 
 class Calculator(FieldManager):
@@ -42,7 +42,7 @@ class Calculator(FieldManager):
 
     rule_class = CalculatorRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(CalculatorRule, rule)
         source_field_dict = get_source_fields_dict(event, rule)
         if self._handle_missing_fields(event, rule, rule.source_fields, source_field_dict.values()):

--- a/logprep/ng/processor/clusterer/processor.py
+++ b/logprep/ng/processor/clusterer/processor.py
@@ -49,6 +49,7 @@ from attrs import define, field, validators
 
 from logprep.ng.abc.processor import Processor
 from logprep.ng.processor.field_manager.processor import FieldManager
+from logprep.processor.base.rule import Rule
 from logprep.processor.clusterer.rule import ClustererRule
 from logprep.processor.clusterer.signature_calculation.signature_phase import (
     LogRecord,
@@ -96,7 +97,8 @@ class Clusterer(FieldManager):
         self._last_rule_id = None
         self._last_non_extracted_signature = None
 
-    def _apply_rules(self, event, rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+        rule = typing.cast(ClustererRule, rule)
         source_field_values = self._get_field_values(event, rule.source_fields)
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
         if self._is_clusterable(event, rule.source_fields[0]):

--- a/logprep/ng/processor/clusterer/processor.py
+++ b/logprep/ng/processor/clusterer/processor.py
@@ -97,7 +97,7 @@ class Clusterer(FieldManager):
         self._last_rule_id = None
         self._last_non_extracted_signature = None
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(ClustererRule, rule)
         source_field_values = self._get_field_values(event, rule.source_fields)
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)

--- a/logprep/ng/processor/concatenator/processor.py
+++ b/logprep/ng/processor/concatenator/processor.py
@@ -62,9 +62,10 @@ class Concatenator(FieldManager):
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
 
         source_field_values = [field for field in source_field_values if field is not None]
-        source_field_values_str: list[str] = [
-            str(source_field_value) for source_field_value in source_field_values
-        ]
-        target_value = f"{rule.separator}".join(source_field_values_str)
+
+        try:
+            target_value = f"{rule.separator}".join(source_field_values)  # type: ignore[arg-type]
+        except:
+            raise
 
         self._write_target_field(event, rule, target_value)

--- a/logprep/ng/processor/concatenator/processor.py
+++ b/logprep/ng/processor/concatenator/processor.py
@@ -25,9 +25,16 @@ Processor Configuration
 .. automodule:: logprep.processor.concatenator.rule
 """
 
+import typing
+from collections.abc import Iterable
+
 from logprep.ng.processor.field_manager.processor import FieldManager
+from logprep.processor.base.rule import Rule
 from logprep.processor.concatenator.rule import ConcatenatorRule
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import (
+    FieldValue,
+    get_dotted_field_value,
+)
 
 
 class Concatenator(FieldManager):
@@ -35,7 +42,7 @@ class Concatenator(FieldManager):
 
     rule_class = ConcatenatorRule
 
-    def _apply_rules(self, event: dict, rule: ConcatenatorRule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """
         Apply matching rule to given log event.
         In the process of doing so, concat all found source fields into the new target field,
@@ -48,13 +55,22 @@ class Concatenator(FieldManager):
         rule :
             Currently applied concatenator rule.
         """
-        source_field_values = []
-        for source_field in rule.source_fields:
-            field_value = get_dotted_field_value(event, source_field)
-            source_field_values.append(field_value)
-        self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
+        rule = typing.cast(ConcatenatorRule, rule)
 
-        source_field_values = [field for field in source_field_values if field is not None]
-        target_value = f"{rule.separator}".join(source_field_values)
+        source_field_values = [
+            get_dotted_field_value(event, source_field) for source_field in rule.source_fields
+        ]
 
+        self._handle_missing_fields(
+            event,
+            rule,
+            rule.source_fields,
+            source_field_values,
+        )
+
+        string_values = [
+            field_value for field_value in source_field_values if isinstance(field_value, str)
+        ]
+
+        target_value = rule.separator.join(string_values)
         self._write_target_field(event, rule, target_value)

--- a/logprep/ng/processor/concatenator/processor.py
+++ b/logprep/ng/processor/concatenator/processor.py
@@ -28,6 +28,7 @@ Processor Configuration
 import typing
 
 from logprep.ng.processor.field_manager.processor import FieldManager
+from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.concatenator.rule import ConcatenatorRule
 from logprep.util.helper import (
@@ -65,7 +66,12 @@ class Concatenator(FieldManager):
 
         try:
             target_value = f"{rule.separator}".join(source_field_values)  # type: ignore[arg-type]
-        except:
-            raise
+        except TypeError as ex:
+            raise ProcessingWarning(
+                f"Only string values are allowed as source field values in {self.__class__.__name__}",
+                rule=rule,
+                event=event,
+                tags=rule.failure_tags,
+            ) from ex
 
         self._write_target_field(event, rule, target_value)

--- a/logprep/ng/processor/concatenator/processor.py
+++ b/logprep/ng/processor/concatenator/processor.py
@@ -26,7 +26,6 @@ Processor Configuration
 """
 
 import typing
-from collections.abc import Iterable
 
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
@@ -34,6 +33,7 @@ from logprep.processor.concatenator.rule import ConcatenatorRule
 from logprep.util.helper import (
     FieldValue,
     get_dotted_field_value,
+    get_dotted_field_values,
 )
 
 
@@ -57,16 +57,8 @@ class Concatenator(FieldManager):
         """
         rule = typing.cast(ConcatenatorRule, rule)
 
-        source_field_values = [
-            get_dotted_field_value(event, source_field) for source_field in rule.source_fields
-        ]
-
-        self._handle_missing_fields(
-            event,
-            rule,
-            rule.source_fields,
-            source_field_values,
-        )
+        source_field_values = get_dotted_field_values(event, rule.source_fields)
+        self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
 
         string_values = [
             field_value for field_value in source_field_values if isinstance(field_value, str)

--- a/logprep/ng/processor/concatenator/processor.py
+++ b/logprep/ng/processor/concatenator/processor.py
@@ -33,7 +33,6 @@ from logprep.processor.concatenator.rule import ConcatenatorRule
 from logprep.util.helper import (
     FieldValue,
     get_dotted_field_value,
-    get_dotted_field_values,
 )
 
 
@@ -56,13 +55,16 @@ class Concatenator(FieldManager):
             Currently applied concatenator rule.
         """
         rule = typing.cast(ConcatenatorRule, rule)
-
-        source_field_values = get_dotted_field_values(event, rule.source_fields)
+        source_field_values = []
+        for source_field in rule.source_fields:
+            field_value = get_dotted_field_value(event, source_field)
+            source_field_values.append(field_value)
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
 
-        string_values = [
-            field_value for field_value in source_field_values if isinstance(field_value, str)
+        source_field_values = [field for field in source_field_values if field is not None]
+        source_field_values_str: list[str] = [
+            str(source_field_value) for source_field_value in source_field_values
         ]
+        target_value = f"{rule.separator}".join(source_field_values_str)
 
-        target_value = rule.separator.join(string_values)
         self._write_target_field(event, rule, target_value)

--- a/logprep/ng/processor/datetime_extractor/processor.py
+++ b/logprep/ng/processor/datetime_extractor/processor.py
@@ -30,7 +30,7 @@ from datetime import datetime, tzinfo
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
 from logprep.processor.datetime_extractor.rule import DatetimeExtractorRule
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 from logprep.util.time import TimeParser
 
 
@@ -49,7 +49,7 @@ class DatetimeExtractor(FieldManager):
             local_timezone_name += f"{tz_name[:-2]}:{tz_name[-2:]}"
         return local_timezone_name
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(DatetimeExtractorRule, rule)
         datetime_field = rule.source_fields[0]
         destination_field = rule.target_field

--- a/logprep/ng/processor/deduplicator/processor.py
+++ b/logprep/ng/processor/deduplicator/processor.py
@@ -28,7 +28,7 @@ import typing
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.deduplicator.rule import DeduplicatorRule
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import get_dotted_field_value, add_fields_to
 
 
 class Deduplicator(Processor):
@@ -36,7 +36,7 @@ class Deduplicator(Processor):
 
     rule_class = DeduplicatorRule  # type: ignore
 
-    def _apply_rules(self, event: dict, rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
         rule = typing.cast(DeduplicatorRule, rule)
         for field in rule.fields:
             value_list = get_dotted_field_value(event, field)

--- a/logprep/ng/processor/deduplicator/processor.py
+++ b/logprep/ng/processor/deduplicator/processor.py
@@ -28,7 +28,7 @@ import typing
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.deduplicator.rule import DeduplicatorRule
-from logprep.util.helper import get_dotted_field_value, add_fields_to
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 
 class Deduplicator(Processor):

--- a/logprep/ng/processor/deduplicator/processor.py
+++ b/logprep/ng/processor/deduplicator/processor.py
@@ -36,7 +36,7 @@ class Deduplicator(Processor):
 
     rule_class = DeduplicatorRule  # type: ignore
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(DeduplicatorRule, rule)
         for field in rule.fields:
             value_list = get_dotted_field_value(event, field)

--- a/logprep/ng/processor/deleter/processor.py
+++ b/logprep/ng/processor/deleter/processor.py
@@ -23,8 +23,12 @@ Processor Configuration
 .. automodule:: logprep.processor.deleter.rule
 """
 
+import typing
+
 from logprep.ng.abc.processor import Processor
+from logprep.processor.base.rule import Rule
 from logprep.processor.deleter.rule import DeleterRule
+from logprep.util.helper import FieldValue
 
 
 class Deleter(Processor):
@@ -32,6 +36,7 @@ class Deleter(Processor):
 
     rule_class = DeleterRule
 
-    def _apply_rules(self, event: dict, rule: DeleterRule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+        rule = typing.cast(DeleterRule, rule)
         if rule.delete_event:
             event.clear()

--- a/logprep/ng/processor/dissector/processor.py
+++ b/logprep/ng/processor/dissector/processor.py
@@ -26,6 +26,7 @@ Processor Configuration
 .. automodule:: logprep.processor.dissector.rule
 """
 
+import typing
 from collections.abc import Callable, Generator
 
 from logprep.ng.processor.field_manager.processor import FieldManager
@@ -45,7 +46,8 @@ class Dissector(FieldManager):
 
     rule_class = DissectorRule  # type: ignore
 
-    def _apply_rules(self, event, rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+        rule = typing.cast(DissectorRule, rule)
         self.__apply_mapping(event, rule)
         self._apply_convert_datatype(event, rule)
 

--- a/logprep/ng/processor/dissector/processor.py
+++ b/logprep/ng/processor/dissector/processor.py
@@ -46,7 +46,7 @@ class Dissector(FieldManager):
 
     rule_class = DissectorRule  # type: ignore
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(DissectorRule, rule)
         self.__apply_mapping(event, rule)
         self._apply_convert_datatype(event, rule)

--- a/logprep/ng/processor/domain_label_extractor/processor.py
+++ b/logprep/ng/processor/domain_label_extractor/processor.py
@@ -34,7 +34,6 @@ Processor Configuration
 import ipaddress
 import logging
 import typing
-from typing import Any, Dict
 from urllib.parse import urlsplit
 
 from attrs import define, field, validators
@@ -43,6 +42,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
 from logprep.processor.domain_label_extractor.rule import DomainLabelExtractorRule
 from logprep.util.helper import (
+    FieldValue,
     add_and_overwrite,
     add_fields_to,
     get_dotted_field_list,
@@ -73,7 +73,7 @@ class DomainLabelExtractor(FieldManager):
         """Provides the properly typed rule configuration object"""
         return typing.cast(DomainLabelExtractor.Config, self._config)
 
-    def _apply_rules(self, event: Dict[str, Any], rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """
         Apply matching rule to given log event. Such that a given domain,
         configured via rule, is split into it's labels and parts. The resulting

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -37,7 +37,6 @@ from enum import IntEnum
 from functools import cached_property
 from multiprocessing import context
 from multiprocessing.pool import ThreadPool
-from typing import Any, Optional
 from urllib.parse import urlsplit
 
 from attrs import define, field, validators
@@ -48,7 +47,7 @@ from logprep.processor.base.rule import Rule
 from logprep.processor.domain_resolver.rule import DomainResolverRule
 from logprep.util.cache import Cache
 from logprep.util.hasher import SHA256Hasher
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 logger = logging.getLogger("DomainResolver")
 
@@ -149,7 +148,7 @@ class DomainResolver(Processor):
 
     __slots__ = ["_domain_ip_map"]
 
-    _domain_ip_map: dict[str, Optional[str]]
+    _domain_ip_map: dict[str, str | None]
 
     rule_class = DomainResolverRule
 
@@ -175,7 +174,7 @@ class DomainResolver(Processor):
     def _thread_pool(self) -> ThreadPool:
         return ThreadPool(processes=1)
 
-    def _apply_rules(self, event: dict[str, Any], rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(DomainResolverRule, rule)
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
@@ -198,7 +197,7 @@ class DomainResolver(Processor):
             self._add_resolve_infos_to_event(event, rule, resolved_ip)
 
     def _resolve_with_cache(
-        self, domain: str, event: dict[str, Any], rule: DomainResolverRule
+        self, domain: str, event: dict[str, FieldValue], rule: DomainResolverRule
     ) -> None:
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
         requires_storing = self._cache.requires_storing(hash_string)
@@ -216,12 +215,12 @@ class DomainResolver(Processor):
             self._store_debug_infos(event, requires_storing)
 
     def _add_resolve_infos_to_event(
-        self, event: dict[str, Any], rule: DomainResolverRule, resolved_ip: Optional[str]
+        self, event: dict[str, FieldValue], rule: DomainResolverRule, resolved_ip: str | None
     ) -> None:
         if resolved_ip:
             self._write_target_field(event, rule, resolved_ip)
 
-    def _resolve_ip(self, domain: str) -> tuple[Optional[str], int]:
+    def _resolve_ip(self, domain: str) -> tuple[str | None, int]:
         """Resolve domain with timeout.
 
         Assumes socket default timeout is None and relies on threading to create a timeout.
@@ -240,7 +239,7 @@ class DomainResolver(Processor):
             self.metrics.unknown_domains += 1
             return None, ResolveStatus.UNKNOWN
 
-    def _store_debug_infos(self, event: dict[str, Any], requires_storing: bool) -> None:
+    def _store_debug_infos(self, event: dict[str, FieldValue], requires_storing: bool) -> None:
         event_dbg = {
             "resolved_ip_debug": {
                 "obtained_from_cache": not requires_storing,

--- a/logprep/ng/processor/dropper/processor.py
+++ b/logprep/ng/processor/dropper/processor.py
@@ -37,7 +37,7 @@ class Dropper(Processor):
 
     rule_class = DropperRule
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """Drops fields from event Logs."""
         rule = typing.cast(DropperRule, rule)
         for dotted_field in rule.fields_to_drop:

--- a/logprep/ng/processor/dropper/processor.py
+++ b/logprep/ng/processor/dropper/processor.py
@@ -29,7 +29,7 @@ import typing
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.dropper.rule import DropperRule
-from logprep.util.helper import pop_dotted_field_value
+from logprep.util.helper import FieldValue, pop_dotted_field_value
 
 
 class Dropper(Processor):
@@ -37,7 +37,7 @@ class Dropper(Processor):
 
     rule_class = DropperRule
 
-    def _apply_rules(self, event: dict, rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
         """Drops fields from event Logs."""
         rule = typing.cast(DropperRule, rule)
         for dotted_field in rule.fields_to_drop:

--- a/logprep/ng/processor/field_manager/processor.py
+++ b/logprep/ng/processor/field_manager/processor.py
@@ -44,9 +44,9 @@ from logprep.util.helper import (
 class FieldManager(Processor):
     """A processor that copies, moves or merges source fields to one target field"""
 
-    rule_class = FieldManagerRule
+    rule_class: typing.ClassVar[type[FieldManagerRule]] = FieldManagerRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(FieldManagerRule, rule)
         rule_args = (
             rule.source_fields,

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -29,7 +29,7 @@ import typing
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.generic_adder.rule import GenericAdderRule
-from logprep.util.helper import add_fields_to
+from logprep.util.helper import FieldValue, add_fields_to
 
 
 class GenericAdder(Processor):
@@ -37,7 +37,7 @@ class GenericAdder(Processor):
 
     rule_class = GenericAdderRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GenericAdderRule, rule)
         items_to_add = rule.add
         if items_to_add:

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -133,7 +133,7 @@ class GenericResolver(FieldManager):
             return self._resolve_value_from_list
         return lru_cache(maxsize=self.max_cache_entries)(self._resolve_value_from_list)
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """Apply the given rule to the current event"""
         rule = typing.cast(GenericResolverRule, rule)
         source_field_values = [

--- a/logprep/ng/processor/geoip_enricher/processor.py
+++ b/logprep/ng/processor/geoip_enricher/processor.py
@@ -40,7 +40,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
 from logprep.processor.geoip_enricher.rule import GEOIP_DATA_STUBS, GeoipEnricherRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 logger = logging.getLogger("GeoipEnricher")
 
@@ -136,7 +136,7 @@ class GeoipEnricher(FieldManager):
         except (ValueError, AddressNotFoundError):
             return {}
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GeoipEnricherRule, rule)
         ip_string = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [ip_string]):

--- a/logprep/ng/processor/grokker/processor.py
+++ b/logprep/ng/processor/grokker/processor.py
@@ -44,7 +44,7 @@ from logprep.processor.base.exceptions import ProcessingError, ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.grokker.rule import GrokkerRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 logger = logging.getLogger("Grokker")
 
@@ -77,7 +77,7 @@ class Grokker(FieldManager):
         """Returns all rules"""
         return typing.cast(Sequence[GrokkerRule], super().rules)
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GrokkerRule, rule)
         matches = []
         source_values = []

--- a/logprep/ng/processor/ip_informer/processor.py
+++ b/logprep/ng/processor/ip_informer/processor.py
@@ -25,6 +25,7 @@ Processor Configuration
 
 import ipaddress
 import typing
+from functools import partial
 from itertools import chain
 from typing import Iterable
 
@@ -34,6 +35,7 @@ from logprep.processor.base.rule import Rule
 from logprep.processor.ip_informer.rule import IpInformerRule, get_ip_property_names
 from logprep.util.helper import (
     FieldValue,
+    get_dotted_field_value,
     get_dotted_field_values,
 )
 
@@ -66,8 +68,7 @@ class IpInformer(FieldManager):
     def _get_flat_ip_address_list(
         self, event: dict[str, FieldValue], rule: IpInformerRule
     ) -> Iterable:
-        source_field_values = get_dotted_field_values(event, rule.source_fields)
-
+        source_field_values = list(get_dotted_field_values(event, rule.source_fields).values())
         list_elements = [value for value in source_field_values if isinstance(value, list)]
         str_elements = [value for value in source_field_values if isinstance(value, str)]
 

--- a/logprep/ng/processor/ip_informer/processor.py
+++ b/logprep/ng/processor/ip_informer/processor.py
@@ -25,7 +25,6 @@ Processor Configuration
 
 import ipaddress
 import typing
-from functools import partial
 from itertools import chain
 from typing import Iterable
 
@@ -33,7 +32,10 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.ip_informer.rule import IpInformerRule, get_ip_property_names
-from logprep.util.helper import FieldValue, get_dotted_field_value
+from logprep.util.helper import (
+    FieldValue,
+    get_dotted_field_values,
+)
 
 
 class IpInformer(FieldManager):
@@ -64,9 +66,7 @@ class IpInformer(FieldManager):
     def _get_flat_ip_address_list(
         self, event: dict[str, FieldValue], rule: IpInformerRule
     ) -> Iterable:
-        source_field_values = [
-            get_dotted_field_value(event, source_field) for source_field in rule.source_fields
-        ]
+        source_field_values = get_dotted_field_values(event, rule.source_fields)
 
         list_elements = [value for value in source_field_values if isinstance(value, list)]
         str_elements = [value for value in source_field_values if isinstance(value, str)]

--- a/logprep/ng/processor/ip_informer/processor.py
+++ b/logprep/ng/processor/ip_informer/processor.py
@@ -24,14 +24,16 @@ Processor Configuration
 """
 
 import ipaddress
+import typing
 from functools import partial
 from itertools import chain
 from typing import Iterable
 
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.exceptions import ProcessingWarning
+from logprep.processor.base.rule import Rule
 from logprep.processor.ip_informer.rule import IpInformerRule, get_ip_property_names
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 
 
 class IpInformer(FieldManager):
@@ -43,7 +45,8 @@ class IpInformer(FieldManager):
 
     rule_class = IpInformerRule
 
-    def _apply_rules(self, event: dict, rule: IpInformerRule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+        rule = typing.cast(IpInformerRule, rule)
         source_field_values = self._get_field_values(event, rule.source_fields)
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
         self._processing_warnings = []
@@ -58,10 +61,16 @@ class IpInformer(FieldManager):
         results = [(ip, self._ip_properties(ip, rule)) for ip in ip_address_list]
         return dict(filter(lambda x: bool(x[1]), results))
 
-    def _get_flat_ip_address_list(self, event: dict, rule: IpInformerRule) -> Iterable:
-        source_field_values = list(map(partial(get_dotted_field_value, event), rule.source_fields))
-        list_elements = filter(lambda x: isinstance(x, list), source_field_values)
-        str_elements = filter(lambda x: isinstance(x, str), source_field_values)
+    def _get_flat_ip_address_list(
+        self, event: dict[str, FieldValue], rule: IpInformerRule
+    ) -> Iterable:
+        source_field_values = [
+            get_dotted_field_value(event, source_field) for source_field in rule.source_fields
+        ]
+
+        list_elements = [value for value in source_field_values if isinstance(value, list)]
+        str_elements = [value for value in source_field_values if isinstance(value, str)]
+
         return chain(*list_elements, str_elements)
 
     def _ip_properties(self, ip_address: str, rule: IpInformerRule) -> dict:

--- a/logprep/ng/processor/key_checker/processor.py
+++ b/logprep/ng/processor/key_checker/processor.py
@@ -24,20 +24,21 @@ Processor Configuration
 .. automodule:: logprep.processor.key_checker.rule
 """
 
-from typing import Iterable
+import typing
 
 from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.key_checker.rule import KeyCheckerRule
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 
 
 class KeyChecker(Processor):
     """Checks if all keys of a given List are in the event"""
 
-    rule_class: Rule = KeyCheckerRule
+    rule_class = KeyCheckerRule
 
-    def _apply_rules(self, event: dict, rule: KeyCheckerRule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+        rule = typing.cast(KeyCheckerRule, rule)
         not_existing_fields = list(
             {
                 dotted_field
@@ -51,7 +52,7 @@ class KeyChecker(Processor):
 
         output_value = get_dotted_field_value(event, rule.target_field)
 
-        if isinstance(output_value, Iterable):
+        if isinstance(output_value, typing.Iterable):
             output_value = list({*not_existing_fields, *output_value})
         else:
             output_value = not_existing_fields

--- a/logprep/ng/processor/labeler/processor.py
+++ b/logprep/ng/processor/labeler/processor.py
@@ -33,7 +33,7 @@ from logprep.ng.abc.processor import Processor
 from logprep.processor.base.rule import Rule
 from logprep.processor.labeler.labeling_schema import LabelingSchema
 from logprep.processor.labeler.rule import LabelerRule
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 
 class Labeler(Processor):
@@ -79,7 +79,7 @@ class Labeler(Processor):
                 rule.add_parent_labels_from_schema(self._schema)
             rule.conforms_to_schema(self._schema)
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """Applies the rule to the current event"""
         rule = typing.cast(LabelerRule, rule)
         add_fields_to(event, rule.prefixed_label, rule=rule, merge_with_target=True)

--- a/logprep/ng/processor/list_comparison/processor.py
+++ b/logprep/ng/processor/list_comparison/processor.py
@@ -84,7 +84,7 @@ class ListComparison(Processor):
         for rule in self.rules:
             rule.init_list_comparison(self._job_tag_for_cleanup, self.config.list_search_base_path)
 
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """
         Apply matching rule to given log event.
         In the process of doing so, add the result of comparing

--- a/logprep/ng/processor/list_comparison/processor.py
+++ b/logprep/ng/processor/list_comparison/processor.py
@@ -84,7 +84,7 @@ class ListComparison(Processor):
         for rule in self.rules:
             rule.init_list_comparison(self._job_tag_for_cleanup, self.config.list_search_base_path)
 
-    def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule):
         """
         Apply matching rule to given log event.
         In the process of doing so, add the result of comparing

--- a/logprep/ng/processor/pre_detector/processor.py
+++ b/logprep/ng/processor/pre_detector/processor.py
@@ -114,7 +114,7 @@ class PreDetector(Processor):
                 tags=["_pre_detector_timeparsing_failure"],
             ) from error
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(PreDetectorRule, rule)
         if not (
             self._ip_alerter.has_ip_fields(rule)

--- a/logprep/ng/processor/pseudonymizer/processor.py
+++ b/logprep/ng/processor/pseudonymizer/processor.py
@@ -63,7 +63,7 @@ from logprep.processor.pseudonymizer.rule import PseudonymizerRule
 from logprep.util.converters import convert_ordered_tuples_with_factory
 from logprep.util.getter import GetterFactory
 from logprep.util.hasher import SHA256Hasher
-from logprep.util.helper import add_fields_to, get_dotted_field_values
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_values
 from logprep.util.pseudo.encrypter import (
     DualPKCS1HybridCTREncrypter,
     DualPKCS1HybridGCMEncrypter,
@@ -232,7 +232,7 @@ class Pseudonymizer(FieldManager):
                         f"Regex keyword '{regex_keyword}' not found in regex_mapping '{self.config.regex_mapping}'"
                     )
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(PseudonymizerRule, rule)
         source_dict = get_dotted_field_values(event, rule.pseudonyms)
         self._handle_missing_fields(event, rule, source_dict.keys(), source_dict.values())

--- a/logprep/ng/processor/replacer/processor.py
+++ b/logprep/ng/processor/replacer/processor.py
@@ -23,13 +23,16 @@ Processor Configuration
 .. automodule:: logprep.processor.replacer.rule
 """
 
+import typing
+
 from logprep.ng.processor.field_manager.processor import FieldManager
+from logprep.processor.base.rule import Rule
 from logprep.processor.replacer.rule import (
     Replacement,
     ReplacementTemplate,
     ReplacerRule,
 )
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 
 class Replacer(FieldManager):
@@ -37,7 +40,8 @@ class Replacer(FieldManager):
 
     rule_class = ReplacerRule
 
-    def _apply_rules(self, event: dict, rule: ReplacerRule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+        rule = typing.cast(ReplacerRule, rule)
         for source_field in rule.mapping:
             template = rule.templates.get(source_field)
             if template is None:
@@ -45,7 +49,7 @@ class Replacer(FieldManager):
 
             value_to_replace = get_dotted_field_value(event, source_field)
             if value_to_replace is None and not rule.ignore_missing_fields:
-                error = BaseException(f"replacer: mapping field '{source_field}' does not exist")
+                error = Exception(f"replacer: mapping field '{source_field}' does not exist")
                 self._handle_warning_error(event, rule, error)
             value_to_replace = str(value_to_replace)
 

--- a/logprep/ng/processor/requester/processor.py
+++ b/logprep/ng/processor/requester/processor.py
@@ -44,6 +44,7 @@ from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.requester.rule import RequesterRule
 from logprep.util.helper import (
+    FieldValue,
     add_fields_to,
     create_template_resolver,
     get_source_fields_dict,
@@ -59,7 +60,7 @@ class Requester(FieldManager):
 
     rule_class = RequesterRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(RequesterRule, rule)
         source_field_dict = get_source_fields_dict(event, rule)
         if self._handle_missing_fields(event, rule, rule.source_fields, source_field_dict.values()):

--- a/logprep/ng/processor/selective_extractor/processor.py
+++ b/logprep/ng/processor/selective_extractor/processor.py
@@ -33,7 +33,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.ng.processor.selective_extractor.filtered_event import FilteredEvent
 from logprep.ng.processor.selective_extractor.rule import SelectiveExtractorRule
 from logprep.processor.base.rule import Rule
-from logprep.util.helper import add_fields_to, get_source_fields_dict
+from logprep.util.helper import FieldValue, add_fields_to, get_source_fields_dict
 
 
 class SelectiveExtractor(FieldManager):
@@ -41,7 +41,7 @@ class SelectiveExtractor(FieldManager):
 
     rule_class = SelectiveExtractorRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         """
         Generates a filtered event based on the incoming event and the configured
         extraction_fields list in processor configuration or from rule.

--- a/logprep/ng/processor/string_splitter/processor.py
+++ b/logprep/ng/processor/string_splitter/processor.py
@@ -32,7 +32,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.string_splitter.rule import StringSplitterRule
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 
 
 class StringSplitter(FieldManager):
@@ -41,7 +41,7 @@ class StringSplitter(FieldManager):
     rule_class = StringSplitterRule
 
     @override
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(StringSplitterRule, rule)
 
         source_field = rule.source_fields[0]

--- a/logprep/ng/processor/template_replacer/processor.py
+++ b/logprep/ng/processor/template_replacer/processor.py
@@ -41,7 +41,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
 from logprep.processor.template_replacer.rule import TemplateReplacerRule
 from logprep.util.getter import GetterFactory
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
 
 
 class TemplateReplacerError(Exception):
@@ -90,7 +90,7 @@ class TemplateReplacer(FieldManager):
         """Provides the properly typed configuration object"""
         return typing.cast(TemplateReplacer.Config, self._config)
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(TemplateReplacerRule, rule)
         source_field_values = self._get_field_values(event, self._fields)
         if self._handle_missing_fields(event, rule, self._fields, source_field_values):

--- a/logprep/ng/processor/timestamp_differ/processor.py
+++ b/logprep/ng/processor/timestamp_differ/processor.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.rule import Rule
 from logprep.processor.timestamp_differ.rule import TimestampDifferRule
-from logprep.util.helper import get_source_fields_dict
+from logprep.util.helper import FieldValue, get_source_fields_dict
 from logprep.util.time import UTC, TimeParser, TimeParserException
 
 
@@ -38,7 +38,7 @@ class TimestampDiffer(FieldManager):
 
     rule_class = TimestampDifferRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(TimestampDifferRule, rule)
         source_field_formats = rule.source_field_formats
         source_field_dict = get_source_fields_dict(event, rule)

--- a/logprep/ng/processor/timestamper/processor.py
+++ b/logprep/ng/processor/timestamper/processor.py
@@ -30,7 +30,7 @@ from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.base.rule import Rule
 from logprep.processor.timestamper.rule import TimestamperRule
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import FieldValue, get_dotted_field_value
 from logprep.util.time import TimeParser, TimeParserException
 
 
@@ -39,7 +39,7 @@ class Timestamper(FieldManager):
 
     rule_class = TimestamperRule
 
-    def _apply_rules(self, event: dict, rule: Rule) -> None:
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(TimestamperRule, rule)
         source_value = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [source_value]):

--- a/logprep/processor/concatenator/processor.py
+++ b/logprep/processor/concatenator/processor.py
@@ -25,6 +25,9 @@ Processor Configuration
 .. automodule:: logprep.processor.concatenator.rule
 """
 
+import typing
+
+from logprep.processor.base.exceptions import ProcessingWarning
 from logprep.processor.concatenator.rule import ConcatenatorRule
 from logprep.processor.field_manager.processor import FieldManager
 from logprep.util.helper import get_dotted_field_value
@@ -48,6 +51,7 @@ class Concatenator(FieldManager):
         rule :
             Currently applied concatenator rule.
         """
+        rule = typing.cast(ConcatenatorRule, rule)
         source_field_values = []
         for source_field in rule.source_fields:
             field_value = get_dotted_field_value(event, source_field)
@@ -55,6 +59,15 @@ class Concatenator(FieldManager):
         self._handle_missing_fields(event, rule, rule.source_fields, source_field_values)
 
         source_field_values = [field for field in source_field_values if field is not None]
-        target_value = f"{rule.separator}".join(source_field_values)
+
+        try:
+            target_value = f"{rule.separator}".join(source_field_values)  # type: ignore[arg-type]
+        except TypeError as ex:
+            raise ProcessingWarning(
+                f"Only string values are allowed as source field values in {self.__class__.__name__}",
+                rule=rule,
+                event=event,
+                tags=rule.failure_tags,
+            ) from ex
 
         self._write_target_field(event, rule, target_value)

--- a/tests/unit/ng/processor/base.py
+++ b/tests/unit/ng/processor/base.py
@@ -302,3 +302,6 @@ class BaseProcessorTestCase(BaseComponentTestCase[ProcessorTypeT], typing.Generi
         ]
         with pytest.raises(InvalidRuleDefinitionError):
             self.object.load_rules(rules_targets=rule_definitions)
+
+    async def test_has_async_io(self):
+        assert await self.object.has_asyncio() is False

--- a/tests/unit/ng/processor/concatenator/test_concatenator.py
+++ b/tests/unit/ng/processor/concatenator/test_concatenator.py
@@ -9,7 +9,7 @@ import pytest
 
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.concatenator.processor import Concatenator
-from logprep.processor.base.exceptions import FieldExistsWarning
+from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 
@@ -194,4 +194,32 @@ class TestConcatenator(BaseProcessorTestCase[Concatenator]):
         assert isinstance(result.warnings[0], FieldExistsWarning)
         assert "target_field" in document.data
         assert document.data["target_field"] == "has already content"
+        assert document.data["tags"] == ["_concatenator_failure"]
+
+    async def test_failing_if_any_field_value_in_not_a_string(self):
+        rule = {
+            "filter": "field.a",
+            "concatenator": {
+                "source_fields": ["field.a", "field.b", "other_field.c"],
+                "target_field": "target_field",
+                "separator": "-",
+                "overwrite_target": False,
+                "delete_source_fields": False,
+            },
+        }
+        await self._load_rule(rule)
+
+        document = LogEvent(
+            {"field": {"a": "first", "b": True}, "other_field": {"c": "third"}},
+            original=b"test_message",
+            input_meta=InputMeta(),
+        )
+        result = await self.object.process(document)
+
+        assert len(result.warnings) == 1
+        exception = result.warnings[0]
+        assert isinstance(exception, ProcessingWarning)
+        assert "Only string values are allowed as source field values in Concatenator" in str(
+            exception
+        )
         assert document.data["tags"] == ["_concatenator_failure"]

--- a/tests/unit/ng/processor/datetime_extractor/test_datetime_extractor.py
+++ b/tests/unit/ng/processor/datetime_extractor/test_datetime_extractor.py
@@ -58,7 +58,7 @@ class TestDatetimeExtractor(BaseProcessorTestCase[DatetimeExtractor]):
         )
         mock_rule = mock.MagicMock()
         with mock.patch.object(self.object, "_handle_missing_fields", return_value=True):
-            result = self.object._apply_rules(document, mock_rule)
+            result = await self.object._apply_rules(document, mock_rule)
             assert result is None
 
     async def test_an_event_extracted_datetime_plus_one(self):

--- a/tests/unit/ng/processor/ip_informer/test_ip_informer.py
+++ b/tests/unit/ng/processor/ip_informer/test_ip_informer.py
@@ -10,14 +10,14 @@ from logprep.ng.processor.ip_informer.processor import IpInformer
 from logprep.processor.base.exceptions import ProcessingWarning
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.ip_informer.test_ip_informer import (
-    failure_test_cases as ng_failure_test_cases,
+    failure_test_cases as non_ng_failure_test_cases,
 )
 from tests.unit.processor.ip_informer.test_ip_informer import (
-    test_cases as ng_test_cases,
+    test_cases as non_ng_test_cases,
 )
 
-test_cases = deepcopy(ng_test_cases)
-failure_test_cases = deepcopy(ng_failure_test_cases)
+test_cases = deepcopy(non_ng_test_cases)
+failure_test_cases = deepcopy(non_ng_failure_test_cases)
 
 
 class TestIpInformer(BaseProcessorTestCase[IpInformer]):

--- a/tests/unit/ng/processor/ip_informer/test_ip_informer.py
+++ b/tests/unit/ng/processor/ip_informer/test_ip_informer.py
@@ -10,14 +10,14 @@ from logprep.ng.processor.ip_informer.processor import IpInformer
 from logprep.processor.base.exceptions import ProcessingWarning
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.ip_informer.test_ip_informer import (
-    failure_test_cases as non_ng_failure_test_cases,
+    failure_test_cases as ng_failure_test_cases,
 )
 from tests.unit.processor.ip_informer.test_ip_informer import (
-    test_cases as non_ng_test_cases,
+    test_cases as ng_test_cases,
 )
 
-test_cases = deepcopy(non_ng_test_cases)
-failure_test_cases = deepcopy(non_ng_failure_test_cases)
+test_cases = deepcopy(ng_test_cases)
+failure_test_cases = deepcopy(ng_failure_test_cases)
 
 
 class TestIpInformer(BaseProcessorTestCase[IpInformer]):

--- a/tests/unit/processor/concatenator/test_concatenator.py
+++ b/tests/unit/processor/concatenator/test_concatenator.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from logprep.processor.base.exceptions import FieldExistsWarning
+from logprep.processor.base.exceptions import (
+    FieldExistsWarning,
+    ProcessingCriticalError,
+)
 from tests.unit.processor.base import BaseProcessorTestCase
 
 
@@ -182,3 +185,23 @@ class TestConcatenator(BaseProcessorTestCase):
         assert "target_field" in document
         assert document.get("target_field") == "has already content"
         assert document.get("tags") == ["_concatenator_failure"]
+
+    def test_failing_if_any_field_value_in_not_a_string(self):
+        rule = {
+            "filter": "field.a",
+            "concatenator": {
+                "source_fields": ["field.a", "field.b", "other_field.c"],
+                "target_field": "target_field",
+                "separator": "-",
+                "overwrite_target": False,
+                "delete_source_fields": False,
+            },
+        }
+        self._load_rule(rule)
+
+        document = {"field": {"a": "first", "b": True}, "other_field": {"c": "third"}}
+        result = self.object.process(document)
+
+        assert len(result.errors) == 1
+        assert isinstance(result.errors[0], ProcessingCriticalError)
+        assert "sequence item 1: expected str instance, bool found" in result.errors[0].message

--- a/tests/unit/processor/concatenator/test_concatenator.py
+++ b/tests/unit/processor/concatenator/test_concatenator.py
@@ -5,7 +5,7 @@ import pytest
 
 from logprep.processor.base.exceptions import (
     FieldExistsWarning,
-    ProcessingCriticalError,
+    ProcessingWarning,
 )
 from tests.unit.processor.base import BaseProcessorTestCase
 
@@ -202,6 +202,10 @@ class TestConcatenator(BaseProcessorTestCase):
         document = {"field": {"a": "first", "b": True}, "other_field": {"c": "third"}}
         result = self.object.process(document)
 
-        assert len(result.errors) == 1
-        assert isinstance(result.errors[0], ProcessingCriticalError)
-        assert "sequence item 1: expected str instance, bool found" in result.errors[0].message
+        assert len(result.warnings) == 1
+        exception = result.warnings[0]
+        assert isinstance(exception, ProcessingWarning)
+        assert "Only string values are allowed as source field values in Concatenator" in str(
+            exception
+        )
+        assert document["tags"] == ["_concatenator_failure"]


### PR DESCRIPTION
## Description

* made some abstract Processor methods and processor-specific methods asynchronous, especially the processing chain through __apply_rules(...)
* introduced has_async_io() with a default return value of False
* updated and fixed the tests

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [ ] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [ ] [Documentation](#documentation) is up-to-date
- [ ] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1003.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->