### PR TITLE
docs: hide non-init fields in docs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,7 +32,7 @@ jobs:
           files: |
             ${{ inputs.path }}
       - name: Install dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen --extra dev --extra doc
       - name: Check black formatting
         run: uv run black --check --diff --config ./pyproject.toml .
       - name: Lint helm charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")
 * docs: use processor name placeholders for most usages
+* docs: hide non-init fields in docs
 * getter: handle "text/yaml" in content type resolution
 * getter: remove noisy debug log
 * vuln: bump aiohttp to at least 3.14.3 in order to fix CVE-2026-69244

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,6 +72,7 @@ extensions = [
     "sphinx_copybutton",
     "security_best_practices",
     "resolve_placeholders",
+    "hide_non_init_fields",
 ]
 
 extensions.append("sphinx.ext.todo")

--- a/doc/source/custom_extensions/hide_non_init_fields.py
+++ b/doc/source/custom_extensions/hide_non_init_fields.py
@@ -1,0 +1,37 @@
+"""
+Init-Field Class Filter
+=======================
+
+This extension filters attrs-based classes for fields with `init=False` and hides those.
+Those fields are either only used internally or explicitly disabled.
+"""
+
+from typing import Any
+
+import attrs
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import ClassDocumenter, ObjectMember
+
+
+class AttrsClassDocumenter(ClassDocumenter):
+    """ClassDocumenter that hides attrs fields defined with init=False."""
+
+    objtype = "class"
+    priority = ClassDocumenter.priority + 1  # override the default documenter
+
+    def filter_members(
+        self, members: list[ObjectMember], want_all: bool
+    ) -> list[tuple[str, Any, bool]]:
+        filtered = super().filter_members(members, want_all)
+
+        if attrs.has(self.object):
+            skip_names = {f.name for f in attrs.fields(self.object) if not f.init}
+            filtered = [m for m in filtered if m[0] not in skip_names]
+
+        return filtered
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """Register the extension."""
+    app.add_autodocumenter(AttrsClassDocumenter, override=True)
+    return {"version": "1.0", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/source/custom_extensions/resolve_placeholders.py
+++ b/doc/source/custom_extensions/resolve_placeholders.py
@@ -58,13 +58,11 @@ import itertools
 import re
 import typing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from docutils.parsers.rst.states import Body
+from sphinx.application import Sphinx
 from sphinx.util import logging
-
-if TYPE_CHECKING:
-    from sphinx.application import Sphinx
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

* docs: hide non-init fields in docs

## Assessment

- Processors using `mapping` don't use `target_field` & `source_fields`, as `mapping` conveys more data
- Sometimes only `source_fields` and only `target_field` are being used
- `ignore_missing_fields` is sometimes implemented, sometimes half-implemented (`_handle_missing_fields` called, but no conditional `return`) and still disabled via `init=False`
- Many components use `init=False` to declare attributes which are only used internally

### Checklist
- [x] logprep/framework/pipeline.py:        init=False,
- [x] logprep/framework/pipeline_manager.py:    sentinel: Any = field(default=None, init=False)
- [x] logprep/framework/pipeline_manager.py:    _process: multiprocessing.Process = field(init=False)
- [x] logprep/metrics/metrics.py:    _tracker: MetricWrapperBase = field(init=False, default=None)
- [x] logprep/ng/abc/event.py:    _errors: list[Exception] = field(factory=list, init=False)
- [x] logprep/ng/abc/event.py:    warnings: list[Exception] = field(factory=list, init=False, eq=False)
- [x] logprep/ng/abc/event.py:    output_target: None = field(kw_only=True, init=False, default=None)
- [x] logprep/ng/connector/confluent_kafka/offset_commit_tracker.py:    committable_offsets: set[int] = field(factory=set, init=False)
- [x] logprep/ng/processor/selective_extractor/rule.py:        target_field: str = field(default="", init=False, repr=False, eq=False)
- [x] logprep/ng/processor/selective_extractor/rule.py:        overwrite_target: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/ng/processor/selective_extractor/rule.py:        merge_with_target: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/ng/processor/selective_extractor/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/ng/util/configuration.py:    _metrics: "Configuration.Metrics" = field(init=False, repr=False, eq=False)
- [x] logprep/ng/util/configuration.py:    _config_failure: bool = field(default=False, repr=False, eq=False, init=False)
- [x] logprep/ng/util/retry.py:    _failures: int = field(default=0, init=False)
- [x] logprep/ng/util/retry.py:    _limit_to_single_probe: asyncio.Lock = field(factory=asyncio.Lock, init=False, repr=False)
- [x] logprep/ng/util/retry.py:    _limit_concurrent_send: asyncio.Semaphore = field(init=False, repr=False)
- [x] logprep/processor/amides/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/amides/rule.py:            init=False, repr=False, eq=False, default=False, validator=validators.instance_of(bool)
- [x] logprep/processor/calculator/rule.py:        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
- [x] logprep/processor/calculator/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/concatenator/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/datetime_extractor/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/datetime_extractor/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/deleter/rule.py:        target_field = field(init=False, repr=False, eq=False)
- [x] logprep/processor/dissector/rule.py:        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
- [x] logprep/processor/dissector/rule.py:        target_field: str = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/domain_label_extractor/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/domain_label_extractor/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/domain_resolver/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/domain_resolver/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/generic_resolver/rule.py:        additions: dict[str, FieldValue] = field(default={}, eq=False, init=False)
- [x] logprep/processor/geoip_enricher/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/geoip_enricher/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/ip_informer/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/key_checker/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/key_checker/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/list_comparison/rule.py:        mapping: dict = field(factory=dict, init=False, repr=False, eq=False)
- [x] logprep/processor/list_comparison/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/replacer/rule.py:        source_fields: list = field(factory=list, init=False, repr=False, eq=False)
- [x] logprep/processor/replacer/rule.py:        extend_target_list: bool = field(factory=bool, init=False, repr=False, eq=False)
- [x] logprep/processor/requester/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/requester/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/selective_extractor/rule.py:        target_field: str = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/selective_extractor/rule.py:        overwrite_target: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/selective_extractor/rule.py:        merge_with_target: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/selective_extractor/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/string_splitter/rule.py:        mapping: dict = field(factory=dict, init=False, repr=False, eq=False)
- [x] logprep/processor/string_splitter/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/timestamp_differ/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/timestamp_differ/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/processor/timestamper/rule.py:        mapping: dict = field(default="", init=False, repr=False, eq=False)
- [x] logprep/processor/timestamper/rule.py:        ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
- [x] logprep/util/configuration.py:    _metrics: "Configuration.Metrics" = field(init=False, repr=False, eq=False)
- [x] logprep/util/configuration.py:        init=False,
- [x] logprep/util/configuration.py:    _config_failure: bool = field(default=False, repr=False, eq=False, init=False)
- [x] logprep/util/credentials.py:        validator=validators.instance_of(datetime), init=False, default=datetime.now()
- [x] logprep/util/credentials.py:        init=False,
- [x] logprep/util/credentials.py:        validator=validators.instance_of((AccessToken, type(None))), init=False, repr=False
- [x] logprep/util/grok/grok.py:    predefined_patterns: dict = field(init=False, factory=dict, repr=False)
- [x] logprep/util/grok/grok.py:    type_mappings: dict = field(init=False, factory=dict)
- [x] logprep/util/grok/grok.py:    field_mappings: dict = field(init=False, factory=dict)
- [x] logprep/util/grok/grok.py:    regex_obj = field(init=False, default=None)
- [x] logprep/util/preprocessor.py:        init=False, default=Factory(lambda self: self.key.encode(), takes_self=True)

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* preview & diff: https://logprep--1009.org.readthedocs.build/en/1009/configuration/processor.html?readthedocs-diff=true

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1009.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->