### PR TITLE
fix: allow None as valid input via add in `generic_adder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * chart: fix command handling
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events
+* generic_adder: allow None as valid input via `add`
 
 ## 20.0.0
 ### Breaking

--- a/logprep/ng/processor/generic_adder/processor.py
+++ b/logprep/ng/processor/generic_adder/processor.py
@@ -57,7 +57,12 @@ class GenericAdder(Processor):
             for items_to_add in rule.additions(event):
                 if items_to_add:
                     add_fields_to(
-                        event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target
+                        event,
+                        items_to_add,
+                        rule,
+                        rule.merge_with_target,
+                        rule.overwrite_target,
+                        skip_none=False,
                     )
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error

--- a/logprep/processor/generic_adder/processor.py
+++ b/logprep/processor/generic_adder/processor.py
@@ -54,7 +54,12 @@ class GenericAdder(Processor):
             for items_to_add in rule.additions(event):
                 if items_to_add:
                     add_fields_to(
-                        event, items_to_add, rule, rule.merge_with_target, rule.overwrite_target
+                        event,
+                        items_to_add,
+                        rule,
+                        rule.merge_with_target,
+                        rule.overwrite_target,
+                        skip_none=False,
                     )
         except Exception as error:
             raise ProcessingWarning(str(error), rule, event) from error

--- a/logprep/processor/generic_adder/rule.py
+++ b/logprep/processor/generic_adder/rule.py
@@ -93,6 +93,7 @@ from attrs import define, field, validators
 from logprep.abc.getter import Getter
 from logprep.filter.expression.filter_expression import FilterExpression
 from logprep.processor.base.rule import InvalidRuleDefinitionError, Rule
+from logprep.util import helper
 from logprep.util.converters import convert_from_dict
 from logprep.util.environ import ENV_VARS
 from logprep.util.getter import GetterFactory, RefreshableGetter
@@ -167,10 +168,10 @@ class GenericAdderRule(Rule):
         of the source fields.
         """
 
-        add: dict = field(
+        add: dict[str, FieldValue] = field(
             validator=validators.deep_mapping(
                 key_validator=validators.instance_of(str),
-                value_validator=validators.instance_of((str, bool, list, dict, int, float)),
+                value_validator=helper.field_value_validator,
             ),
             factory=dict,
         )

--- a/logprep/util/helper.py
+++ b/logprep/util/helper.py
@@ -23,6 +23,8 @@ from typing import (
     cast,
 )
 
+from attrs import Attribute
+
 from logprep.processor.base.exceptions import FieldExistsWarning
 from logprep.util.defaults import DEFAULT_CONFIG_LOCATION
 
@@ -939,3 +941,23 @@ def transform_field_value(
             return transform_value(data)
         case _:
             raise ValueError(f"unexpected type encountered: {type(data)}")
+
+
+def field_value_validator(_: object, attribute: Attribute, value: object) -> None:
+    """Validate that an attrs attribute recursively contains only ``FieldValue`` values.
+
+    Dictionaries must use strings as keys. Unsupported values raise :class:`TypeError`.
+    """
+    match value:
+        case None | str() | bool() | int() | float():
+            return
+        case list():
+            for item in value:
+                field_value_validator(_, attribute, item)
+        case dict():
+            if not all(isinstance(key, str) for key in value):
+                raise TypeError(f"{attribute.name} must have string keys")
+            for item in value.values():
+                field_value_validator(_, attribute, item)
+        case _:
+            raise TypeError(f"{attribute.name} must be a FieldValue, got {type(value).__name__}")

--- a/tests/unit/ng/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/ng/processor/generic_adder/test_generic_adder.py
@@ -19,6 +19,7 @@ from logprep.processor.base.exceptions import (
     ProcessingWarning,
 )
 from logprep.util.getter import HttpGetter
+from tests.conftest import FIELD_VALUE_TEST_CASES
 from tests.unit.ng.processor.base import BaseProcessorTestCase
 from tests.unit.processor.generic_adder.test_generic_adder import (
     dynamic_uri_failure_test_cases as non_ng_dynamic_uri_failure_test_cases,

--- a/tests/unit/processor/generic_adder/test_generic_adder.py
+++ b/tests/unit/processor/generic_adder/test_generic_adder.py
@@ -16,7 +16,7 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.generic_adder.processor import GenericAdder
 from logprep.util.getter import HttpGetter
-from tests.conftest import mock_env
+from tests.conftest import FIELD_VALUE_TEST_CASES, mock_env
 from tests.unit.processor.base import BaseProcessorTestCase
 
 RULES_DIR_MISSING = "tests/testdata/unit/generic_adder/rules_missing"
@@ -399,6 +399,15 @@ test_cases = [  # testcase, rule, event, expected
         {"float_value_test": "Test", "float_field": 12.3},
         id="Add float value",
     ),
+    *[
+        pytest.param(
+            {"filter": "*", "generic_adder": {"add": {"some_field": test_case.values[0]}}},
+            {"message": "Test"},
+            {"message": "Test", "some_field": test_case.values[0]},
+            id=f"Add single value: {test_case.id}",
+        )
+        for test_case in FIELD_VALUE_TEST_CASES
+    ],
     pytest.param(
         {
             "filter": "add_list_generic_test",

--- a/tests/unit/util/test_helper.py
+++ b/tests/unit/util/test_helper.py
@@ -12,6 +12,7 @@ from logprep.util.helper import (
     Missing,
     Skip,
     camel_to_snake,
+    field_value_validator,
     get_dotted_field_list,
     get_dotted_field_value,
     get_versions_string,
@@ -496,3 +497,23 @@ class TestReduceFieldValue:
         value = typing.cast(FieldValue, tuple([1, 2, 3]))
         with pytest.raises(ValueError, match="unexpected type"):
             reduce_field_value(self.collect_node_type_or_leaf_value, value, [])
+
+
+class TestFieldValueValidator:
+    @pytest.mark.parametrize(
+        "value, expected_error",
+        [
+            ({"nested": ["value", 42, 13.37, True, None, {"child": False}]}, None),
+            ({1: "value"}, "add must have string keys"),
+            ({"nested": [object()]}, "add must be a FieldValue, got object"),
+        ],
+    )
+    def test_validates_recursive_field_values(self, value, expected_error):
+        attribute = mock.Mock()
+        attribute.name = "add"
+
+        if expected_error:
+            with pytest.raises(TypeError, match=expected_error):
+                field_value_validator(None, attribute, value)
+        else:
+            field_value_validator(None, attribute, value)


### PR DESCRIPTION
## Description

generic_adder: allow None as valid input via `add`

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* Tests

## Reviewer
- [x] The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] [Documentation](#documentation) is up-to-date
- [x] Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1010.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->

<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1010.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->