### PR TITLE
fix: ng http input collect_meta shared metadata between events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 
 ### Bugfix
 * chart: fix command handling
-* fix ng input timeout to also accept int parameters
+* ng: fix input timeout to also accept int parameters
+* ng: fix `http_input` `collect_meta` leading to shared dicts between events
 
 ## 20.0.0
 ### Breaking

--- a/examples/exampledata/config/ng_http_pipeline.yml
+++ b/examples/exampledata/config/ng_http_pipeline.yml
@@ -49,6 +49,9 @@ input:
       /json: json
       /lab/123/(ABC|DEF)/pl.*: plaintext
       /lab/123/ABC/auditlog: jsonl
+    preprocessing:
+      version_info_target_field: "@metadata.konnektor"
+      log_arrival_time_target_field: "event.created"
 output:
   kafka:
     type: confluentkafka_output

--- a/logprep/ng/connector/http/input.py
+++ b/logprep/ng/connector/http/input.py
@@ -98,6 +98,7 @@ import zlib
 from abc import ABC
 from base64 import b64encode
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from functools import cached_property
 
 import aiohttp
@@ -218,7 +219,8 @@ class HttpEndpoint(ABC):
         """Puts message to internal queue"""
         if self.metafield_name in event:
             logger.warning("metadata field was in event and got overwritten")
-        await self.messages.put(event | metadata)
+        event.update(deepcopy(metadata))
+        await self.messages.put(event)
 
 
 class JSONHttpEndpoint(HttpEndpoint):

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -22,6 +22,7 @@ from logprep.factory import Factory
 from logprep.factory_error import InvalidConfigurationError
 from logprep.framework.pipeline_manager import ThrottlingQueue
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from logprep.util.helper import FieldValue, reduce_field_value
 from tests.conftest import mock_env
 from tests.unit.connector.base import BaseInputTestCase
 
@@ -277,6 +278,32 @@ class TestHttpConnector(BaseInputTestCase):
         assert message["custom"]["url"].endswith("/json")
         assert re.search(r"\d+\.\d+\.\d+\.\d+", message["custom"]["remote_addr"])
         assert isinstance(message["custom"]["user_agent"], str)
+
+    def test_collect_meta_produces_disjoint_events(self):
+        connector_config = deepcopy(self.CONFIG)
+        connector_config["collect_meta"] = True
+        connector = Factory.create({"test connector": connector_config})
+        connector.pipeline_index = 1
+        connector.setup()
+        client = testing.TestClient(connector.app)
+
+        data = """
+        {"message": "1"}
+        {"message": "2"}
+        """
+        client.post("/jsonl", body=data)
+
+        def _collect_ids(value: FieldValue, ids: set[int]) -> set[int]:
+            if isinstance(value, (list, dict)):
+                ids.add(id(value))
+            return ids
+
+        msg_1 = connector.get_next(1)
+        msg_2 = connector.get_next(1)
+
+        ids_1 = reduce_field_value(_collect_ids, msg_1, set())
+        ids_2 = reduce_field_value(_collect_ids, msg_2, set())
+        assert ids_1.isdisjoint(ids_2), "no shared object references between events allowed"
 
     def test_get_no_metadata_when_collect_meta_false(self):
         message = {"message": "my message"}

--- a/tests/unit/ng/connector/test_http_input.py
+++ b/tests/unit/ng/connector/test_http_input.py
@@ -26,6 +26,7 @@ from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.connector.http.input import HttpInput
 from logprep.ng.util.workflow.worker import SizeLimitedQueue
 from logprep.util.defaults import ENV_NAME_LOGPREP_CREDENTIALS_FILE
+from logprep.util.helper import FieldValue, reduce_field_value
 from tests.conftest import mock_env
 from tests.unit.ng.connector.base import BaseInputTestCase
 
@@ -293,6 +294,31 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
             assert message["custom"]["url"].endswith("/json")
             assert re.search(r"\d+\.\d+\.\d+\.\d+", message["custom"]["remote_addr"])
             assert isinstance(message["custom"]["user_agent"], str)
+
+    async def test_collect_meta_produces_disjoint_events(self):
+        instance = self._create_test_instance({"collect_meta": True})
+        await instance.setup()
+        data = """
+        {"message": "1"}
+        {"message": "2"}
+        """
+
+        async with testing.ASGIConductor(instance.app) as client:
+            await client.post("/jsonl", body=data)
+
+        def _collect_ids(value: FieldValue, ids: set[int]) -> set[int]:
+            if isinstance(value, (list, dict)):
+                ids.add(id(value))
+            return ids
+
+        msg_1 = await instance.get_next(1)
+        msg_2 = await instance.get_next(1)
+        assert isinstance(msg_1, LogEvent) and isinstance(msg_2, LogEvent)
+        assert not msg_1.is_failed() and not msg_2.is_failed()
+
+        ids_1 = reduce_field_value(_collect_ids, msg_1.data, set())
+        ids_2 = reduce_field_value(_collect_ids, msg_2.data, set())
+        assert ids_1.isdisjoint(ids_2), "no shared object references between events allowed"
 
     async def test_original_event_field_with_event_as_dict(self):
         message = {"message": "my message"}


### PR DESCRIPTION
## Description

* ng: fix http input collect_meta shared metadata objects between events

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest
* local testing with `ng_http_pipeline.yml`

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1007.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->