### PR TITLE
ci: update documentation-preview to only run on openend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           uv run sphinx-apidoc -fT -o source/module_reference ../logprep
           uv run make clean html
   documentation-preview:
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # https://github.com/readthedocs/actions/releases/tag/v1.5


### PR DESCRIPTION
## Description

Make rtd not always append new rtd doc links

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [ ] Patch test coverage > 95% and does not decrease
- [ ] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

<!-- TODO: fill out and remove this -->
* List of (preferably easy reproducible) tests including OS

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1015.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->