### PR TITLE
fix: ng error output structure to stay consistent with non-ng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * chart: fix command handling
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events
+* ng: fix error output structure to stay consistent with non-ng
 * generic_adder: allow None as valid input via `add`
 
 ## 20.0.0

--- a/logprep/ng/abc/event.py
+++ b/logprep/ng/abc/event.py
@@ -136,7 +136,7 @@ class ErrorEvent(_BaseFailableEvent, OutputEvent):
     @property
     def reason(self) -> str:
         """Get the textual representation for the error which caused the `ErrorEvent`"""
-        return typing.cast(str, self.data["reason"])
+        return typing.cast(str, self.data["errors"])
 
     @classmethod
     def from_failed_event(cls, event: LogEvent) -> "ErrorEvent":
@@ -149,7 +149,7 @@ class ErrorEvent(_BaseFailableEvent, OutputEvent):
         return cls(
             data={
                 "@timestamp": datetime.now(timezone.utc).isoformat(),
-                "reason": str(reason),
+                "errors": str(reason),
                 # TODO shouldnt we send the raw bytes? at least handle decoding failures properly
                 "original": (
                     event.original.decode("utf-8", errors="ignore")
@@ -169,7 +169,7 @@ class ErrorEvent(_BaseFailableEvent, OutputEvent):
         return cls(
             data={
                 "@timestamp": datetime.now(timezone.utc).isoformat(),
-                "reason": str(cause) if isinstance(cause, Exception) else cause,
+                "errors": str(cause) if isinstance(cause, Exception) else cause,
                 "original": (
                     original.decode("utf-8", errors="ignore") if original is not None else None
                 ),

--- a/tests/unit/ng/connector/test_confluent_kafka_input.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_input.py
@@ -375,7 +375,7 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
 
         error_event = await self.object.get_next(1)
         assert isinstance(error_event, ErrorEvent)
-        assert "Input record value is not a valid json string" in error_event.data["reason"]
+        assert "Input record value is not a valid json string" in error_event.data["errors"]
 
     async def test_commit_callback_raises_warning_error_and_counts_failures(self):
         self.object.metrics.commit_failures = 0

--- a/tests/unit/ng/event/test_error_event.py
+++ b/tests/unit/ng/event/test_error_event.py
@@ -43,6 +43,6 @@ class TestErrorEvents(TestEventClass):
         assert error_event.data["original"] == "raw"
         assert isinstance(error_event.data["event"], str)
         assert error_event.data["event"] == '{"foo": "bar"}'
-        assert isinstance(error_event.data["reason"], str)
-        assert "Some value is wrong" in error_event.data["reason"]
+        assert isinstance(error_event.data["errors"], str)
+        assert "Some value is wrong" in error_event.data["errors"]
         assert error_event.data["event"] == json.dumps(self.log_event.data)


### PR DESCRIPTION
## Description

* ng: fix error output structure to stay consistent with non-ng

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1013.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->