### PR TITLE
fix ng input timeout; add getter support for text/yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugfix
 * chart: fix command handling
+* fix ng input timeout to also accept int parameters
 
 ## 20.0.0
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")
 * docs: use processor name placeholders for most usages
+* getter: handle "text/yaml" in content type resolution
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")
 * docs: use processor name placeholders for most usages
 * getter: handle "text/yaml" in content type resolution
+* getter: remove noisy debug log
 
 ### Bugfix
 * chart: fix command handling

--- a/logprep/abc/getter.py
+++ b/logprep/abc/getter.py
@@ -68,7 +68,7 @@ class Getter(ABC):
         match content_type:
             case "application/json":
                 return self._parse_json(content)
-            case "application/yaml":
+            case "application/yaml" | "text/yaml":
                 return self._parse_yaml(content)
             case "text/plain" | None:
                 return content

--- a/logprep/ng/abc/input.py
+++ b/logprep/ng/abc/input.py
@@ -95,7 +95,9 @@ class Input(Connector, AsyncIterator[LogEvent | ErrorEvent | None]):
         """See :class:`PreprocessingConfig` for further details."""
 
         timeout: float = field(
-            validator=(validators.instance_of(float), validators.gt(0)), default=5.0, eq=False
+            validator=(validators.instance_of(float), validators.gt(0)),
+            converter=float,
+            default=5.0,
         )
         """Timeout for retrieving the next event"""
 

--- a/logprep/util/getter.py
+++ b/logprep/util/getter.py
@@ -551,7 +551,6 @@ class RefreshableGetter(Getter, ABC):
     @classmethod
     def refresh(cls):
         """Run pending refresh schedulers and cleanup timed-out targets."""
-        rg_logger.debug("refreshing all cached getters")
         for target, shared_target_data in list(cls._target_to_data_caches.items()):
             if cls.timed_out_for_target(target):
                 rg_logger.debug("target has timed out and will be cleaned up: %s", target)

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -69,6 +69,13 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
     async def test_component_is_input(self):
         assert isinstance(self.object, Input)
 
+    @pytest.mark.parametrize(
+        ("timeout"), [pytest.param(3, id="int"), pytest.param(3.5, id="float")]
+    )
+    async def test_accepts_timeout_type(self, timeout):
+        self.object = self._create_test_instance(config_patch={"timeout": timeout})
+        assert self.object.config.timeout == float(timeout)
+
     @pytest.fixture(name="default_hmac_config")
     def _add_default_hmac_config(self):
         # TODO refactor to patch CONFIG instead

--- a/tests/unit/util/test_getter.py
+++ b/tests/unit/util/test_getter.py
@@ -1663,6 +1663,12 @@ class TestHttpGetter:
                 id="yaml-list-returns-parsed-list",
             ),
             pytest.param(
+                "content:\n  key: value",
+                "text/yaml",
+                {"content": {"key": "value"}},
+                id="text/yaml-is-supported",
+            ),
+            pytest.param(
                 "plain text content",
                 "text/plain",
                 "plain text content",


### PR DESCRIPTION
## Description

* fix ng input timeout not accepting int
* getter: add support for text/yaml content type
* getter: remove noisy debug log

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1005.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->