### PR TITLE
chart: fix command handling in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * docs: use processor name placeholders for most usages
 
 ### Bugfix
+* chart: fix command handling
 
 ## 20.0.0
 ### Breaking

--- a/charts/logprep/Chart.yaml
+++ b/charts/logprep/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "16.1.1"
+version: "16.1.2"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "16.1.1"
+appVersion: "16.1.2"

--- a/charts/logprep/templates/deployment.yaml
+++ b/charts/logprep/templates/deployment.yaml
@@ -50,7 +50,8 @@ spec:
             - name: http-input
               containerPort: {{ .Values.input.uvicorn_config.port }}
             {{- end }}
-          command: {{ .Values.command }}
+          command:
+            - {{ .Values.command }}
           args:
             - run
             {{- range .Values.configurations }}
@@ -81,7 +82,7 @@ spec:
               value: /home/logprep/certificates/{{ .Values.secrets.certificates.name }}
             {{- end }}
             {{- if .Values.environment }}
-            {{- toYaml .Values.environment  | nindent 12 }}
+            {{- toYaml .Values.environment | nindent 12 }}
             {{- end }}
           volumeMounts:
 


### PR DESCRIPTION
## Description

* fix command handling in helm chart

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* not yet

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1004.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->