### PR TITLE
perf: improve metrics performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
 * grokker: improve performance by stopping on first matching expression
 * metrics: cache labeled child metric collectors
-* metrics: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
+* metrics: avoid heavy time context manager and hardwire passthrough metric collector methods on wrapper class
 * metrics: remove `__add__` interface from metrics and use the passthrough instead
 * metrics: consolidate `measure_time` and `measure_time_async` in single decorator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@
 * getter: remove noisy debug log
 * vuln: bump aiohttp to at least 3.14.3 in order to fix CVE-2026-69244
 * tests: add context handling framework for `test_cases`
+* tests: add mock_env decorator support for async functions
 * ci: enforce CHANGELOG.md is updated
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
-* perf: improve metrics performance by caching labeled child collectors
+* perf: cache labeled child metric collectors
+* perf: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
 * refactor: consolidate `measure_time` and `measure_time_async` in single decorator
+
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * ci: enforce CHANGELOG.md is updated
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
+* perf: improve metrics performance by caching labeled child collectors
+* refactor: consolidate `measure_time` and `measure_time_async` in single decorator
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
 * grokker: improve performance by stopping on first matching expression
-* perf: cache labeled child metric collectors
-* perf: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
-* refactor: consolidate `measure_time` and `measure_time_async` in single decorator
-
+* metrics: cache labeled child metric collectors
+* metrics: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
+* metrics: remove `__add__` interface from metrics and use the passthrough instead
+* metrics: consolidate `measure_time` and `measure_time_async` in single decorator
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@
 * ci: enforce CHANGELOG.md is updated
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
-* perf: cache labeled child metric collectors
-* perf: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
-* refactor: consolidate `measure_time` and `measure_time_async` in single decorator
+* metrics: cache labeled child metric collectors
+* metrics: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
+* metrics: remove `__add__` interface from metrics and use the passthrough instead
+* metrics: consolidate `measure_time` and `measure_time_async` in single decorator
 
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
 * grokker: improve performance by stopping on first matching expression
+* perf: improve metrics performance by caching labeled child collectors
+* refactor: consolidate `measure_time` and `measure_time_async` in single decorator
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,9 @@
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
 * metrics: cache labeled child metric collectors
-* metrics: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
+* metrics: avoid heavy time context manager and hardwire passthrough metric collector methods on wrapper class
 * metrics: remove `__add__` interface from metrics and use the passthrough instead
 * metrics: consolidate `measure_time` and `measure_time_async` in single decorator
-
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,15 @@
 * getter: remove noisy debug log
 * vuln: bump aiohttp to at least 3.14.3 in order to fix CVE-2026-69244
 * tests: add context handling framework for `test_cases`
+* tests: add mock_env decorator support for async functions
 * ci: enforce CHANGELOG.md is updated
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
 * grokker: improve performance by stopping on first matching expression
-* perf: improve metrics performance by caching labeled child collectors
+* perf: cache labeled child metric collectors
+* perf: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
 * refactor: consolidate `measure_time` and `measure_time_async` in single decorator
+
 
 ### Bugfix
 * chart: fix command handling

--- a/logprep/abc/component.py
+++ b/logprep/abc/component.py
@@ -52,7 +52,7 @@ class Component(ABC):
                 attribute = getattr(self, attr_name)
                 if isinstance(attribute, Metric):
                     attribute.labels = self._labels
-                    attribute.init_tracker()
+                    attribute.init_collector()
 
     __slots__ = [
         "name",

--- a/logprep/abc/input.py
+++ b/logprep/abc/input.py
@@ -46,7 +46,7 @@ class InputError(LogprepException):
     """Base class for Input related exceptions."""
 
     def __init__(self, input_connector: "Input", message: str) -> None:
-        input_connector.metrics.number_of_errors += 1
+        input_connector.metrics.number_of_errors.inc(1)
         super().__init__(f"{self.__class__.__name__} in {input_connector.description}: {message}")
 
 
@@ -73,7 +73,7 @@ class InputWarning(LogprepException):
     """May be catched but must be displayed to the user/logged."""
 
     def __init__(self, input_connector: "Input", message: str) -> None:
-        input_connector.metrics.number_of_warnings += 1
+        input_connector.metrics.number_of_warnings.inc(1)
         super().__init__(f"{self.__class__.__name__} in {input_connector.description}: {message}")
 
 
@@ -213,7 +213,7 @@ class Input(Connector):
         event, raw_event = self._get_event(timeout)
         if event is None:
             return None
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
         if not isinstance(event, dict):
             raise CriticalInputError(self, "not a dict", event)
         try:

--- a/logprep/abc/output.py
+++ b/logprep/abc/output.py
@@ -17,7 +17,7 @@ class OutputError(LogprepException):
     """Base class for Output related exceptions."""
 
     def __init__(self, output: "Output", message: str) -> None:
-        output.metrics.number_of_errors += 1
+        output.metrics.number_of_errors.inc(1)
         super().__init__(f"{self.__class__.__name__} in {output.description}: {message}")
 
 
@@ -25,7 +25,7 @@ class OutputWarning(LogprepException):
     """Base class for Output related warnings."""
 
     def __init__(self, output: "Output", message: str) -> None:
-        output.metrics.number_of_warnings += 1
+        output.metrics.number_of_warnings.inc(1)
         super().__init__(f"{self.__class__.__name__} in {output.description}: {message}")
 
 

--- a/logprep/abc/processor.py
+++ b/logprep/abc/processor.py
@@ -197,7 +197,7 @@ class Processor(Component):
     @Metric.measure_time(self_arg=1)
     def _process_rule(self, rule, event):
         self._apply_rules_wrapper(event, rule)
-        rule.metrics.number_of_processed_events += 1
+        rule.metrics.number_of_processed_events.inc(1)
         return event
 
     def _process_rule_tree_multiple_times(self, tree: RuleTree, event: dict) -> None:

--- a/logprep/connector/confluent_kafka/input.py
+++ b/logprep/connector/confluent_kafka/input.py
@@ -343,7 +343,7 @@ class ConfluentKafkaInput(Input):
         error : KafkaException
             the error that occurred
         """
-        self.metrics.number_of_errors += 1
+        self.metrics.number_of_errors.inc(1)
         logger.error("%s: %s", self.description, error)
 
     def _stats_callback(self, stats_raw: str) -> None:
@@ -359,25 +359,25 @@ class ConfluentKafkaInput(Input):
         """
 
         stats = self._decoder.decode(stats_raw)
-        self.metrics.librdkafka_age += stats.get("age", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx += stats.get("rx", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx += stats.get("tx", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx_bytes += stats.get("rx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx_bytes += stats.get("tx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_rxmsgs += stats.get("rxmsgs", DEFAULT_RETURN)
-        self.metrics.librdkafka_rxmsg_bytes += stats.get("rxmsg_bytes", DEFAULT_RETURN)
+        self.metrics.librdkafka_age.set(stats.get("age", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx.set(stats.get("rx", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx.set(stats.get("tx", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx_bytes.set(stats.get("rx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx_bytes.set(stats.get("tx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_rxmsgs.set(stats.get("rxmsgs", DEFAULT_RETURN))
+        self.metrics.librdkafka_rxmsg_bytes.set(stats.get("rxmsg_bytes", DEFAULT_RETURN))
 
-        self.metrics.librdkafka_cgrp_stateage += stats.get("cgrp", {}).get(
-            "stateage", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_stateage.set(
+            stats.get("cgrp", {}).get("stateage", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_rebalance_age += stats.get("cgrp", {}).get(
-            "rebalance_age", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_rebalance_age.set(
+            stats.get("cgrp", {}).get("rebalance_age", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_rebalance_cnt += stats.get("cgrp", {}).get(
-            "rebalance_cnt", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_rebalance_cnt.set(
+            stats.get("cgrp", {}).get("rebalance_cnt", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_assignment_size += stats.get("cgrp", {}).get(
-            "assignment_size", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_assignment_size.set(
+            stats.get("cgrp", {}).get("assignment_size", DEFAULT_RETURN)
         )
 
     def _commit_callback(
@@ -399,9 +399,9 @@ class ConfluentKafkaInput(Input):
             if `error` is not None
         """
         if error is not None:
-            self.metrics.commit_failures += 1
+            self.metrics.commit_failures.inc(1)
             raise InputWarning(self, f"Could not commit offsets for {topic_partitions}: {error}")
-        self.metrics.commit_success += 1
+        self.metrics.commit_success.inc(1)
         for topic_partition in topic_partitions:
             offset = topic_partition.offset
             if offset in SPECIAL_OFFSETS:
@@ -532,7 +532,7 @@ class ConfluentKafkaInput(Input):
     def _revoke_callback(self, _: Any, topic_partitions: list[TopicPartition]) -> None:
 
         for topic_partition in topic_partitions:
-            self.metrics.number_of_warnings += 1
+            self.metrics.number_of_warnings.inc(1)
             member_id = self._get_memberid()
             logger.warning(
                 "%s to be revoked from topic: %s | partition %s",
@@ -544,7 +544,7 @@ class ConfluentKafkaInput(Input):
 
     def _lost_callback(self, _: Consumer, topic_partitions: list[TopicPartition]) -> None:
         for topic_partition in topic_partitions:
-            self.metrics.number_of_warnings += 1
+            self.metrics.number_of_warnings.inc(1)
             member_id = self._get_memberid()
             logger.warning(
                 "%s has lost topic: %s | partition %s - try to reassign",
@@ -583,7 +583,7 @@ class ConfluentKafkaInput(Input):
                 return False
         except KafkaException as error:
             logger.error("Health check failed: %s", error)
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             return False
 
         return True

--- a/logprep/connector/confluent_kafka/output.py
+++ b/logprep/connector/confluent_kafka/output.py
@@ -245,7 +245,7 @@ class ConfluentKafkaOutput(Output):
         error : KafkaException
             the error that occurred
         """
-        self.metrics.number_of_errors += 1
+        self.metrics.number_of_errors.inc(1)
         logger.error("%s: %s", self.description, error)
 
     def _stats_callback(self, stats_raw: str) -> None:
@@ -260,17 +260,17 @@ class ConfluentKafkaOutput(Output):
             https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
         """
         stats = self._decoder.decode(stats_raw)
-        self.metrics.librdkafka_age += stats.get("age", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_cnt += stats.get("msg_cnt", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_size += stats.get("msg_size", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_max += stats.get("msg_max", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_size_max += stats.get("msg_size_max", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx += stats.get("tx", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx_bytes += stats.get("tx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx += stats.get("rx", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx_bytes += stats.get("rx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_txmsgs += stats.get("txmsgs", DEFAULT_RETURN)
-        self.metrics.librdkafka_txmsg_bytes += stats.get("txmsg_bytes", DEFAULT_RETURN)
+        self.metrics.librdkafka_age.set(stats.get("age", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_cnt.set(stats.get("msg_cnt", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_size.set(stats.get("msg_size", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_max.set(stats.get("msg_max", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_size_max.set(stats.get("msg_size_max", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx.set(stats.get("tx", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx_bytes.set(stats.get("tx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx.set(stats.get("rx", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx_bytes.set(stats.get("rx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_txmsgs.set(stats.get("txmsgs", DEFAULT_RETURN))
+        self.metrics.librdkafka_txmsg_bytes.set(stats.get("txmsg_bytes", DEFAULT_RETURN))
 
     def _describe(self) -> str:
         """Get name of Kafka endpoint with the bootstrap server."""
@@ -309,7 +309,7 @@ class ConfluentKafkaOutput(Output):
             self._producer.produce(target, value=self._encoder.encode(document))
             logger.debug("Produced message %s to topic %s", str(document), target)
             self._producer.poll(self.config.send_timeout)
-            self.metrics.number_of_processed_events += 1
+            self.metrics.number_of_processed_events.inc(1)
         except BufferError:
             # block program until buffer is empty or timeout is reached
             self._producer.flush(timeout=self.config.flush_timeout)
@@ -325,7 +325,7 @@ class ConfluentKafkaOutput(Output):
         """
         remaining_messages = self._producer.flush()
         if remaining_messages:
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             logger.error(
                 "Flushing producer timed out. %s messages are still in the buffer.",
                 remaining_messages,
@@ -349,7 +349,7 @@ class ConfluentKafkaOutput(Output):
                 return False
         except KafkaException as error:
             logger.error("Health check failed: %s", error)
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             return False
         return True
 

--- a/logprep/connector/console/output.py
+++ b/logprep/connector/console/output.py
@@ -26,8 +26,8 @@ class ConsoleOutput(Output):
 
     def store(self, document: dict):
         pprint(document)
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
 
     def store_custom(self, document: dict, target: str):
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
         pprint(document, stream=getattr(sys, target))

--- a/logprep/connector/dummy/output.py
+++ b/logprep/connector/dummy/output.py
@@ -96,7 +96,7 @@ class DummyOutput(Output):
             if exception is not None:
                 raise Exception(exception)  # pylint: disable=broad-exception-raised
         self.events.append(document)
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
 
     def store_custom(self, document: dict, target: str):
         """Store additional data in a custom location inside the output destination."""

--- a/logprep/connector/http/input.py
+++ b/logprep/connector/http/input.py
@@ -299,7 +299,7 @@ class HttpEndpoint(ABC):
 
     def collect_metrics(self):
         """Increment number of requests"""
-        self.metrics.number_of_http_requests += 1
+        self.metrics.number_of_http_requests.inc(1)
 
     async def get_data(self, req: falcon.asgi.Request) -> bytes:
         """returns the data from the request body
@@ -644,7 +644,7 @@ class HttpInput(Input):
         """Returns the first message from the queue"""
         messages = typing.cast(Queue, self.messages)
 
-        self._typed_metrics.message_backlog_size += messages.qsize()
+        self._typed_metrics.message_backlog_size.set(messages.qsize())
         try:
             message = messages.get(timeout=timeout)
             raw_message = str(message).encode("utf8")
@@ -689,7 +689,7 @@ class HttpInput(Input):
                 ).raise_for_status()
             except (requests.exceptions.RequestException, requests.exceptions.Timeout) as error:
                 logger.error("Health check failed for endpoint: %s due to %s", endpoint, str(error))
-                self._typed_metrics.number_of_errors += 1
+                self._typed_metrics.number_of_errors.inc(1)
                 return False
 
         return True

--- a/logprep/connector/http/output.py
+++ b/logprep/connector/http/output.py
@@ -213,7 +213,7 @@ class HttpOutput(Output):
             request_data = document.replace(";", "\n")
         else:
             error = TypeError(f"Document type {type(document)} is not supported")
-            self.metrics.number_of_failed_events += 1
+            self.metrics.number_of_failed_events.inc(1)
             logger.error(str(error))
             return
         try:
@@ -234,20 +234,20 @@ class HttpOutput(Output):
                     },
                 )
                 response.raise_for_status()
-                self.metrics.number_of_processed_events += document_count
-                self.metrics.number_of_http_requests += 1
+                self.metrics.number_of_processed_events.inc(document_count)
+                self.metrics.number_of_http_requests.inc(1)
             except requests.RequestException as error:
                 logger.error("Failed to send event: %s", str(error))
                 logger.debug("Failed event: %s", document)
-                self.metrics.number_of_failed_events += document_count
-                self.metrics.number_of_http_requests += 1
+                self.metrics.number_of_failed_events.inc(document_count)
+                self.metrics.number_of_http_requests.inc(1)
                 if not isinstance(error, requests.exceptions.HTTPError):
                     raise error
         except requests.exceptions.ConnectionError as error:
             logger.error(error)
-            self.metrics.connection_errors += 1
+            self.metrics.connection_errors.inc(1)
             if isinstance(error, requests.exceptions.Timeout):
-                self.metrics.timeouts += 1
+                self.metrics.timeouts.inc(1)
         except requests.exceptions.MissingSchema as error:
             raise ConnectionError(
                 f"No schema set in target-url: {self.config.target_url}"
@@ -255,4 +255,4 @@ class HttpOutput(Output):
         except requests.exceptions.Timeout as error:
             # other timeouts than connection timeouts are handled here
             logger.error(error)
-            self.metrics.timeouts += 1
+            self.metrics.timeouts.inc(1)

--- a/logprep/connector/http/output.py
+++ b/logprep/connector/http/output.py
@@ -40,6 +40,7 @@ of the :code:`target_url`.
 
 import json
 import logging
+import typing
 from functools import cached_property
 
 import requests
@@ -135,24 +136,29 @@ class HttpOutput(Output):
                     )
                 )
             ),
-            validator=validators.instance_of(str | bool),
+            validator=validators.instance_of((str, bool)),
         )
         """Switch to disable ssl verification or path to certificate"""
+
+    @cached_property
+    def config(self) -> Config:
+        """Provides the properly typed configuration object"""
+        return typing.cast(HttpOutput.Config, self._config)
 
     @property
     def user(self):
         """Return the user that is used for the http request"""
-        return self._config.user
+        return self.config.user
 
     @property
     def password(self):
         """Return the password that is used for the http request"""
-        return self._config.password
+        return self.config.password
 
     @property
     def timeout(self):
         """Return the timeout in seconds for the http request"""
-        return self._config.timeout
+        return self.config.timeout
 
     @cached_property
     def _headers(self):
@@ -161,7 +167,7 @@ class HttpOutput(Output):
     @property
     def verify(self):
         """Return the ssl verify status that is used for the http request"""
-        return self._config.verify
+        return self.config.verify
 
     @property
     def statistics(self) -> str:
@@ -173,7 +179,7 @@ class HttpOutput(Output):
                 lambda x: x.name.endswith("_total")
                 and "number_of_warnings" not in x.name  # blocklisted metric
                 and "number_of_errors" not in x.name,  # blocklisted metric
-                getattr(self.metrics, metric.name).tracker.collect()[0].samples,
+                getattr(self.metrics, metric.name).collect_samples(),
             )
             for sample in samples:
                 key = (
@@ -187,14 +193,15 @@ class HttpOutput(Output):
     def store(self, document: tuple[str, dict | list[dict]] | dict) -> None:
         if isinstance(document, tuple):
             target, payload = document
-            target = f"{self._config.target_url}{target}"
+            target = f"{self.config.target_url}{target}"
             self.store_custom(payload, target)
         else:
-            target = self._config.target_url
+            target = self.config.target_url
             self.store_custom(document, target)
 
     def store_custom(self, document: dict | tuple | list | str, target: str) -> None:
         """Send a post request with given data to the specified endpoint"""
+        request_data: str | bytes
         if isinstance(document, (tuple, list)):
             request_data = self._encoder.encode_lines(document)
             document_count = len(document)
@@ -243,7 +250,7 @@ class HttpOutput(Output):
                 self.metrics.timeouts += 1
         except requests.exceptions.MissingSchema as error:
             raise ConnectionError(
-                f"No schema set in target-url: {self._config.get('target_url')}"
+                f"No schema set in target-url: {self.config.target_url}"
             ) from error
         except requests.exceptions.Timeout as error:
             # other timeouts than connection timeouts are handled here

--- a/logprep/connector/jsonl/output.py
+++ b/logprep/connector/jsonl/output.py
@@ -19,6 +19,8 @@ Example
 """
 
 import json
+import typing
+from functools import cached_property
 
 from attrs import define, field, validators
 
@@ -55,6 +57,11 @@ class JsonlOutput(Output):
         "failed_events",
     ]
 
+    @cached_property
+    def config(self) -> Config:
+        """Provides the properly typed configuration object"""
+        return typing.cast(JsonlOutput.Config, self._config)
+
     def __init__(self, name: str, configuration: "Output.Config"):
         super().__init__(name, configuration)
         self.events = []
@@ -62,9 +69,9 @@ class JsonlOutput(Output):
 
     def setup(self):
         super().setup()
-        open(self._config.output_file, "a+", encoding="utf8").close()
-        if self._config.output_file_custom:
-            open(self._config.output_file_custom, "a+", encoding="utf8").close()
+        open(self.config.output_file, "a+", encoding="utf8").close()
+        if self.config.output_file_custom:
+            open(self.config.output_file_custom, "a+", encoding="utf8").close()
 
     @staticmethod
     def _write_json(filepath: str, line: dict):
@@ -74,13 +81,13 @@ class JsonlOutput(Output):
 
     def store(self, document: dict):
         self.events.append(document)
-        JsonlOutput._write_json(self._config.output_file, document)
-        self.metrics.number_of_processed_events += 1
+        JsonlOutput._write_json(self.config.output_file, document)
+        self.metrics.number_of_processed_events.inc(1)
 
     def store_custom(self, document: dict, target: str):
         document = {target: document}
         self.events.append(document)
 
-        if self._config.output_file_custom:
-            JsonlOutput._write_json(self._config.output_file_custom, document)
-        self.metrics.number_of_processed_events += 1
+        if self.config.output_file_custom:
+            JsonlOutput._write_json(self.config.output_file_custom, document)
+        self.metrics.number_of_processed_events.inc(1)

--- a/logprep/connector/opensearch/output.py
+++ b/logprep/connector/opensearch/output.py
@@ -253,7 +253,7 @@ class OpensearchOutput(Output):
         """
         document["_index"] = target
         document["_op_type"] = document.get("_op_type", self.config.default_op_type)
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
         self._message_backlog.append(document)
         self._write_to_search_context()
 
@@ -317,7 +317,7 @@ class OpensearchOutput(Output):
             )
         except (OpenSearchException, ConnectionError) as error:
             logger.error("Health check failed: %s", error)
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             return False
         return resp.get("status") in self.config.desired_cluster_status
 

--- a/logprep/connector/s3/output.py
+++ b/logprep/connector/s3/output.py
@@ -228,7 +228,7 @@ class S3Output(Output):
         document : dict
            Document to store.
         """
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
         prefix_value = get_dotted_field_value(document, self.config.prefix_field)
         if prefix_value is None:
             document = self._build_no_prefix_document(
@@ -258,7 +258,7 @@ class S3Output(Output):
             Prefix for the document.
 
         """
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
         self._add_to_backlog(document, target)
 
     def _add_dates(self, prefix: str) -> str:
@@ -306,7 +306,7 @@ class S3Output(Output):
         logger.debug('Writing "%s" to s3 bucket "%s"', identifier, self.config.bucket)
         s3_obj = self._s3_resource.Object(self.config.bucket, identifier)  # type: ignore
         s3_obj.put(Body=self._encoder.encode(document_batch), ContentType="application/json")
-        self.metrics.number_of_successful_writes += len(document_batch)
+        self.metrics.number_of_successful_writes.inc(len(document_batch))
 
     def _build_no_prefix_document(self, message_document: dict, reason: str) -> dict:
         document = {

--- a/logprep/framework/pipeline.py
+++ b/logprep/framework/pipeline.py
@@ -377,13 +377,13 @@ class Pipeline:
             case CriticalOutputError():
                 event = self._get_output_error_event(item)
             case PipelineResult(input_event, errors):
-                self.metrics.number_of_failed_events += 1
+                self.metrics.number_of_failed_events.inc(1)
                 event = {
                     "event": str(input_event),
                     "errors": ", ".join((str(error.message) for error in errors)),
                 }
             case CriticalInputError():
-                self.metrics.number_of_failed_events += 1
+                self.metrics.number_of_failed_events.inc(1)
                 event = {"event": str(item.raw_input), "errors": str(item.message)}
             case list():
                 event = [{"event": str(i), "errors": "Unknown error"} for i in item]
@@ -420,15 +420,15 @@ class Pipeline:
                 event = [
                     {"event": str(i["event"]), "errors": str(i["errors"])} for i in item.raw_input
                 ]
-                self.metrics.number_of_failed_events += len(event)
+                self.metrics.number_of_failed_events.inc(len(event))
                 return event
             case CriticalOutputError({"errors": error, "event": event}):
-                self.metrics.number_of_failed_events += 1
+                self.metrics.number_of_failed_events.inc(1)
                 return {"event": str(event), "errors": str(error)}
             case CriticalOutputError(raw_input) if isinstance(raw_input, (list, tuple)):
                 event = [{"event": str(i), "errors": str(item.message)} for i in raw_input]
-                self.metrics.number_of_failed_events += len(event)
+                self.metrics.number_of_failed_events.inc(len(event))
                 return event
             case _:
-                self.metrics.number_of_failed_events += 1
+                self.metrics.number_of_failed_events.inc(1)
                 return {"event": str(item.raw_input), "errors": str(item.message)}

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -239,14 +239,14 @@ class PipelineManager:
         while len(self._pipelines) < count:
             new_pipeline_index = len(self._pipelines) + 1
             self._pipelines.append(self._create_pipeline(new_pipeline_index))
-            self.metrics.number_of_pipeline_starts += 1
+            self.metrics.number_of_pipeline_starts.inc(1)
 
     def _decrease_to_count(self, count: int):
         while len(self._pipelines) > count:
             pipeline_process = self._pipelines.pop()
             pipeline_process.stop()  # type: ignore
             pipeline_process.join()
-            self.metrics.number_of_pipeline_stops += 1
+            self.metrics.number_of_pipeline_stops.inc(1)
 
     def restart_failed_pipeline(self):
         """Remove one pipeline at a time."""
@@ -264,7 +264,7 @@ class PipelineManager:
         for index, failed_pipeline in failed_pipelines:
             pipeline_index = index + 1
             self._pipelines.pop(index)
-            self.metrics.number_of_failed_pipelines += 1
+            self.metrics.number_of_failed_pipelines.inc(1)
             if self.prometheus_exporter:
                 self.prometheus_exporter.mark_process_dead(failed_pipeline.pid)
             self._pipelines.insert(index, self._create_pipeline(pipeline_index))

--- a/logprep/framework/pipeline_manager.py
+++ b/logprep/framework/pipeline_manager.py
@@ -142,8 +142,6 @@ class PipelineManager:
             factory=lambda: CounterMetric(
                 description="Number of pipeline starts",
                 name="number_of_pipeline_starts",
-                labels={"component": "manager"},
-                inject_label_values=False,
             )
         )
         """Number of pipeline starts"""

--- a/logprep/generator/confluent_kafka/output.py
+++ b/logprep/generator/confluent_kafka/output.py
@@ -12,7 +12,7 @@ from typing import overload
 
 from attrs import define, evolve, field
 
-from logprep.abc.output import CriticalOutputError, Output
+from logprep.abc.output import CriticalOutputError
 from logprep.connector.confluent_kafka.output import ConfluentKafkaOutput
 from logprep.metrics.metrics import CounterMetric, Metric
 
@@ -34,7 +34,7 @@ class ConfluentKafkaGeneratorOutput(ConfluentKafkaOutput):
         )
         """Total number of batches send to brokers"""
 
-    _config: Output.Config
+    _config: ConfluentKafkaOutput.Config
 
     @property
     def statistics(self) -> str:
@@ -50,7 +50,7 @@ class ConfluentKafkaGeneratorOutput(ConfluentKafkaOutput):
                 lambda x: x.name.endswith("_total")
                 and "number_of_warnings" not in x.name  # blocklisted metric
                 and "number_of_errors" not in x.name,  # blocklisted metric
-                getattr(self.metrics, metric.name).tracker.collect()[0].samples,
+                getattr(self.metrics, metric.name).collect_samples(),
             )
             for sample in samples:
                 key = (

--- a/logprep/generator/confluent_kafka/output.py
+++ b/logprep/generator/confluent_kafka/output.py
@@ -71,7 +71,7 @@ class ConfluentKafkaGeneratorOutput(ConfluentKafkaOutput):
     def store(self, document) -> None:
 
         with self.lock:
-            self.metrics.processed_batches += 1
+            self.metrics.processed_batches.inc(1)
             topic, _, payload = document.partition(",")
             _, _, topic = topic.rpartition("/")
             self._config = evolve(self._config, topic=topic)
@@ -99,7 +99,7 @@ class ConfluentKafkaGeneratorOutput(ConfluentKafkaOutput):
             self._producer.produce(target, value=document)
             logger.debug("Produced message %s to topic %s", str(document), target)
             self._producer.poll(self._config.send_timeout)
-            self.metrics.number_of_processed_events += 1
+            self.metrics.number_of_processed_events.inc(1)
         except BufferError:
             self._producer.flush(timeout=self._config.flush_timeout)
             logger.debug("Buffer full, flushing")

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -171,8 +171,11 @@ class Metric(ABC, Generic[M]):
 
     _collector: M = field(default=None, init=False)
 
-    _collector_methods: ClassVar[set[str]] = set()
+    _collector_methods: ClassVar[set[str]]
     """Methods marked as tracked method collected on subclass init"""
+
+    _value_series_suffix: ClassVar[str]
+    """Suffix implemented by subclasses to select the right series carrying the metric value"""
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
@@ -238,14 +241,14 @@ class Metric(ABC, Generic[M]):
         """Return the labelled child of the collector for the given labels"""
         return self._collector.labels(**(self.labels | labels))
 
-    def _bind(self, child: M) -> M:
-        """Bind the child's exposed methods directly onto this instance."""
+    def _bind(self, child: M) -> Self:
+        """Bind the child's exposed methods directly onto this instance"""
         for name in self._collector_methods:
             setattr(self, name, getattr(child, name))
-        return child
+        return self
 
-    def _lazy_bind_default_child(self) -> M:
-        """Bind the default child on first use and return it."""
+    def _lazy_bind_default_child(self) -> Self:
+        """Bind the default child on first use and return the metric."""
         return self._bind(self._labeled_child(self.labels))
 
     def child_collector(self, labels: dict[str, str], inject_label_values: bool = True) -> Self:
@@ -260,9 +263,11 @@ class Metric(ABC, Generic[M]):
     def _init_collector(self) -> M:
         """Create the concrete prometheus metric object"""
 
-    @abstractmethod
-    def __add__(self, other):
-        """Increment the metric by the given value"""
+    @property
+    def value(self) -> float:
+        """The value this metric currently exports, summed over its labelled children."""
+        series_name = f"{self.fullname}{self._value_series_suffix}"
+        return sum(sample.value for sample in self.collect_samples() if sample.name == series_name)
 
     def collect_samples(self) -> list[Sample]:
         """Return the samples of the whole collector, including every labelled child."""
@@ -360,6 +365,9 @@ class Metric(ABC, Generic[M]):
 class CounterMetric(Metric[Counter]):
     """Wrapper for prometheus Counter metric"""
 
+    _value_series_suffix: ClassVar[str] = "_total"
+    """A counter exports its value under the `_total` series"""
+
     @property
     def collector_type(self) -> type[Counter]:
         return Counter
@@ -375,11 +383,7 @@ class CounterMetric(Metric[Counter]):
     @_collector_method
     def inc(self, amount: float = 1, exemplar: dict[str, str] | None = None) -> None:
         """Increment the counter. Rebinds to the collector's method on first call."""
-        self._lazy_bind_default_child().inc(amount, exemplar)
-
-    def __add__(self, other: Any) -> Self:
-        self.inc(other)
-        return self
+        return self._lazy_bind_default_child().inc(amount, exemplar)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
@@ -389,6 +393,15 @@ class CounterMetric(Metric[Counter]):
 @define(kw_only=True)
 class HistogramMetric(Metric[Histogram]):
     """Wrapper for prometheus Histogram metric"""
+
+    _value_series_suffix: ClassVar[str] = "_sum"
+    """The histogram value is the sum of the observations"""
+
+    @property
+    def count(self) -> float:
+        """How many observations were made, summed over the labelled children"""
+        series = f"{self.fullname}_count"
+        return sum(sample.value for sample in self.collect_samples() if sample.name == series)
 
     @property
     def collector_type(self) -> type[Histogram]:
@@ -406,16 +419,7 @@ class HistogramMetric(Metric[Histogram]):
     @_collector_method
     def observe(self, amount: float, exemplar: dict[str, str] | None = None) -> None:
         """Observe a value. Rebinds to the collector's method on first call."""
-        self._lazy_bind_default_child().observe(amount, exemplar)
-
-    @_collector_method
-    def time(self) -> Any:
-        """Time a block or function. Rebinds on first call."""
-        return self._lazy_bind_default_child().time()
-
-    def __add__(self, other) -> Self:
-        self.observe(other)
-        return self
+        return self._lazy_bind_default_child().observe(amount, exemplar)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
@@ -424,7 +428,10 @@ class HistogramMetric(Metric[Histogram]):
 
 @define(kw_only=True)
 class GaugeMetric(Metric[Gauge]):
-    """Wrapper for prometheus Gauge metric""" ""
+    """Wrapper for prometheus Gauge metric"""
+
+    _value_series_suffix: ClassVar[str] = ""
+    """A gauge exports its value under the bare metric name, without a suffix"""
 
     @property
     def collector_type(self) -> type[Gauge]:
@@ -441,22 +448,18 @@ class GaugeMetric(Metric[Gauge]):
 
     @_collector_method
     def set(self, value: float) -> None:
-        """Set the gauge. Rebinds to the collector's method on first call."""
-        self._lazy_bind_default_child().set(value)
+        """Set the gauge. Rebinds to the collector's method on first call"""
+        return self._lazy_bind_default_child().set(value)
 
     @_collector_method
     def inc(self, amount: float = 1) -> None:
-        """Increment the gauge. Rebinds to the collector's method on first call."""
-        self._lazy_bind_default_child().inc(amount)
+        """Increment the gauge. Rebinds to the collector's method on first call"""
+        return self._lazy_bind_default_child().inc(amount)
 
     @_collector_method
     def dec(self, amount: float = 1) -> None:
-        """Decrement the gauge. Rebinds to the collector's method on first call."""
-        self._lazy_bind_default_child().dec(amount)
-
-    def __add__(self, other) -> Self:
-        self.set(other)
-        return self
+        """Decrement the gauge. Rebinds to the collector's method on first call"""
+        return self._lazy_bind_default_child().dec(amount)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -125,6 +125,7 @@ from _socket import gethostname
 from attrs import define, field, validators
 from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram
 from prometheus_client.metrics import MetricWrapperBase
+from prometheus_client.samples import Sample
 
 from logprep.util.environ import ENV_VARS
 from logprep.util.helper import _add_field_to_silent_fail
@@ -253,6 +254,12 @@ class Metric(ABC, Generic[M]):
     @abstractmethod
     def __add__(self, other):
         """Increment the metric by the given value"""
+
+    def collect_samples(self) -> list[Sample]:
+        """Return the samples of the whole collector, including every labelled child."""
+        metrics = self._base_tracker.collect()
+        assert isinstance(metrics, list) and len(metrics) == 1
+        return metrics[0].samples
 
     # TODO refactor measure_time for ng reducing implicit logic relying on hasattr
     @staticmethod

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -116,6 +116,7 @@ Processor Specific Metrics
 """
 
 import functools
+import inspect
 import time
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Generic, Self, TypeVar
@@ -266,111 +267,85 @@ class Metric(ABC, Generic[M]):
     def measure_time(metric_name: str = "processing_time_per_event", self_arg: int = 0):
         """Decorate function to measure execution time for function and add results to event."""
 
-        if not ENV_VARS.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
+        perf_counter = time.perf_counter
+        append_to_event = bool(ENV_VARS.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"))
 
-            def without_append(func):
+        def decorator(func):
+            is_async = inspect.iscoroutinefunction(func)
+
+            if not append_to_event:
+
                 @functools.wraps(func)
-                def inner(*args, **kwargs):  # nosemgrep
+                async def timed_async(*args, **kwargs):
                     self = args[self_arg]
-                    metric = getattr(self.metrics, metric_name)
-                    with metric.time():
-                        result = func(*args, **kwargs)
-                    return result
+                    begin = perf_counter()
+                    try:
+                        return await func(*args, **kwargs)
+                    finally:
+                        duration = perf_counter() - begin
+                        getattr(self.metrics, metric_name).observe(duration)
 
-                return inner
+                @functools.wraps(func)
+                def timed(*args, **kwargs):
+                    self = args[self_arg]
+                    begin = perf_counter()
+                    try:
+                        return func(*args, **kwargs)
+                    finally:
+                        duration = perf_counter() - begin
+                        getattr(self.metrics, metric_name).observe(duration)
 
-            return without_append
+                return timed_async if is_async else timed
 
-        def with_append(func):
+            def append_measurement(self, args, duration: float) -> None:
+                is_rule = hasattr(self, "rule_type")
+                is_pipeline = hasattr(self, "_logprep_config")
+                if not (is_rule or is_pipeline):
+                    return
+                event = args[self_arg + 1]
+                if not event:
+                    return
+                if is_rule:
+                    _add_field_to_silent_fail(
+                        event=event,
+                        field=(f"processing_times.{self.rule_type}", duration),
+                        rule=None,
+                    )
+                elif is_pipeline:
+                    _add_field_to_silent_fail(
+                        event=event, field=("processing_times.pipeline", duration), rule=None
+                    )
+                    _add_field_to_silent_fail(
+                        event=event, field=("processing_times.hostname", gethostname()), rule=None
+                    )
+
             @functools.wraps(func)
-            def inner(*args, **kwargs):  # nosemgrep
+            async def timed_and_appended_async(*args, **kwargs):
                 self = args[self_arg]
-                metric = getattr(self.metrics, metric_name)
-                begin = time.perf_counter()
-                result = func(*args, **kwargs)
-                duration = time.perf_counter() - begin
-                metric += duration
-
-                if hasattr(self, "rule_type"):
-                    event = args[self_arg + 1]
-                    if event:
-                        _add_field_to_silent_fail(
-                            event=event,
-                            field=(f"processing_times.{self.rule_type}", duration),
-                            rule=None,
-                        )
-                if hasattr(self, "_logprep_config"):  # attribute of the Pipeline class
-                    event = args[self_arg + 1]
-                    if event:
-                        _add_field_to_silent_fail(
-                            event=event, field=("processing_times.pipeline", duration), rule=None
-                        )
-                        _add_field_to_silent_fail(
-                            event=event,
-                            field=("processing_times.hostname", gethostname()),
-                            rule=None,
-                        )
+                begin = perf_counter()
+                try:
+                    result = await func(*args, **kwargs)
+                finally:
+                    duration = perf_counter() - begin
+                    getattr(self.metrics, metric_name).observe(duration)
+                append_measurement(self, args, duration)
                 return result
 
-            return inner
-
-        return with_append
-
-    @staticmethod
-    def measure_time_async(metric_name: str = "processing_time_per_event", self_arg: int = 0):
-        """Decorate function to measure execution time for function and add results to event."""
-
-        if not ENV_VARS.get("LOGPREP_APPEND_MEASUREMENT_TO_EVENT"):
-
-            def without_append(func):
-                @functools.wraps(func)
-                async def inner(*args, **kwargs):  # nosemgrep
-                    self = args[self_arg]
-                    metric = getattr(self.metrics, metric_name)
-                    with metric.time():
-                        # TODO does this make sense for async functions?!
-                        result = await func(*args, **kwargs)
-                    return result
-
-                return inner
-
-            return without_append
-
-        def with_append(func):
             @functools.wraps(func)
-            async def inner(*args, **kwargs):  # nosemgrep
+            def timed_and_appended(*args, **kwargs):
                 self = args[self_arg]
-                metric = getattr(self.metrics, metric_name)
-                begin = time.perf_counter()
-                # TODO does this make sense for async functions?!
-                result = await func(*args, **kwargs)
-                duration = time.perf_counter() - begin
-                metric += duration
-
-                if hasattr(self, "rule_type"):
-                    event = args[self_arg + 1]
-                    if event:
-                        _add_field_to_silent_fail(
-                            event=event,
-                            field=(f"processing_times.{self.rule_type}", duration),
-                            rule=None,
-                        )
-                if hasattr(self, "_logprep_config"):  # attribute of the Pipeline class
-                    event = args[self_arg + 1]
-                    if event:
-                        _add_field_to_silent_fail(
-                            event=event, field=("processing_times.pipeline", duration), rule=None
-                        )
-                        _add_field_to_silent_fail(
-                            event=event,
-                            field=("processing_times.hostname", gethostname()),
-                            rule=None,
-                        )
+                begin = perf_counter()
+                try:
+                    result = func(*args, **kwargs)
+                finally:
+                    duration = perf_counter() - begin
+                    getattr(self.metrics, metric_name).observe(duration)
+                append_measurement(self, args, duration)
                 return result
 
-            return inner
+            return timed_and_appended_async if is_async else timed_and_appended
 
-        return with_append
+        return decorator
 
 
 @define(kw_only=True)

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -181,8 +181,8 @@ class Metric(ABC, Generic[M]):
         super().__init_subclass__(**kwargs)
         cls._collector_methods = {
             name
-            for klass in cls.__mro__
-            for name, value in vars(klass).items()
+            for super_cls in cls.__mro__
+            for name, value in vars(super_cls).items()
             if getattr(value, "__collector_method__", False)
         }
 
@@ -230,7 +230,7 @@ class Metric(ABC, Generic[M]):
                 ) from error
             self._collector = collector
         if self.inject_label_values:
-            self._bind(self._labeled_child(self.labels))
+            self._bind_default_child()
 
     @property
     def initialized(self) -> bool:
@@ -241,15 +241,13 @@ class Metric(ABC, Generic[M]):
         """Return the labelled child of the collector for the given labels"""
         return self._collector.labels(**(self.labels | labels))
 
-    def _bind(self, child: M) -> Self:
-        """Bind the child's exposed methods directly onto this instance"""
+    def _bind_default_child(self) -> Self:
+        """Bind the default childs methods and return the metric."""
+        child_collector = self._labeled_child(self.labels)
         for name in self._collector_methods:
-            setattr(self, name, getattr(child, name))
+            child_collector_method = getattr(child_collector, name)
+            setattr(self, name, child_collector_method)
         return self
-
-    def _lazy_bind_default_child(self) -> Self:
-        """Bind the default child on first use and return the metric."""
-        return self._bind(self._labeled_child(self.labels))
 
     def child_collector(self, labels: dict[str, str], inject_label_values: bool = True) -> Self:
         """Return a child metric configured with the given labels"""
@@ -383,7 +381,7 @@ class CounterMetric(Metric[Counter]):
     @_collector_method
     def inc(self, amount: float = 1, exemplar: dict[str, str] | None = None) -> None:
         """Increment the counter. Rebinds to the collector's method on first call."""
-        return self._lazy_bind_default_child().inc(amount, exemplar)
+        return self._bind_default_child().inc(amount, exemplar)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
@@ -419,7 +417,7 @@ class HistogramMetric(Metric[Histogram]):
     @_collector_method
     def observe(self, amount: float, exemplar: dict[str, str] | None = None) -> None:
         """Observe a value. Rebinds to the collector's method on first call."""
-        return self._lazy_bind_default_child().observe(amount, exemplar)
+        return self._bind_default_child().observe(amount, exemplar)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
@@ -449,17 +447,17 @@ class GaugeMetric(Metric[Gauge]):
     @_collector_method
     def set(self, value: float) -> None:
         """Set the gauge. Rebinds to the collector's method on first call"""
-        return self._lazy_bind_default_child().set(value)
+        return self._bind_default_child().set(value)
 
     @_collector_method
     def inc(self, amount: float = 1) -> None:
         """Increment the gauge. Rebinds to the collector's method on first call"""
-        return self._lazy_bind_default_child().inc(amount)
+        return self._bind_default_child().inc(amount)
 
     @_collector_method
     def dec(self, amount: float = 1) -> None:
         """Decrement the gauge. Rebinds to the collector's method on first call"""
-        return self._lazy_bind_default_child().dec(amount)
+        return self._bind_default_child().dec(amount)
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -134,13 +134,13 @@ from logprep.util.helper import _add_field_to_silent_fail
 M = TypeVar("M", bound=MetricWrapperBase)
 
 
-def _tracker_method(func):
+def _collector_method(func):
     """
-    Marks a metric method as a 1:1 wrapper of the underlying tracker method.
-    The wrapper is then automatically replaced with the bound tracker method.
-    This happens either eagerly on init or lazily (`_bind()`).
+    Marks a metric method as a 1:1 wrapper of the underlying collector method.
+    The wrapper is then automatically replaced with the bound child method.
+    This happens either eagerly on init or lazily (see :code:`Metric._bind(...)`).
     """
-    func.__tracker_method__ = True
+    func.__collector_method__ = True
     return func
 
 
@@ -161,37 +161,42 @@ class Metric(ABC, Generic[M]):
         factory=dict,
     )
     inject_label_values: bool = field(default=True)
-    tracker: M = field(default=None)
+    """
+    Registers the labels with metric 0 in :code:`init_collector`.
+    Otherwise registration takes place on first metric increment.
+    """
+
     _prefix: str = field(default="logprep_")
-    _base_tracker: M = field(default=None)
     _registry: CollectorRegistry | None = field(default=None)
 
-    _tracker_methods: ClassVar[set[str]] = set()
+    _collector: M = field(default=None, init=False)
+
+    _collector_methods: ClassVar[set[str]] = set()
     """Methods marked as tracked method collected on subclass init"""
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
-        cls._tracker_methods = {
+        cls._collector_methods = {
             name
             for klass in cls.__mro__
             for name, value in vars(klass).items()
-            if getattr(value, "__tracker_method__", False)
+            if getattr(value, "__collector_method__", False)
         }
 
     def __attrs_post_init__(self):
         if self._registry is not None:
             return
 
-        # When this environment variable is set, the prometheus_client will automatically run in multiprocessing mode
+        # When this environment variable is set,
+        # the prometheus_client will automatically run in multiprocessing mode
         # In that mode it is not allowed to set a Registry specifically.
-        # For the non multiprocessing mode, we need to set a Registry otherwise our custom metrics never get
+        # For the non multiprocessing mode,
+        # we need to set a Registry otherwise our custom metrics never get
         # registered and then subsequently cannot be exported
         if ENV_VARS.get("PROMETHEUS_MULTIPROC_DIR", "") != "":
             self._registry = None
         else:
             self._registry = REGISTRY
-        if self.tracker is not None:
-            self._bind(self.tracker)
 
     @property
     @abstractmethod
@@ -203,53 +208,56 @@ class Metric(ABC, Generic[M]):
         """returns the fullname"""
         return f"{self._prefix}{self.name}"
 
-    def init_tracker(self) -> None:
-        """initializes the tracker and adds it to the trackers dict"""
+    def init_collector(self) -> None:
+        """initializes the collector and registers it"""
         try:
-            self._base_tracker = self._init_tracker()
+            self._collector = self._init_collector()
         except ValueError as error:
             # pylint: disable=protected-access
-            tracker = None
+            collector = None
             if self._registry:
-                tracker = self._registry._names_to_collectors.get(self.fullname)
+                # recover by getting the existing instance, which is the likely error source
+                collector = self._registry._names_to_collectors.get(self.fullname)
             # pylint: enable=protected-access
-            if tracker is not None:
-                if not isinstance(tracker, self.collector_type):
-                    raise ValueError(
-                        f"Metric {self.fullname} already exists with different type"
-                    ) from error
-                self._base_tracker = tracker
+            if collector is None:
+                raise
+            if not isinstance(collector, self.collector_type):
+                raise ValueError(
+                    f"Metric {self.fullname} already exists with different type"
+                ) from error
+            self._collector = collector
         if self.inject_label_values:
-            self._bind(self._child_tracker(self.labels))
-        else:
-            self.tracker = self._base_tracker
+            self._bind(self._labeled_child(self.labels))
 
-    def _child_tracker(self, labels: dict[str, str]) -> M:
-        """Return the child tracker configured with the given labels"""
-        return self._base_tracker.labels(**(self.labels | labels))
+    @property
+    def initialized(self) -> bool:
+        """Whether :code:`init_collector` has been called successfully"""
+        return self._collector is not None
 
-    def _bind(self, tracker: M) -> None:
-        """Bind `tracker` and its exposed methods directly onto this instance.
+    def _labeled_child(self, labels: dict[str, str]) -> M:
+        """Return the labelled child of the collector for the given labels"""
+        return self._collector.labels(**(self.labels | labels))
 
-        The bound methods land in the instance dict, shadowing the fallback methods
-        defined on the class, so `metric.inc(1)` becomes a plain attribute lookup
-        followed by a call into prometheus with nothing in between.
-        """
-        self.tracker = tracker
-        for name in self._tracker_methods:
-            setattr(self, name, getattr(tracker, name))
+    def _bind(self, child: M) -> M:
+        """Bind the child's exposed methods directly onto this instance."""
+        for name in self._collector_methods:
+            setattr(self, name, getattr(child, name))
+        return child
 
     def _lazy_bind_default_child(self) -> M:
-        """Bind the default child on first use and return its tracker."""
-        self._bind(self._child_tracker(self.labels))
-        return self.tracker
+        """Bind the default child on first use and return it."""
+        return self._bind(self._labeled_child(self.labels))
 
-    def child(self, labels: dict[str, str]) -> Self:
+    def child_collector(self, labels: dict[str, str], inject_label_values: bool = True) -> Self:
         """Return a child metric configured with the given labels"""
-        return attrs.evolve(self, tracker=self._child_tracker(labels))
+        child = attrs.evolve(
+            self, labels=self.labels | labels, inject_label_values=inject_label_values
+        )
+        child.init_collector()
+        return child
 
     @abstractmethod
-    def _init_tracker(self) -> M:
+    def _init_collector(self) -> M:
         """Create the concrete prometheus metric object"""
 
     @abstractmethod
@@ -258,11 +266,10 @@ class Metric(ABC, Generic[M]):
 
     def collect_samples(self) -> list[Sample]:
         """Return the samples of the whole collector, including every labelled child."""
-        metrics = self._base_tracker.collect()
-        assert isinstance(metrics, list) and len(metrics) == 1
+        metrics = self._collector.collect()
+        assert isinstance(metrics, list) and len(metrics) == 1, ".collect() implementation changed"
         return metrics[0].samples
 
-    # TODO refactor measure_time for ng reducing implicit logic relying on hasattr
     @staticmethod
     def measure_time(metric_name: str = "processing_time_per_event", self_arg: int = 0):
         """Decorate function to measure execution time for function and add results to event."""
@@ -298,6 +305,7 @@ class Metric(ABC, Generic[M]):
                 return timed_async if is_async else timed
 
             def append_measurement(self, args, duration: float) -> None:
+                # TODO refactor measure_time for ng reducing implicit logic relying on hasattr
                 is_rule = hasattr(self, "rule_type")
                 is_pipeline = hasattr(self, "_logprep_config")
                 if not (is_rule or is_pipeline):
@@ -311,7 +319,7 @@ class Metric(ABC, Generic[M]):
                         field=(f"processing_times.{self.rule_type}", duration),
                         rule=None,
                     )
-                elif is_pipeline:
+                if is_pipeline:
                     _add_field_to_silent_fail(
                         event=event, field=("processing_times.pipeline", duration), rule=None
                     )
@@ -356,7 +364,7 @@ class CounterMetric(Metric[Counter]):
     def collector_type(self) -> type[Counter]:
         return Counter
 
-    def _init_tracker(self):
+    def _init_collector(self):
         return Counter(
             name=self.fullname,
             documentation=self.description,
@@ -364,9 +372,9 @@ class CounterMetric(Metric[Counter]):
             registry=self._registry,
         )
 
-    @_tracker_method
+    @_collector_method
     def inc(self, amount: float = 1, exemplar: dict[str, str] | None = None) -> None:
-        """Increment the counter. Rebinds to the tracker method on first call."""
+        """Increment the counter. Rebinds to the collector's method on first call."""
         self._lazy_bind_default_child().inc(amount, exemplar)
 
     def __add__(self, other: Any) -> Self:
@@ -375,7 +383,7 @@ class CounterMetric(Metric[Counter]):
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
-        self._child_tracker(labels).inc(other)
+        self._labeled_child(labels).inc(other)
 
 
 @define(kw_only=True)
@@ -386,7 +394,7 @@ class HistogramMetric(Metric[Histogram]):
     def collector_type(self) -> type[Histogram]:
         return Histogram
 
-    def _init_tracker(self):
+    def _init_collector(self):
         return Histogram(
             name=self.fullname,
             documentation=self.description,
@@ -395,12 +403,12 @@ class HistogramMetric(Metric[Histogram]):
             registry=self._registry,
         )
 
-    @_tracker_method
+    @_collector_method
     def observe(self, amount: float, exemplar: dict[str, str] | None = None) -> None:
-        """Observe a value. Rebinds to the tracker method on first call."""
+        """Observe a value. Rebinds to the collector's method on first call."""
         self._lazy_bind_default_child().observe(amount, exemplar)
 
-    @_tracker_method
+    @_collector_method
     def time(self) -> Any:
         """Time a block or function. Rebinds on first call."""
         return self._lazy_bind_default_child().time()
@@ -411,7 +419,7 @@ class HistogramMetric(Metric[Histogram]):
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
-        self._child_tracker(labels).observe(other)
+        self._labeled_child(labels).observe(other)
 
 
 @define(kw_only=True)
@@ -422,7 +430,7 @@ class GaugeMetric(Metric[Gauge]):
     def collector_type(self) -> type[Gauge]:
         return Gauge
 
-    def _init_tracker(self) -> Gauge:
+    def _init_collector(self) -> Gauge:
         return Gauge(
             name=self.fullname,
             documentation=self.description,
@@ -431,19 +439,19 @@ class GaugeMetric(Metric[Gauge]):
             multiprocess_mode="liveall",
         )
 
-    @_tracker_method
+    @_collector_method
     def set(self, value: float) -> None:
-        """Set the gauge. Rebinds to the tracker method on first call."""
+        """Set the gauge. Rebinds to the collector's method on first call."""
         self._lazy_bind_default_child().set(value)
 
-    @_tracker_method
+    @_collector_method
     def inc(self, amount: float = 1) -> None:
-        """Increment the gauge. Rebinds to the tracker method on first call."""
+        """Increment the gauge. Rebinds to the collector's method on first call."""
         self._lazy_bind_default_child().inc(amount)
 
-    @_tracker_method
+    @_collector_method
     def dec(self, amount: float = 1) -> None:
-        """Decrement the gauge. Rebinds to the tracker method on first call."""
+        """Decrement the gauge. Rebinds to the collector's method on first call."""
         self._lazy_bind_default_child().dec(amount)
 
     def __add__(self, other) -> Self:
@@ -452,4 +460,4 @@ class GaugeMetric(Metric[Gauge]):
 
     def add_with_labels(self, other: Any, labels: dict) -> None:
         """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
-        self._child_tracker(labels).set(other)
+        self._labeled_child(labels).set(other)

--- a/logprep/metrics/metrics.py
+++ b/logprep/metrics/metrics.py
@@ -117,10 +117,10 @@ Processor Specific Metrics
 
 import functools
 import time
-import typing
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, ClassVar, Generic, Self, TypeVar
 
+import attrs
 from _socket import gethostname
 from attrs import define, field, validators
 from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram
@@ -129,9 +129,21 @@ from prometheus_client.metrics import MetricWrapperBase
 from logprep.util.environ import ENV_VARS
 from logprep.util.helper import _add_field_to_silent_fail
 
+M = TypeVar("M", bound=MetricWrapperBase)
+
+
+def _tracker_method(func):
+    """
+    Marks a metric method as a 1:1 wrapper of the underlying tracker method.
+    The wrapper is then automatically replaced with the bound tracker method.
+    This happens either eagerly on init or lazily (`_bind()`).
+    """
+    func.__tracker_method__ = True
+    return func
+
 
 @define(kw_only=True, slots=False)
-class Metric(ABC):
+class Metric(ABC, Generic[M]):
     """Metric base class"""
 
     name: str = field(validator=validators.instance_of(str))
@@ -146,10 +158,23 @@ class Metric(ABC):
         ],
         factory=dict,
     )
-    _prefix: str = field(default="logprep_")
     inject_label_values: bool = field(default=True)
-    _tracker: MetricWrapperBase = field(init=False, default=None)
+    tracker: M = field(default=None)
+    _prefix: str = field(default="logprep_")
+    _base_tracker: M = field(default=None)
     _registry: CollectorRegistry | None = field(default=None)
+
+    _tracker_methods: ClassVar[set[str]] = set()
+    """Methods marked as tracked method collected on subclass init"""
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._tracker_methods = {
+            name
+            for klass in cls.__mro__
+            for name, value in vars(klass).items()
+            if getattr(value, "__tracker_method__", False)
+        }
 
     def __attrs_post_init__(self):
         if self._registry is not None:
@@ -163,16 +188,13 @@ class Metric(ABC):
             self._registry = None
         else:
             self._registry = REGISTRY
+        if self.tracker is not None:
+            self._bind(self.tracker)
 
     @property
     @abstractmethod
-    def collector_type(self) -> type[MetricWrapperBase]:
+    def collector_type(self) -> type[M]:
         """The prometheus metric companion type"""
-
-    @property
-    def tracker(self) -> MetricWrapperBase:
-        """Returns the prometheus metric object"""
-        return self._tracker
 
     @property
     def fullname(self):
@@ -182,7 +204,7 @@ class Metric(ABC):
     def init_tracker(self) -> None:
         """initializes the tracker and adds it to the trackers dict"""
         try:
-            self._tracker = self._init_tracker()
+            self._base_tracker = self._init_tracker()
         except ValueError as error:
             # pylint: disable=protected-access
             tracker = None
@@ -194,17 +216,43 @@ class Metric(ABC):
                     raise ValueError(
                         f"Metric {self.fullname} already exists with different type"
                     ) from error
-                self._tracker = tracker
+                self._base_tracker = tracker
         if self.inject_label_values:
-            self._tracker.labels(**self.labels)
+            self._bind(self._child_tracker(self.labels))
+        else:
+            self.tracker = self._base_tracker
+
+    def _child_tracker(self, labels: dict[str, str]) -> M:
+        """Return the child tracker configured with the given labels"""
+        return self._base_tracker.labels(**(self.labels | labels))
+
+    def _bind(self, tracker: M) -> None:
+        """Bind `tracker` and its exposed methods directly onto this instance.
+
+        The bound methods land in the instance dict, shadowing the fallback methods
+        defined on the class, so `metric.inc(1)` becomes a plain attribute lookup
+        followed by a call into prometheus with nothing in between.
+        """
+        self.tracker = tracker
+        for name in self._tracker_methods:
+            setattr(self, name, getattr(tracker, name))
+
+    def _lazy_bind_default_child(self) -> M:
+        """Bind the default child on first use and return its tracker."""
+        self._bind(self._child_tracker(self.labels))
+        return self.tracker
+
+    def child(self, labels: dict[str, str]) -> Self:
+        """Return a child metric configured with the given labels"""
+        return attrs.evolve(self, tracker=self._child_tracker(labels))
+
+    @abstractmethod
+    def _init_tracker(self) -> M:
+        """Create the concrete prometheus metric object"""
 
     @abstractmethod
     def __add__(self, other):
         """Increment the metric by the given value"""
-
-    @abstractmethod
-    def _init_tracker(self) -> MetricWrapperBase:
-        """Create the concrete prometheus metric object"""
 
     # TODO refactor measure_time for ng reducing implicit logic relying on hasattr
     @staticmethod
@@ -218,7 +266,7 @@ class Metric(ABC):
                 def inner(*args, **kwargs):  # nosemgrep
                     self = args[self_arg]
                     metric = getattr(self.metrics, metric_name)
-                    with metric.tracker.labels(**metric.labels).time():
+                    with metric.time():
                         result = func(*args, **kwargs)
                     return result
 
@@ -272,7 +320,7 @@ class Metric(ABC):
                 async def inner(*args, **kwargs):  # nosemgrep
                     self = args[self_arg]
                     metric = getattr(self.metrics, metric_name)
-                    with metric.tracker.labels(**metric.labels).time():
+                    with metric.time():
                         # TODO does this make sense for async functions?!
                         result = await func(*args, **kwargs)
                     return result
@@ -319,7 +367,7 @@ class Metric(ABC):
 
 
 @define(kw_only=True)
-class CounterMetric(Metric):
+class CounterMetric(Metric[Counter]):
     """Wrapper for prometheus Counter metric"""
 
     @property
@@ -334,23 +382,22 @@ class CounterMetric(Metric):
             registry=self._registry,
         )
 
-    @property
-    def tracker(self) -> Counter:
-        """Returns the prometheus metric object"""
-        return typing.cast(Counter, self._tracker)
+    @_tracker_method
+    def inc(self, amount: float = 1, exemplar: dict[str, str] | None = None) -> None:
+        """Increment the counter. Rebinds to the tracker method on first call."""
+        self._lazy_bind_default_child().inc(amount, exemplar)
 
-    def __add__(self, other: Any) -> "CounterMetric":
-        return self.add_with_labels(other, self.labels)
-
-    def add_with_labels(self, other: Any, labels: dict) -> "CounterMetric":
-        """Add with labels"""
-        labels = self.labels | labels
-        self.tracker.labels(**labels).inc(other)
+    def __add__(self, other: Any) -> Self:
+        self.inc(other)
         return self
+
+    def add_with_labels(self, other: Any, labels: dict) -> None:
+        """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
+        self._child_tracker(labels).inc(other)
 
 
 @define(kw_only=True)
-class HistogramMetric(Metric):
+class HistogramMetric(Metric[Histogram]):
     """Wrapper for prometheus Histogram metric"""
 
     @property
@@ -366,25 +413,34 @@ class HistogramMetric(Metric):
             registry=self._registry,
         )
 
-    @property
-    def tracker(self) -> Histogram:
-        """Returns the prometheus metric object"""
-        return typing.cast(Histogram, self._tracker)
+    @_tracker_method
+    def observe(self, amount: float, exemplar: dict[str, str] | None = None) -> None:
+        """Observe a value. Rebinds to the tracker method on first call."""
+        self._lazy_bind_default_child().observe(amount, exemplar)
 
-    def __add__(self, other):
-        self.tracker.labels(**self.labels).observe(other)
+    @_tracker_method
+    def time(self) -> Any:
+        """Time a block or function. Rebinds on first call."""
+        return self._lazy_bind_default_child().time()
+
+    def __add__(self, other) -> Self:
+        self.observe(other)
         return self
+
+    def add_with_labels(self, other: Any, labels: dict) -> None:
+        """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
+        self._child_tracker(labels).observe(other)
 
 
 @define(kw_only=True)
-class GaugeMetric(Metric):
+class GaugeMetric(Metric[Gauge]):
     """Wrapper for prometheus Gauge metric""" ""
 
     @property
     def collector_type(self) -> type[Gauge]:
         return Gauge
 
-    def _init_tracker(self):
+    def _init_tracker(self) -> Gauge:
         return Gauge(
             name=self.fullname,
             documentation=self.description,
@@ -393,16 +449,25 @@ class GaugeMetric(Metric):
             multiprocess_mode="liveall",
         )
 
-    @property
-    def tracker(self) -> Gauge:
-        """Returns the prometheus metric object"""
-        return typing.cast(Gauge, self._tracker)
+    @_tracker_method
+    def set(self, value: float) -> None:
+        """Set the gauge. Rebinds to the tracker method on first call."""
+        self._lazy_bind_default_child().set(value)
 
-    def __add__(self, other):
-        return self.add_with_labels(other, self.labels)
+    @_tracker_method
+    def inc(self, amount: float = 1) -> None:
+        """Increment the gauge. Rebinds to the tracker method on first call."""
+        self._lazy_bind_default_child().inc(amount)
 
-    def add_with_labels(self, other, labels):
-        """Add with labels"""
-        labels = self.labels | labels
-        self.tracker.labels(**labels).set(other)
+    @_tracker_method
+    def dec(self, amount: float = 1) -> None:
+        """Decrement the gauge. Rebinds to the tracker method on first call."""
+        self._lazy_bind_default_child().dec(amount)
+
+    def __add__(self, other) -> Self:
+        self.set(other)
         return self
+
+    def add_with_labels(self, other: Any, labels: dict) -> None:
+        """Deprecated method. Always creates a metric with labels set and adds/sets the value"""
+        self._child_tracker(labels).set(other)

--- a/logprep/ng/abc/input.py
+++ b/logprep/ng/abc/input.py
@@ -142,7 +142,7 @@ class Input(Connector, AsyncIterator[LogEvent | ErrorEvent | None]):
         LogEvent | ErrorEvent | None
         """
 
-    @Metric.measure_time_async()
+    @Metric.measure_time()
     async def get_next(self, timeout: float) -> LogEvent | ErrorEvent | None:
         """Return the next document
 

--- a/logprep/ng/abc/input.py
+++ b/logprep/ng/abc/input.py
@@ -29,7 +29,7 @@ class InputError(LogprepException):
     def from_error(
         cls, connector: "Input", error: Exception, message: str | None = None
     ) -> "InputError":
-        connector.metrics.number_of_errors += 1
+        connector.metrics.number_of_errors.inc(1)
         if message is not None:
             return cls(f"{cls.__name__} in {connector.description}: {message}: {str(error)}")
         else:
@@ -37,7 +37,7 @@ class InputError(LogprepException):
 
     @classmethod
     def from_message(cls, connector: "Input", message: str) -> "InputError":
-        connector.metrics.number_of_errors += 1
+        connector.metrics.number_of_errors.inc(1)
         return cls(f"{cls.__name__} in {connector.description}: {message}")
 
 
@@ -61,7 +61,7 @@ class InputWarning(LogprepException):
         cls, connector: "Input", error: Exception, message: str | None = None
     ) -> "InputWarning":
         """Generate an `InputWarning` from a low level error"""
-        connector.metrics.number_of_warnings += 1
+        connector.metrics.number_of_warnings.inc(1)
         if message is not None:
             return cls(f"{cls.__name__} in {connector.description}: {message}: {str(error)}")
         else:
@@ -70,7 +70,7 @@ class InputWarning(LogprepException):
     @classmethod
     def from_message(cls, connector: "Input", message: str) -> "InputWarning":
         """Generate an `InputWarning` from a message"""
-        connector.metrics.number_of_warnings += 1
+        connector.metrics.number_of_warnings.inc(1)
         return cls(f"{cls.__name__} in {connector.description}: {message}")
 
 
@@ -172,7 +172,7 @@ class Input(Connector, AsyncIterator[LogEvent | ErrorEvent | None]):
             event.mark_failed(error)
             return ErrorEvent.from_failed_event(event)
 
-        self.metrics.number_of_processed_events += 1
+        self.metrics.number_of_processed_events.inc(1)
 
         return event
 

--- a/logprep/ng/abc/output.py
+++ b/logprep/ng/abc/output.py
@@ -21,7 +21,7 @@ class OutputError(LogprepException):
         cls, connector: "Output", error: Exception, message: str | None = None
     ) -> "OutputError":
         """Generate an `OutputException` from a low level error"""
-        connector.metrics.number_of_errors += 1
+        connector.metrics.number_of_errors.inc(1)
         if message is not None:
             return cls(f"{cls.__name__} in {connector.description}: {message}: {str(error)}")
         return cls(f"{cls.__name__} in {connector.description}: {str(error)}")
@@ -29,7 +29,7 @@ class OutputError(LogprepException):
     @classmethod
     def from_message(cls, connector: "Output", message: str) -> "OutputError":
         """Generate an `OutputException` from a message"""
-        connector.metrics.number_of_errors += 1
+        connector.metrics.number_of_errors.inc(1)
         return cls(f"{cls.__name__} in {connector.description}: {message}")
 
 
@@ -106,8 +106,8 @@ class Output(Connector):
                 )
 
         # modify metrics in batches
-        self.metrics.number_of_processed_events += sum(1 for e in events if e.stored)
-        self.metrics.number_of_errors += sum(1 for e in events if e.is_failed())
+        self.metrics.number_of_processed_events.inc(sum(1 for e in events if e.stored))
+        self.metrics.number_of_errors.inc(sum(1 for e in events if e.is_failed()))
 
     @staticmethod
     def _handle_error(event: OutputEvent, error: Exception) -> None:

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -146,7 +146,7 @@ class Processor(Component):
     @Metric.measure_time(self_arg=1)
     async def _process_rule(self, rule, event):
         await self._apply_rules_wrapper(event, rule)
-        rule.metrics.number_of_processed_events += 1
+        rule.metrics.number_of_processed_events.inc(1)
         return event
 
     async def _process_rule_tree_multiple_times(self, tree: RuleTree, event: dict) -> None:

--- a/logprep/ng/abc/processor.py
+++ b/logprep/ng/abc/processor.py
@@ -143,7 +143,7 @@ class Processor(Component):
         await self._process_rule_tree(event.data, self._rule_tree)
         return self._event
 
-    @Metric.measure_time_async(self_arg=1)
+    @Metric.measure_time(self_arg=1)
     async def _process_rule(self, rule, event):
         await self._apply_rules_wrapper(event, rule)
         rule.metrics.number_of_processed_events += 1

--- a/logprep/ng/connector/confluent_kafka/input.py
+++ b/logprep/ng/connector/confluent_kafka/input.py
@@ -363,7 +363,7 @@ class ConfluentKafkaInput(Input):
         error : KafkaException
             the error that occurred
         """
-        self.metrics.number_of_errors += 1
+        self.metrics.number_of_errors.inc(1)
         logger.error("%s: %s", self.description, error)
 
     async def _stats_callback(self, stats_raw: str) -> None:
@@ -379,25 +379,25 @@ class ConfluentKafkaInput(Input):
         """
 
         stats = self._decoder.decode(stats_raw)
-        self.metrics.librdkafka_age += stats.get("age", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx += stats.get("rx", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx += stats.get("tx", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx_bytes += stats.get("rx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx_bytes += stats.get("tx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_rxmsgs += stats.get("rxmsgs", DEFAULT_RETURN)
-        self.metrics.librdkafka_rxmsg_bytes += stats.get("rxmsg_bytes", DEFAULT_RETURN)
+        self.metrics.librdkafka_age.set(stats.get("age", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx.set(stats.get("rx", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx.set(stats.get("tx", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx_bytes.set(stats.get("rx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx_bytes.set(stats.get("tx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_rxmsgs.set(stats.get("rxmsgs", DEFAULT_RETURN))
+        self.metrics.librdkafka_rxmsg_bytes.set(stats.get("rxmsg_bytes", DEFAULT_RETURN))
 
-        self.metrics.librdkafka_cgrp_stateage += stats.get("cgrp", {}).get(
-            "stateage", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_stateage.set(
+            stats.get("cgrp", {}).get("stateage", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_rebalance_age += stats.get("cgrp", {}).get(
-            "rebalance_age", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_rebalance_age.set(
+            stats.get("cgrp", {}).get("rebalance_age", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_rebalance_cnt += stats.get("cgrp", {}).get(
-            "rebalance_cnt", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_rebalance_cnt.set(
+            stats.get("cgrp", {}).get("rebalance_cnt", DEFAULT_RETURN)
         )
-        self.metrics.librdkafka_cgrp_assignment_size += stats.get("cgrp", {}).get(
-            "assignment_size", DEFAULT_RETURN
+        self.metrics.librdkafka_cgrp_assignment_size.set(
+            stats.get("cgrp", {}).get("assignment_size", DEFAULT_RETURN)
         )
 
     def _describe(self) -> str:
@@ -526,7 +526,7 @@ class ConfluentKafkaInput(Input):
         self, _: AIOConsumer, topic_partitions: list[TopicPartition]
     ) -> None:
         for tp in topic_partitions:
-            self.metrics.number_of_warnings += 1
+            self.metrics.number_of_warnings.inc(1)
             member_id = await self._get_memberid()
             logger.warning(
                 "%s to be revoked from topic: %s | partition %s", member_id, tp.topic, tp.partition
@@ -535,7 +535,7 @@ class ConfluentKafkaInput(Input):
 
     async def _lost_callback(self, _: AIOConsumer, topic_partitions: list[TopicPartition]) -> None:
         for tp in topic_partitions:
-            self.metrics.number_of_warnings += 1
+            self.metrics.number_of_warnings.inc(1)
             member_id = await self._get_memberid()
             logger.warning(
                 "%s has lost topic: %s | partition %s", member_id, tp.topic, tp.partition
@@ -557,9 +557,9 @@ class ConfluentKafkaInput(Input):
         """
 
         if error is not None:
-            self.metrics.commit_failures += 1
+            self.metrics.commit_failures.inc(1)
             raise InputWarning.from_error(self, error, "Could not commit offsets")
-        self.metrics.commit_success += 1
+        self.metrics.commit_success.inc(1)
         for tp in topic_partitions:
             offset = tp.offset
             if offset in SPECIAL_OFFSETS:
@@ -594,7 +594,7 @@ class ConfluentKafkaInput(Input):
                 return False
         except KafkaException as error:
             logger.error("Health check failed: %s", error)
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             return False
         return True
 

--- a/logprep/ng/connector/confluent_kafka/output.py
+++ b/logprep/ng/connector/confluent_kafka/output.py
@@ -284,7 +284,7 @@ class ConfluentKafkaOutput(Output):
             target = event.output_target if event.output_target is not None else self.config.topic
             await self._store_single(event, target)
 
-    @Metric.measure_time_async()
+    @Metric.measure_time()
     async def _store_single(self, event: OutputEvent, target: str) -> None:
         """Write document to Kafka into target topic.
 

--- a/logprep/ng/connector/confluent_kafka/output.py
+++ b/logprep/ng/connector/confluent_kafka/output.py
@@ -245,7 +245,7 @@ class ConfluentKafkaOutput(Output):
         error : KafkaException
             the error that occurred
         """
-        self.metrics.number_of_errors += 1
+        self.metrics.number_of_errors.inc(1)
         logger.error("%s: %s", self.description, error)
 
     async def _stats_callback(self, stats_raw: str) -> None:
@@ -260,17 +260,17 @@ class ConfluentKafkaOutput(Output):
             https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
         """
         stats = self._decoder.decode(stats_raw)
-        self.metrics.librdkafka_age += stats.get("age", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_cnt += stats.get("msg_cnt", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_size += stats.get("msg_size", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_max += stats.get("msg_max", DEFAULT_RETURN)
-        self.metrics.librdkafka_msg_size_max += stats.get("msg_size_max", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx += stats.get("tx", DEFAULT_RETURN)
-        self.metrics.librdkafka_tx_bytes += stats.get("tx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx += stats.get("rx", DEFAULT_RETURN)
-        self.metrics.librdkafka_rx_bytes += stats.get("rx_bytes", DEFAULT_RETURN)
-        self.metrics.librdkafka_txmsgs += stats.get("txmsgs", DEFAULT_RETURN)
-        self.metrics.librdkafka_txmsg_bytes += stats.get("txmsg_bytes", DEFAULT_RETURN)
+        self.metrics.librdkafka_age.set(stats.get("age", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_cnt.set(stats.get("msg_cnt", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_size.set(stats.get("msg_size", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_max.set(stats.get("msg_max", DEFAULT_RETURN))
+        self.metrics.librdkafka_msg_size_max.set(stats.get("msg_size_max", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx.set(stats.get("tx", DEFAULT_RETURN))
+        self.metrics.librdkafka_tx_bytes.set(stats.get("tx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx.set(stats.get("rx", DEFAULT_RETURN))
+        self.metrics.librdkafka_rx_bytes.set(stats.get("rx_bytes", DEFAULT_RETURN))
+        self.metrics.librdkafka_txmsgs.set(stats.get("txmsgs", DEFAULT_RETURN))
+        self.metrics.librdkafka_txmsg_bytes.set(stats.get("txmsg_bytes", DEFAULT_RETURN))
 
     def _describe(self) -> str:
         """Get name of Kafka endpoint with the bootstrap server."""
@@ -334,7 +334,7 @@ class ConfluentKafkaOutput(Output):
                 return False
         except KafkaException as error:
             logger.error("Health check failed: %s", error)
-            self.metrics.number_of_errors += 1
+            self.metrics.number_of_errors.inc(1)
             return False
         return True
 

--- a/logprep/ng/connector/http/input.py
+++ b/logprep/ng/connector/http/input.py
@@ -189,7 +189,7 @@ class HttpEndpoint(ABC):
 
     def collect_metrics(self):
         """Increment number of requests"""
-        self.metrics.number_of_http_requests += 1
+        self.metrics.number_of_http_requests.inc(1)
 
     async def get_data(self, req: falcon.asgi.Request) -> bytes:
         """returns the data from the request body
@@ -529,7 +529,7 @@ class HttpInput(Input):
 
     async def _get_event(self, timeout: float) -> LogEvent | ErrorEvent | None:
         """Returns the first message from the queue"""
-        self.metrics.message_backlog_size += self.messages.qsize()
+        self.metrics.message_backlog_size.set(self.messages.qsize())
         try:
             async with asyncio.timeout(timeout):
                 message = await self.messages.get()
@@ -590,7 +590,7 @@ class HttpInput(Input):
             try:
                 await asyncio.gather(*map(check_endpoint_status, self.health_endpoints))
             except (aiohttp.ClientError, TimeoutError):
-                self.metrics.number_of_errors += 1
+                self.metrics.number_of_errors.inc(1)
                 return False
 
         return True

--- a/logprep/ng/connector/opensearch/output.py
+++ b/logprep/ng/connector/opensearch/output.py
@@ -587,7 +587,7 @@ class OpensearchOutput(Output):
         chunk.shrink_to(retry_indices)
         return chunk.is_resolved
 
-    @Metric.measure_time_async(metric_name="send_time_per_bulk_request")
+    @Metric.measure_time(metric_name="send_time_per_bulk_request")
     async def _send(self, chunk: _Chunk) -> dict[str, Any]:
         """One bulk network request; counts requests, documents and bytes."""
         payload = chunk.payload
@@ -617,8 +617,8 @@ class OpensearchOutput(Output):
             logger.error("critical failure while sending bulk chunk", exc_info=True)
             chunk.fail_remaining(error)
 
-    @Metric.measure_time_async(metric_name="processing_time_per_event")
-    @Metric.measure_time_async(metric_name="send_time_per_batch")
+    @Metric.measure_time(metric_name="processing_time_per_event")
+    @Metric.measure_time(metric_name="send_time_per_batch")
     async def _store(self, events: Sequence[OutputEvent]) -> None:
         logger.debug("Flushing %d documents to opensearch", len(events))
         # TODO maybe introduce step-wise chunking in the future, if memory use becomes a problem

--- a/logprep/ng/connector/opensearch/output.py
+++ b/logprep/ng/connector/opensearch/output.py
@@ -464,7 +464,7 @@ class OpensearchOutput(Output):
         return isinstance(error, OSError)  # includes TimeoutError
 
     def _count_connection_failure(self, _: Exception) -> None:
-        self._metrics.number_of_connection_failures += 1
+        self._metrics.number_of_connection_failures.inc(1)
 
     def _describe(self) -> str:
         """Get name of Opensearch endpoint with the host."""
@@ -525,7 +525,7 @@ class OpensearchOutput(Output):
                 payload = self._serialize(event)
             except SerializationError as error:
                 logger.info("failed to serialize event %s", event, exc_info=True)
-                self._metrics.number_of_serialization_errors += 1
+                self._metrics.number_of_serialization_errors.inc(1)
                 event.mark_failed(
                     BulkError(message=f"failed to serialize event: {error}", exception=str(error))
                 )
@@ -583,7 +583,7 @@ class OpensearchOutput(Output):
                     )
                 )
         if retry_indices:
-            self._metrics.number_of_document_rejections += len(retry_indices)
+            self._metrics.number_of_document_rejections.inc(len(retry_indices))
         chunk.shrink_to(retry_indices)
         return chunk.is_resolved
 
@@ -591,9 +591,9 @@ class OpensearchOutput(Output):
     async def _send(self, chunk: _Chunk) -> dict[str, Any]:
         """One bulk network request; counts requests, documents and bytes."""
         payload = chunk.payload
-        self._metrics.number_of_bulk_requests += 1
-        self._metrics.documents_per_bulk_request += len(chunk.events)
-        self._metrics.number_of_bytes_sent += len(payload)
+        self._metrics.number_of_bulk_requests.inc(1)
+        self._metrics.documents_per_bulk_request.observe(len(chunk.events))
+        self._metrics.number_of_bytes_sent.inc(len(payload))
         return await self._search_context.bulk(body=payload)
 
     async def _resolve_chunk(self, chunk: _Chunk) -> None:
@@ -634,7 +634,7 @@ class OpensearchOutput(Output):
             )
         except (OpenSearchException, ConnectionError) as error:
             logger.error("Health check failed: %s", error)
-            self._metrics.number_of_errors += 1
+            self._metrics.number_of_errors.inc(1)
             return False
         return (await super().health()) and resp.get("status") in self.config.desired_cluster_status
 

--- a/logprep/ng/processor/amides/processor.py
+++ b/logprep/ng/processor/amides/processor.py
@@ -235,7 +235,7 @@ class Amides(FieldManager):
         if self._handle_missing_fields(event, rule, rule.source_fields, [cmdline]):
             return
 
-        self.metrics.total_cmdlines += 1
+        self.metrics.total_cmdlines.inc(1)
 
         normalized = self._normalizer.normalize(cmdline)
         if not normalized:
@@ -267,7 +267,7 @@ class Amides(FieldManager):
 
     def _update_cache_metrics(self):
         cache_info = self._evaluate_cmdline_cached.cache_info()
-        self.metrics.new_results += cache_info.misses
-        self.metrics.cached_results += cache_info.hits
-        self.metrics.num_cache_entries += cache_info.currsize
-        self.metrics.cache_load += cache_info.currsize / cache_info.maxsize
+        self.metrics.new_results.set(cache_info.misses)
+        self.metrics.cached_results.set(cache_info.hits)
+        self.metrics.num_cache_entries.set(cache_info.currsize)
+        self.metrics.cache_load.set(cache_info.currsize / cache_info.maxsize)

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -189,7 +189,7 @@ class DomainResolver(Processor):
             domain = url.path
         if not domain:
             return
-        self.metrics.total_urls += 1
+        self.metrics.total_urls.inc(1)
         if self.config.cache_enabled:
             self._resolve_with_cache(domain, event, rule)
         else:
@@ -205,10 +205,10 @@ class DomainResolver(Processor):
             resolved_ip, status = self._resolve_ip(domain)
             if status in (ResolveStatus.SUCCESS, ResolveStatus.UNKNOWN, ResolveStatus.TIMEOUT):
                 self._domain_ip_map.update({hash_string: resolved_ip})
-            self.metrics.resolved_new += 1
+            self.metrics.resolved_new.inc(1)
         else:
             resolved_ip = self._domain_ip_map.get(hash_string)
-            self.metrics.resolved_cached += 1
+            self.metrics.resolved_cached.inc(1)
         self._add_resolve_infos_to_event(event, rule, resolved_ip)
 
         if self.config.debug_cache:
@@ -230,13 +230,13 @@ class DomainResolver(Processor):
             resolved_ip = result.get(timeout=self.config.timeout)
             return resolved_ip, ResolveStatus.SUCCESS
         except ValueError:  # Makes no connection so does not need to be cached
-            self.metrics.invalid_domains += 1
+            self.metrics.invalid_domains.inc(1)
             return None, ResolveStatus.INVALID
         except context.TimeoutError:
-            self.metrics.timeouts += 1
+            self.metrics.timeouts.inc(1)
             return None, ResolveStatus.TIMEOUT
         except OSError:  # Won't be timeout if default timeout is None
-            self.metrics.unknown_domains += 1
+            self.metrics.unknown_domains.inc(1)
             return None, ResolveStatus.UNKNOWN
 
     def _store_debug_infos(self, event: dict[str, FieldValue], requires_storing: bool) -> None:

--- a/logprep/ng/processor/generic_resolver/processor.py
+++ b/logprep/ng/processor/generic_resolver/processor.py
@@ -208,10 +208,10 @@ class GenericResolver(FieldManager):
         self._cache_metrics_skip_count = 0
 
         cache_info = self._get_lru_cached_value_from_list.cache_info()
-        self.metrics.new_results += cache_info.misses
-        self.metrics.cached_results += cache_info.hits
-        self.metrics.num_cache_entries += cache_info.currsize
-        self.metrics.cache_load += cache_info.currsize / self.max_cache_entries
+        self.metrics.new_results.set(cache_info.misses)
+        self.metrics.cached_results.set(cache_info.hits)
+        self.metrics.num_cache_entries.set(cache_info.currsize)
+        self.metrics.cache_load.set(cache_info.currsize / self.max_cache_entries)
 
     async def setup(self) -> None:
         await super().setup()

--- a/logprep/ng/processor/pseudonymizer/processor.py
+++ b/logprep/ng/processor/pseudonymizer/processor.py
@@ -326,7 +326,7 @@ class Pseudonymizer(FieldManager):
                 pseudonymized_query_parts, safe="<pseudonym:>", doseq=True
             )
             url_string = url_string.replace(parsed_url.query, pseudonymized_query)
-        self.metrics.pseudonymized_urls += 1
+        self.metrics.pseudonymized_urls.inc(1)
         return url_string
 
     def _wrap_hash(self, hash_string: str) -> str:
@@ -339,9 +339,9 @@ class Pseudonymizer(FieldManager):
             if is_lru_cached(f)
         ]
 
-        self.metrics.new_results += sum(c.misses for c in caches)
-        self.metrics.cached_results += sum(c.hits for c in caches)
-        self.metrics.num_cache_entries += sum(c.currsize for c in caches)
-        self.metrics.cache_load += (sum(c.currsize for c in caches)) / (
-            sum(typing.cast(int, c.maxsize) for c in caches)
+        self.metrics.new_results.set(sum(c.misses for c in caches))
+        self.metrics.cached_results.set(sum(c.hits for c in caches))
+        self.metrics.num_cache_entries.set(sum(c.currsize for c in caches))
+        self.metrics.cache_load.set(
+            (sum(c.currsize for c in caches)) / (sum(typing.cast(int, c.maxsize) for c in caches))
         )

--- a/logprep/ng/util/configuration.py
+++ b/logprep/ng/util/configuration.py
@@ -916,7 +916,7 @@ class Configuration:
             self._set_attributes_from_configs()
             self._set_version_info_metric()
             self.pipeline = new_config.pipeline
-            self._metrics.number_of_config_refreshes += 1
+            self._metrics.number_of_config_refreshes.inc(1)
             logger.info("Successfully reloaded configuration")
             if self._config_failure:
                 logger.info("Config refresh recovered from failing source")
@@ -926,7 +926,7 @@ class Configuration:
         except ConfigGetterException as error:
             self._config_failure = True
             logger.warning("Failed to load configuration: %s", error)
-            self._metrics.number_of_config_refresh_failures += 1
+            self._metrics.number_of_config_refresh_failures.inc(1)
             if self.config_refresh_interval is not None:
                 self._set_config_refresh_interval(int(self.config_refresh_interval / 4))
         except InvalidConfigurationErrors as error:
@@ -934,14 +934,14 @@ class Configuration:
             errors = [*errors, *error.errors]
         if errors:
             logger.error("Failed to reload configuration: %s", errors)
-            self._metrics.number_of_config_refresh_failures += 1
+            self._metrics.number_of_config_refresh_failures.inc(1)
 
     def _set_config_refresh_interval(self, config_refresh_interval: int | None) -> None:
         if config_refresh_interval is None:
             return
         config_refresh_interval = max(config_refresh_interval, MIN_CONFIG_REFRESH_INTERVAL)
         self.config_refresh_interval = config_refresh_interval
-        self._metrics.config_refresh_interval += config_refresh_interval
+        self._metrics.config_refresh_interval.set(config_refresh_interval)
 
     def _set_attributes_from_configs(self) -> None:
         for attribute in filter(lambda x: x.repr, fields(self.__class__)):

--- a/logprep/processor/amides/processor.py
+++ b/logprep/processor/amides/processor.py
@@ -233,7 +233,7 @@ class Amides(FieldManager):
         if self._handle_missing_fields(event, rule, rule.source_fields, [cmdline]):
             return
 
-        self.metrics.total_cmdlines += 1
+        self.metrics.total_cmdlines.inc(1)
 
         normalized = self._normalizer.normalize(cmdline)
         if not normalized:
@@ -265,7 +265,7 @@ class Amides(FieldManager):
 
     def _update_cache_metrics(self):
         cache_info = self._evaluate_cmdline_cached.cache_info()
-        self.metrics.new_results += cache_info.misses
-        self.metrics.cached_results += cache_info.hits
-        self.metrics.num_cache_entries += cache_info.currsize
-        self.metrics.cache_load += cache_info.currsize / cache_info.maxsize
+        self.metrics.new_results.set(cache_info.misses)
+        self.metrics.cached_results.set(cache_info.hits)
+        self.metrics.num_cache_entries.set(cache_info.currsize)
+        self.metrics.cache_load.set(cache_info.currsize / cache_info.maxsize)

--- a/logprep/processor/base/exceptions.py
+++ b/logprep/processor/base/exceptions.py
@@ -53,7 +53,7 @@ class ProcessingError(LogprepException):
     """Base class for exceptions related to processing events."""
 
     def __init__(self, message: str, rule: "Rule"):
-        rule.metrics.number_of_errors += 1
+        rule.metrics.number_of_errors.inc(1)
         super().__init__(f"{self.__class__.__name__}: {message}")
 
 
@@ -75,7 +75,7 @@ class ProcessingWarning(Warning):
     ):
         self.tags = tags if tags else []
         if rule:
-            rule.metrics.number_of_warnings += 1
+            rule.metrics.number_of_warnings.inc(1)
             message += f", {rule.id=}, {rule.description=}"
         message += f", {event=}"
         super().__init__(f"{self.__class__.__name__}: {message}")

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -203,7 +203,7 @@ class DomainResolver(Processor):
             domain = url.path
         if not domain:
             return
-        self.metrics.total_urls += 1
+        self.metrics.total_urls.inc(1)
         if self.config.cache_enabled:
             self._resolve_with_cache(domain, event, rule)
         else:
@@ -219,10 +219,10 @@ class DomainResolver(Processor):
             resolved_ip, status = self._resolve_ip(domain)
             if status in (ResolveStatus.SUCCESS, ResolveStatus.UNKNOWN, ResolveStatus.TIMEOUT):
                 self._domain_ip_map.update({hash_string: resolved_ip})
-            self.metrics.resolved_new += 1
+            self.metrics.resolved_new.inc(1)
         else:
             resolved_ip = self._domain_ip_map.get(hash_string)
-            self.metrics.resolved_cached += 1
+            self.metrics.resolved_cached.inc(1)
         self._add_resolve_infos_to_event(event, rule, resolved_ip)
 
         if self.config.debug_cache:
@@ -244,13 +244,13 @@ class DomainResolver(Processor):
             resolved_ip = result.get(timeout=self.config.timeout)
             return resolved_ip, ResolveStatus.SUCCESS
         except ValueError:  # Makes no connection so does not need to be cached
-            self.metrics.invalid_domains += 1
+            self.metrics.invalid_domains.inc(1)
             return None, ResolveStatus.INVALID
         except context.TimeoutError:
-            self.metrics.timeouts += 1
+            self.metrics.timeouts.inc(1)
             return None, ResolveStatus.TIMEOUT
         except OSError:  # Won't be timeout if default timeout is None
-            self.metrics.unknown_domains += 1
+            self.metrics.unknown_domains.inc(1)
             return None, ResolveStatus.UNKNOWN
 
     def _store_debug_infos(self, event: dict[str, Any], requires_storing: bool) -> None:

--- a/logprep/processor/generic_resolver/processor.py
+++ b/logprep/processor/generic_resolver/processor.py
@@ -217,10 +217,10 @@ class GenericResolver(FieldManager):
         self._cache_metrics_skip_count = 0
 
         cache_info = self._get_lru_cached_value_from_list.cache_info()
-        self.metrics.new_results += cache_info.misses
-        self.metrics.cached_results += cache_info.hits
-        self.metrics.num_cache_entries += cache_info.currsize
-        self.metrics.cache_load += cache_info.currsize / self.max_cache_entries
+        self.metrics.new_results.set(cache_info.misses)
+        self.metrics.cached_results.set(cache_info.hits)
+        self.metrics.num_cache_entries.set(cache_info.currsize)
+        self.metrics.cache_load.set(cache_info.currsize / self.max_cache_entries)
 
     def setup(self) -> None:
         super().setup()

--- a/logprep/processor/pseudonymizer/processor.py
+++ b/logprep/processor/pseudonymizer/processor.py
@@ -361,7 +361,7 @@ class Pseudonymizer(FieldManager):
                 pseudonymized_query_parts, safe="<pseudonym:>", doseq=True
             )
             url_string = url_string.replace(parsed_url.query, pseudonymized_query)
-        self.metrics.pseudonymized_urls += 1
+        self.metrics.pseudonymized_urls.inc(1)
         return url_string
 
     def _wrap_hash(self, hash_string: str) -> str:
@@ -374,9 +374,9 @@ class Pseudonymizer(FieldManager):
             if is_lru_cached(f)
         ]
 
-        self.metrics.new_results += sum(c.misses for c in caches)
-        self.metrics.cached_results += sum(c.hits for c in caches)
-        self.metrics.num_cache_entries += sum(c.currsize for c in caches)
-        self.metrics.cache_load += (sum(c.currsize for c in caches)) / (
-            sum(typing.cast(int, c.maxsize) for c in caches)
+        self.metrics.new_results.set(sum(c.misses for c in caches))
+        self.metrics.cached_results.set(sum(c.hits for c in caches))
+        self.metrics.num_cache_entries.set(sum(c.currsize for c in caches))
+        self.metrics.cache_load.set(
+            (sum(c.currsize for c in caches)) / (sum(typing.cast(int, c.maxsize) for c in caches))
         )

--- a/logprep/runner.py
+++ b/logprep/runner.py
@@ -129,7 +129,7 @@ class Runner:
                 self._logger.error("Restart count exceeded. Exiting.")
                 sys.exit(self.exit_code)
             if self._manager.error_queue is not None:
-                self.metrics.number_of_events_in_error_queue += self._manager.error_queue.qsize()
+                self.metrics.number_of_events_in_error_queue.set(self._manager.error_queue.qsize())
             self._manager.restart_failed_pipeline()
 
     def stop(self) -> None:

--- a/logprep/util/configuration.py
+++ b/logprep/util/configuration.py
@@ -865,7 +865,7 @@ class Configuration:
             self._set_attributes_from_configs()
             self._set_version_info_metric()
             self.pipeline = new_config.pipeline
-            self._metrics.number_of_config_refreshes += 1
+            self._metrics.number_of_config_refreshes.inc(1)
             logger.info("Successfully reloaded configuration")
             if self._config_failure:
                 logger.info("Config refresh recovered from failing source")
@@ -875,7 +875,7 @@ class Configuration:
         except ConfigGetterException as error:
             self._config_failure = True
             logger.warning("Failed to load configuration: %s", error)
-            self._metrics.number_of_config_refresh_failures += 1
+            self._metrics.number_of_config_refresh_failures.inc(1)
             if self.config_refresh_interval is not None:
                 self._set_config_refresh_interval(int(self.config_refresh_interval / 4))
         except InvalidConfigurationErrors as error:
@@ -883,7 +883,7 @@ class Configuration:
             errors = [*errors, *error.errors]
         if errors:
             logger.error("Failed to reload configuration: %s", errors)
-            self._metrics.number_of_config_refresh_failures += 1
+            self._metrics.number_of_config_refresh_failures.inc(1)
 
     def _set_config_refresh_interval(self, config_refresh_interval: int | None) -> None:
         if config_refresh_interval is None:
@@ -891,7 +891,7 @@ class Configuration:
         config_refresh_interval = max(config_refresh_interval, MIN_CONFIG_REFRESH_INTERVAL)
         self.config_refresh_interval = config_refresh_interval
         self.schedule_config_refresh()
-        self._metrics.config_refresh_interval += config_refresh_interval
+        self._metrics.config_refresh_interval.set(config_refresh_interval)
 
     def schedule_config_refresh(self) -> None:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import functools
+import inspect
 import json
 from collections.abc import Generator, Sequence
 from multiprocessing import active_children, set_start_method
@@ -83,29 +84,62 @@ def cleanup_child_processes():
         child.join(timeout=2)
 
 
-@contextlib.contextmanager
-def mock_env(env_dict):
+class _MockEnv(contextlib.ContextDecorator, contextlib.AsyncContextDecorator):
+    """Context manager and decorator returned by :code:`mock_env`."""
+
+    def __init__(self, env_dict):
+        self._env_dict = env_dict
+        self._original = None
+        self._environ_patch = None
+
+    def _recreate_cm(self):
+        return type(self)(self._env_dict)
+
+    def __enter__(self):
+        self._original = dict(_ENV_SNAPSHOT)
+        _ENV_SNAPSHOT.clear()
+        _ENV_SNAPSHOT.update(self._env_dict)
+        self._environ_patch = mock.patch("os.environ", self._env_dict)
+        self._environ_patch.start()
+        return _ENV_SNAPSHOT
+
+    def __exit__(self, *exc_info):
+        self._environ_patch.stop()
+        _ENV_SNAPSHOT.clear()
+        _ENV_SNAPSHOT.update(self._original)
+        return False
+
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, *exc_info):
+        return self.__exit__(*exc_info)
+
+    def __call__(self, func):
+        if inspect.iscoroutinefunction(func):
+            return contextlib.AsyncContextDecorator.__call__(self, func)
+        return contextlib.ContextDecorator.__call__(self, func)
+
+
+def mock_env(env_dict: dict) -> _MockEnv:
     """
     Mock helper to update the env snapshot.
+    Supports sync / async and decorator / context manager use cases.
 
     Usage:
         @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
         def test_something():
             ...
 
+        @mock_env({"PYTEST_TEST_TOKEN": "mytoken"})
+        async def test_something_async():
+            ...
+
         def test_something_else():
             with mock_env({"PYTEST_TEST_TOKEN": "mytoken"}):
+                ...
     """
-
-    original = dict(_ENV_SNAPSHOT)
-    try:
-        _ENV_SNAPSHOT.clear()
-        _ENV_SNAPSHOT.update(env_dict)
-        with mock.patch("os.environ", env_dict):
-            yield _ENV_SNAPSHOT
-    finally:
-        _ENV_SNAPSHOT.clear()
-        _ENV_SNAPSHOT.update(original)
+    return _MockEnv(env_dict)
 
 
 @pytest.fixture

--- a/tests/unit/component/base.py
+++ b/tests/unit/component/base.py
@@ -11,7 +11,6 @@ import pytest
 import schedule
 from attrs import asdict
 from attrs.exceptions import FrozenInstanceError
-from prometheus_client import Counter, Gauge, Histogram
 
 from logprep.abc.component import Component
 from logprep.factory import Factory
@@ -115,9 +114,7 @@ class BaseComponentTestCase(ABC):
             )
             metric_name = metric_name.replace("logprep_", "")
             metric_attribute = getattr(self.object.metrics, metric_name)
-            assert metric_attribute.tracker is not None
-            possibile_tracker_types = (Counter, Gauge, Histogram)
-            assert isinstance(metric_attribute.tracker, possibile_tracker_types)
+            assert metric_attribute.initialized
 
     def test_all_metric_attributes_are_tested(self):
         if self.object.__class__.Metrics is Component.Metrics:

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -662,7 +662,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
         # asserts entering context manager in metrics.metrics.Metric.measure_time
-        mock_metric.assert_has_calls([mock.call.tracker.labels().time().__enter__()])
+        mock_metric.assert_has_calls([mock.call.time().__enter__()])
 
     def test_add_full_event_to_target_field_without_clear(self):
         preprocessing_config = {

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -662,7 +662,7 @@ class BaseInputTestCase(BaseConnectorTestCase):
         self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
         # asserts entering context manager in metrics.metrics.Metric.measure_time
-        mock_metric.assert_has_calls([mock.call.time().__enter__()])
+        mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     def test_add_full_event_to_target_field_without_clear(self):
         preprocessing_config = {

--- a/tests/unit/connector/base.py
+++ b/tests/unit/connector/base.py
@@ -320,16 +320,14 @@ class BaseInputTestCase(BaseConnectorTestCase):
         assert result is None
 
     def test_connector_metrics_counts_processed_events(self):
-        self.object.metrics.number_of_processed_events = 0
         self.object._get_event = mock.MagicMock(return_value=({"message": "test"}, None))
         self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     def test_connector_metrics_does_not_count_if_no_event_was_retrieved(self):
-        self.object.metrics.number_of_processed_events = 0
         self.object._get_event = mock.MagicMock(return_value=(None, None))
         self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 0
+        assert self.object.metrics.number_of_processed_events.value == 0
 
     def test_get_next_adds_timestamp_if_configured(self):
         preprocessing_config = {
@@ -642,17 +640,15 @@ class BaseInputTestCase(BaseConnectorTestCase):
         }
 
     def test_get_next_counts_number_of_processed_events(self):
-        self.object.metrics.number_of_processed_events = 0
         return_value = ({"message": "test message"}, b'{"message": "test message"}')
         self.object._get_event = mock.MagicMock(return_value=return_value)
         self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     def test_get_next_does_not_count_number_of_processed_events_if_event_is_none(self):
-        self.object.metrics.number_of_processed_events = 0
         self.object._get_event = mock.MagicMock(return_value=(None, None))
         self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 0
+        assert self.object.metrics.number_of_processed_events.value == 0
 
     def test_get_next_has_time_measurement(self):
         mock_metric = mock.MagicMock()
@@ -661,7 +657,6 @@ class BaseInputTestCase(BaseConnectorTestCase):
         self.object._get_event = mock.MagicMock(return_value=return_value)
         self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
-        # asserts entering context manager in metrics.metrics.Metric.measure_time
         mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     def test_add_full_event_to_target_field_without_clear(self):
@@ -691,6 +686,5 @@ class BaseOutputTestCase(BaseConnectorTestCase):
         assert isinstance(self.object, Output)
 
     def test_store_counts_processed_events(self):
-        self.object.metrics.number_of_processed_events = 0
         self.object.store({"message": "my event message"})
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -79,13 +79,12 @@ class TestConfluentKafkaInput(BaseInputTestCase):
             _ = Factory.create({"test connector": kafka_config})
 
     def test_error_callback_logs_error(self):
-        self.object.metrics.number_of_errors = 0
         with mock.patch("logging.Logger.error") as mock_error:
             test_error = Exception("test error")
             self.object._error_callback(test_error)
             mock_error.assert_called()
             mock_error.assert_called_with("%s: %s", self.object.description, test_error)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     def test_stats_callback_sets_metric_objetc_attributes(self):
         librdkafka_metrics = tuple(
@@ -103,10 +102,9 @@ class TestConfluentKafkaInput(BaseInputTestCase):
             assert getattr(self.object.metrics, metric) == metric_value, metric
 
     def test_stats_set_age_metric_explicitly(self):
-        self.object.metrics.librdkafka_age = 0
         json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         self.object._stats_callback(json_string)
-        assert self.object.metrics.librdkafka_age == 1337
+        assert self.object.metrics.librdkafka_age.value == 1337
 
     def test_kafka_config_is_immutable(self):
         self.object.setup()
@@ -297,9 +295,8 @@ class TestConfluentKafkaInput(BaseInputTestCase):
             assert self.object._commit_failures == 1
 
     def test_commit_callback_counts_commit_success(self):
-        self.object.metrics.commit_success = 0
         self.object._commit_callback(None, [mock.MagicMock()])
-        assert self.object.metrics.commit_success == 1
+        assert self.object.metrics.commit_success.value == 1
 
     def test_commit_callback_sets_committed_offsets(self):
         mock_add = mock.MagicMock()
@@ -404,12 +401,11 @@ class TestConfluentKafkaInput(BaseInputTestCase):
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_lost_callback_counts_warnings_and_logs(self, mock_consumer):
-        self.object.metrics.number_of_warnings = 0
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
             self.object._lost_callback(mock_consumer, mock_partitions)
         mock_warning.assert_called()
-        assert self.object.metrics.number_of_warnings == 1
+        assert self.object.metrics.number_of_warnings.value == 1
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_commit_callback_sets_offset_to_0_for_special_offsets(self, _):
@@ -438,13 +434,12 @@ class TestConfluentKafkaInput(BaseInputTestCase):
         self.object.metrics.current_offsets.add_with_labels.assert_called_with(0, expected_labels)
 
     def test_revoke_callback_logs_warning_and_counts(self):
-        self.object.metrics.number_of_warnings = 0
         self.object.output_connector = mock.MagicMock()
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
             self.object._revoke_callback(None, mock_partitions)
         mock_warning.assert_called()
-        assert self.object.metrics.number_of_warnings == 1
+        assert self.object.metrics.number_of_warnings.value == 1
 
     def test_revoke_callback_calls_batch_finished_callback(self):
         self.object.output_connector = mock.MagicMock()
@@ -496,13 +491,12 @@ class TestConfluentKafkaInput(BaseInputTestCase):
 
     def test_health_counts_metrics_on_kafka_exception(self):
         kafka_input = Factory.create({"kafka_input": self.CONFIG})
-        kafka_input.metrics.number_of_errors = 0
 
         with mock.patch.object(kafka_input, "_consumer") as mock_consumer:
             mock_consumer.list_topics.side_effect = KafkaException("test error")
 
             assert not kafka_input.health()
-            assert kafka_input.metrics.number_of_errors == 1
+            assert kafka_input.metrics.number_of_errors.value == 1
 
     @pytest.mark.parametrize(
         ["kafka_config_update", "expected_admin_client_config"],

--- a/tests/unit/connector/test_confluent_kafka_input.py
+++ b/tests/unit/connector/test_confluent_kafka_input.py
@@ -400,8 +400,7 @@ class TestConfluentKafkaInput(BaseInputTestCase):
     )
     def test_offset_metrics_not_initialized_with_default_label_values(self, metric_name):
         metric = getattr(self.object.metrics, metric_name)
-        metric_object = metric.tracker.collect()[0]
-        assert len(metric_object.samples) == 0
+        assert len(metric.collect_samples()) == 0
 
     @mock.patch("logprep.connector.confluent_kafka.input.Consumer")
     def test_lost_callback_counts_warnings_and_logs(self, mock_consumer):

--- a/tests/unit/connector/test_confluent_kafka_output.py
+++ b/tests/unit/connector/test_confluent_kafka_output.py
@@ -69,13 +69,12 @@ class TestConfluentKafkaOutput(BaseOutputTestCase):
             _ = Factory.create({"test connector": kafka_config})
 
     def test_error_callback_logs_error(self):
-        self.object.metrics.number_of_errors = 0
         with mock.patch("logging.Logger.error") as mock_error:
             test_error = Exception("test error")
             self.object._error_callback(test_error)
             mock_error.assert_called()
             mock_error.assert_called_with("%s: %s", self.object.description, test_error)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     def test_stats_callback_sets_metric_object_attributes(self):
         librdkafka_metrics = tuple(
@@ -93,10 +92,9 @@ class TestConfluentKafkaOutput(BaseOutputTestCase):
             assert getattr(self.object.metrics, metric) == metric_value, metric
 
     def test_stats_set_age_metric_explicitly(self):
-        self.object.metrics.librdkafka_age = 0
         json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         self.object._stats_callback(json_string)
-        assert self.object.metrics.librdkafka_age == 1337
+        assert self.object.metrics.librdkafka_age.value == 1337
 
     def test_kafka_config_is_immutable(self):
         self.object.setup()
@@ -156,9 +154,8 @@ class TestConfluentKafkaOutput(BaseOutputTestCase):
 
     @mock.patch("logprep.connector.confluent_kafka.output.Producer")
     def test_store_counts_processed_events(self, _):  # pylint: disable=arguments-differ
-        self.object.metrics.number_of_processed_events = 0
         self.object.store({"message": "my event message"})
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     def test_setup_raises_fatal_output_error_on_invalid_config(self):
         kafka_config = {"myconfig": "the config", "bootstrap.servers": "localhost:9092"}
@@ -202,20 +199,17 @@ class TestConfluentKafkaOutput(BaseOutputTestCase):
         mock_error.assert_called()
 
     def test_health_counts_metrics_on_kafka_exception(self):
-        self.object.metrics.number_of_errors = 0
         self.object._admin = mock.MagicMock()
         self.object._admin.list_topics.side_effect = KafkaException("test error")
         assert not self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     def test_shutdown_logs_and_counts_error_if_queue_not_fully_flushed(self):
-        self.object.metrics.number_of_errors = 0
         self.object._producer = mock.MagicMock()
         self.object._producer.flush.return_value = 1
         with mock.patch("logging.Logger.error") as mock_error:
             self.object.shut_down()
         mock_error.assert_called()
-        self.object.metrics.number_of_errors = 1
 
     def test_health_returns_bool(self):
         with mock.patch.object(self.object, "_admin"):

--- a/tests/unit/connector/test_http_input.py
+++ b/tests/unit/connector/test_http_input.py
@@ -644,20 +644,18 @@ class TestHttpConnector(BaseInputTestCase):
         assert connector.target.startswith("http://")
 
     def test_get_event_sets_message_backlog_size_metric(self):
-        self.object.metrics.message_backlog_size = 0
         random_number = random.randint(1, 100)
         for number in range(random_number):
             self.object.messages.put({"message": f"my message{number}"})
         self.object.get_next(0.001)
-        assert self.object.metrics.message_backlog_size == random_number
+        assert self.object.metrics.message_backlog_size.value == random_number
 
     def test_enpoints_count_requests(self):
-        self.object.metrics.number_of_http_requests = 0
         self.object.setup()
         random_number = random.randint(1, 100)
         for number in range(random_number):
             self.client.post("/json", json={"message": f"my message{number}"})
-        assert self.object.metrics.number_of_http_requests == random_number
+        assert self.object.metrics.number_of_http_requests.value == random_number
 
     @pytest.mark.parametrize("endpoint", ["json", "plaintext", "jsonl"])
     def test_endpoint_handles_gzip_compression(self, endpoint):
@@ -723,11 +721,10 @@ class TestHttpConnector(BaseInputTestCase):
 
     @responses.activate
     def test_health_counts_errors(self):
-        self.object.metrics.number_of_errors = 0
         endpoint = self.object.health_endpoints[0]
         responses.get(f"http://127.0.0.1:9000{endpoint}", status=500)  # bad
         assert not self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     def test_health_endpoints_are_shortened(self):
         config = deepcopy(self.CONFIG)

--- a/tests/unit/connector/test_http_output.py
+++ b/tests/unit/connector/test_http_output.py
@@ -33,25 +33,21 @@ class TestOutput(BaseOutputTestCase):
 
     @responses.activate
     def test_one_repeat(self):
-        self.object.metrics.number_of_processed_events = 0
         responses.add(responses.POST, f"{TARGET_URL}/123", status=200)
         events = [{"event1_key": "event1_value"}, {"event2_key": "event2_value"}]
         batch = ("/123", events)
         self.object.store(batch)
-        assert self.object.metrics.number_of_processed_events == 2
+        assert self.object.metrics.number_of_processed_events.value == 2
 
     @responses.activate
     def test_404_status_code(self):
-        self.object.metrics.number_of_failed_events = 0
-        self.object.metrics.number_of_processed_events = 0
-        self.object.metrics.number_of_http_requests = 0
         responses.add(responses.POST, f"{TARGET_URL}/123", status=404)
         events = '{"event1_key": "event1_value", "event2_key": "event2_value"}'
         batch = f"/123,{events}"
         self.object.store(batch)
-        assert self.object.metrics.number_of_failed_events == 1
-        assert self.object.metrics.number_of_processed_events == 0
-        assert self.object.metrics.number_of_http_requests == 1
+        assert self.object.metrics.number_of_failed_events.value == 1
+        assert self.object.metrics.number_of_processed_events.value == 0
+        assert self.object.metrics.number_of_http_requests.value == 1
 
     @pytest.mark.parametrize(
         "testcase, input_data, number_of_expected_requests, number_of_expected_events",
@@ -82,15 +78,12 @@ class TestOutput(BaseOutputTestCase):
         else:
             target_url = TARGET_URL
         responses.add(responses.POST, f"{target_url}", status=200)
-        self.object.metrics.number_of_processed_events = 0
-        self.object.metrics.number_of_http_requests = 0
-        self.object.metrics.number_of_failed_events = 0
         self.object.store(input_data)
         assert (
-            self.object.metrics.number_of_failed_events == 0
+            self.object.metrics.number_of_failed_events.value == 0
         ), f"no failed events for input {testcase}"
-        assert self.object.metrics.number_of_processed_events == number_of_expected_events
-        assert self.object.metrics.number_of_http_requests == number_of_expected_requests
+        assert self.object.metrics.number_of_processed_events.value == number_of_expected_events
+        assert self.object.metrics.number_of_http_requests.value == number_of_expected_requests
 
     @pytest.mark.parametrize(
         "testcase, input_data",
@@ -103,9 +96,8 @@ class TestOutput(BaseOutputTestCase):
         ],
     )
     def test_send_not_supported_input_data(self, testcase, input_data):
-        self.object.metrics.number_of_failed_events = 0
         self.object.store_custom(123, input_data)
-        assert self.object.metrics.number_of_failed_events == 1, testcase
+        assert self.object.metrics.number_of_failed_events.value == 1, testcase
 
     @responses.activate
     def test_store_counts_http_status_codes(self):
@@ -142,9 +134,8 @@ class TestOutput(BaseOutputTestCase):
     @responses.activate
     def test_store_counts_processed_events(self):
         responses.add(responses.POST, f"{TARGET_URL}/")
-        self.object.metrics.number_of_processed_events = 0
         self.object.store("," + '"message": "my event message"')
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     @pytest.mark.skip(reason="not implemented")
     def test_setup_calls_wait_for_health(self):

--- a/tests/unit/connector/test_jsonl_output.py
+++ b/tests/unit/connector/test_jsonl_output.py
@@ -80,9 +80,8 @@ class TestJsonlOutputOutput(BaseOutputTestCase):
 
     @mock.patch("builtins.open")
     def test_store_counts_processed_events(self, _):  # pylint: disable=arguments-differ
-        self.object.metrics.number_of_processed_events = 0
         self.object.store({"message": "my event message"})
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     @mock.patch("builtins.open")
     def test_store_calls_batch_finished_callback_without_errors(

--- a/tests/unit/connector/test_opensearch_output.py
+++ b/tests/unit/connector/test_opensearch_output.py
@@ -107,11 +107,10 @@ class TestOpenSearchOutput(BaseOutputTestCase):
             mock_error.assert_called()
 
     def test_health_counts_metrics_on_failure(self):
-        self.object.metrics.number_of_errors = 0
         self.object._search_context = mock.MagicMock()
         self.object._search_context.cluster.health.side_effect = SearchException
         assert not self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     def test_health_returns_false_on_cluster_status_not_green(self):
         self.object._search_context = mock.MagicMock()

--- a/tests/unit/exceptions/base.py
+++ b/tests/unit/exceptions/base.py
@@ -29,7 +29,6 @@ class ExceptionBaseTest:
             raise self.exception(*self.exception_args)
 
     def test_metrics_counts(self):
-        setattr(self.object.metrics, self.counted_metric_name, 0)
         with pytest.raises(self.exception):
             raise self.exception(*self.exception_args)
-        assert getattr(self.object.metrics, self.counted_metric_name) == 1
+        assert getattr(self.object.metrics, self.counted_metric_name).value == 1

--- a/tests/unit/framework/test_pipeline.py
+++ b/tests/unit/framework/test_pipeline.py
@@ -222,7 +222,6 @@ class TestPipeline(ConfigurationForTests):
             raise InputWarning(self.pipeline._input, "i warn you")
 
         self.pipeline._input.metrics = mock.MagicMock()
-        self.pipeline._input.metrics.number_of_warnings = 0
         self.pipeline._input.get_next.return_value = {"order": 1}
         self.pipeline.process_pipeline()
         self.pipeline._input.get_next.side_effect = raise_warning_error
@@ -238,7 +237,6 @@ class TestPipeline(ConfigurationForTests):
         self.pipeline._setup()
         self.pipeline._input.get_next.return_value = {"order": 1}
         self.pipeline._output["dummy"].metrics = mock.MagicMock()
-        self.pipeline._output["dummy"].metrics.number_of_warnings = 0
         self.pipeline.process_pipeline()
         self.pipeline._output["dummy"].store.side_effect = OutputWarning(
             self.pipeline._output["dummy"], ""
@@ -334,7 +332,6 @@ class TestPipeline(ConfigurationForTests):
             raise raised_error
 
         self.pipeline._input.metrics = mock.MagicMock()
-        self.pipeline._input.metrics.number_of_errors = 0
         self.pipeline._input.get_next.return_value = input_event
         self.pipeline._input.get_next.side_effect = raise_critical
         self.pipeline.enqueue_error = mock.MagicMock()
@@ -368,14 +365,13 @@ class TestPipeline(ConfigurationForTests):
 
         input_event = {"test": "message"}
         dummy_output.store = raise_critical
-        dummy_output.metrics.number_of_errors = 0
         self.pipeline._setup()
         self.pipeline._output["dummy"] = dummy_output
         self.pipeline._input.get_next.return_value = input_event
         self.pipeline.enqueue_error = mock.MagicMock()
         self.pipeline.process_pipeline()
         self.pipeline.enqueue_error.assert_called()
-        assert dummy_output.metrics.number_of_errors == 1, "counts error metric"
+        assert dummy_output.metrics.number_of_errors.value == 1, "counts error metric"
         mock_log_error.assert_called_with(
             str(CriticalOutputError(dummy_output, "mock output error", input_event))
         )
@@ -748,26 +744,23 @@ class TestPipeline(ConfigurationForTests):
 
     def test_enqueue_error_counts_failed_event_for_critical_output_with_single_event(self, _):
         self.pipeline._setup()
-        self.pipeline.metrics.number_of_failed_events = 0
         error = CriticalOutputError(self.pipeline._output["dummy"], "error", {"some": "event"})
         self.pipeline.enqueue_error(error)
-        assert self.pipeline.metrics.number_of_failed_events == 1
+        assert self.pipeline.metrics.number_of_failed_events.value == 1
 
     def test_enqueue_error_counts_failed_event_for_multi_event_output_error(self, _):
         self.pipeline._setup()
-        self.pipeline.metrics.number_of_failed_events = 0
         error = CriticalOutputError(
             self.pipeline._output["dummy"], "error", [{"some": "event"}, {"some": "other"}]
         )
         self.pipeline.enqueue_error(error)
-        assert self.pipeline.metrics.number_of_failed_events == 2
+        assert self.pipeline.metrics.number_of_failed_events.value == 2
 
     def test_enqueue_error_counts_failed_event_for_pipeline_result(self, mock_create):
-        self.pipeline.metrics.number_of_failed_events = 0
         mock_result = mock.create_autospec(spec=PipelineResult)
         mock_result.pipeline = self.pipeline._pipeline
         self.pipeline.enqueue_error(mock_result)
-        assert self.pipeline.metrics.number_of_failed_events == 1
+        assert self.pipeline.metrics.number_of_failed_events.value == 1
 
 
 class TestPipelineWithActualInput:

--- a/tests/unit/framework/test_pipeline_manager.py
+++ b/tests/unit/framework/test_pipeline_manager.py
@@ -72,10 +72,10 @@ class TestPipelineManager:
             assert self.manager._pipelines == current_pipelines
 
     def test_decrease_to_count_increases_number_of_pipeline_stops_metric(self):
+        before = self.manager.metrics.number_of_pipeline_stops.value
         self.manager._increase_to_count(2)
-        self.manager.metrics.number_of_pipeline_stops = 0
         self.manager._decrease_to_count(0)
-        assert self.manager.metrics.number_of_pipeline_stops == 2
+        assert self.manager.metrics.number_of_pipeline_stops.value - before == 2
 
     def test_set_count_increases_or_decreases_count_of_pipelines_as_needed(self):
         self.manager._increase_to_count(3)
@@ -148,9 +148,9 @@ class TestPipelineManager:
         failed_pipeline.is_alive = mock.MagicMock()
         failed_pipeline.is_alive.return_value = False
         self.manager._pipelines = [failed_pipeline]
-        self.manager.metrics.number_of_failed_pipelines = 0
+        before = self.manager.metrics.number_of_failed_pipelines.value
         self.manager.restart_failed_pipeline()
-        assert self.manager.metrics.number_of_failed_pipelines == 1
+        assert self.manager.metrics.number_of_failed_pipelines.value - before == 1
 
     def test_stop_calls_prometheus_cleanup_method(self, tmpdir, config_path):
         with mock_env({"PROMETHEUS_MULTIPROC_DIR": tmpdir}):
@@ -171,15 +171,15 @@ class TestPipelineManager:
         assert isinstance(manager.prometheus_exporter, PrometheusExporter)
 
     def test_set_count_increases_number_of_pipeline_starts_metric(self):
-        self.manager.metrics.number_of_pipeline_starts = 0
+        before = self.manager.metrics.number_of_pipeline_starts.value
         self.manager.set_count(2)
-        assert self.manager.metrics.number_of_pipeline_starts == 2
+        assert self.manager.metrics.number_of_pipeline_starts.value - before == 2
 
     def test_set_count_increases_number_of_pipeline_stops_metric(self):
-        self.manager.metrics.number_of_pipeline_stops = 0
+        before = self.manager.metrics.number_of_pipeline_stops.value
         self.manager.set_count(2)
         self.manager.set_count(0)
-        assert self.manager.metrics.number_of_pipeline_stops == 2
+        assert self.manager.metrics.number_of_pipeline_stops.value - before == 2
 
     def test_restart_calls_set_count(self):
         with mock.patch.object(self.manager, "set_count") as mock_set_count:

--- a/tests/unit/generator/confluent_kafka/test_output.py
+++ b/tests/unit/generator/confluent_kafka/test_output.py
@@ -64,9 +64,8 @@ class TestConfluentKafkaGeneratorOutput(TestConfluentKafkaOutput):
 
     @mock.patch("logprep.connector.confluent_kafka.output.Producer")
     def test_store_counts_processed_events(self, _):  # pylint: disable=arguments-differ
-        self.object.metrics.number_of_processed_events = 0
         self.object.store("default,test_payload")
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     @mock.patch("logprep.connector.confluent_kafka.output.Producer")
     def test_raises_critical_output_on_any_exception(self, _):

--- a/tests/unit/generator/confluent_kafka/test_output.py
+++ b/tests/unit/generator/confluent_kafka/test_output.py
@@ -6,7 +6,6 @@
 from unittest import mock
 
 import pytest
-from prometheus_client import Counter, Gauge, Histogram
 
 from logprep.abc.output import CriticalOutputError
 from logprep.metrics.metrics import Metric
@@ -95,9 +94,7 @@ class TestConfluentKafkaGeneratorOutput(TestConfluentKafkaOutput):
             metric_name = expected_metric.replace("logprep_confluent_kafka_output_", "")
             metric_name = metric_name.replace("logprep_", "")
             metric_attribute = getattr(self.object.metrics, metric_name)
-            assert metric_attribute.tracker is not None
-            possible_tracker_types = (Counter, Gauge, Histogram)
-            assert isinstance(metric_attribute.tracker, possible_tracker_types)
+            assert metric_attribute.initialized
 
     def test_store_updates_topic(self):
         assert self.object._config.topic == "default"

--- a/tests/unit/generator/confluent_kafka/test_output.py
+++ b/tests/unit/generator/confluent_kafka/test_output.py
@@ -106,9 +106,9 @@ class TestConfluentKafkaGeneratorOutput(TestConfluentKafkaOutput):
 
     def test_store_counting_batches(self):
         self.object.store("test_topic,test_payload")
-        assert self.object.metrics.processed_batches.tracker.collect()[0].samples[0].value == 1
+        assert self.object.metrics.processed_batches.collect_samples()[0].value == 1
         self.object.store("test_topic,test_payload")
-        assert self.object.metrics.processed_batches.tracker.collect()[0].samples[0].value == 2
+        assert self.object.metrics.processed_batches.collect_samples()[0].value == 2
 
     def test_store_handles_empty_payload(self):
         with mock.patch(

--- a/tests/unit/generator/http/test_output.py
+++ b/tests/unit/generator/http/test_output.py
@@ -35,11 +35,10 @@ class TestHttpGeneratorOutput(TestOutput):
 
     @responses.activate
     def test_one_repeat(self):
-        self.object.metrics.number_of_processed_events = 0
         responses.add(responses.POST, f"{TARGET_URL}/123", status=200)
         document = "/123,{'event1_key': 'event1_value'};{'event2_key': 'event2_value'}"
         self.object.store(document)
-        assert self.object.metrics.number_of_processed_events == 2
+        assert self.object.metrics.number_of_processed_events.value == 2
 
     def test_store_calls_store_custom(self):
         self.object.store_custom = MagicMock()
@@ -72,12 +71,9 @@ class TestHttpGeneratorOutput(TestOutput):
 
         target_url = TARGET_URL
         responses.add(responses.POST, f"{target_url}{testcase}", status=200)
-        self.object.metrics.number_of_processed_events = 0
-        self.object.metrics.number_of_http_requests = 0
-        self.object.metrics.number_of_failed_events = 0
         self.object.store(testcase + "," + input_data)
         assert (
-            self.object.metrics.number_of_failed_events == 0
+            self.object.metrics.number_of_failed_events.value == 0
         ), f"no failed events for input {input_data}"
-        assert self.object.metrics.number_of_processed_events == number_of_expected_events
-        assert self.object.metrics.number_of_http_requests == number_of_expected_requests
+        assert self.object.metrics.number_of_processed_events.value == number_of_expected_events
+        assert self.object.metrics.number_of_http_requests.value == number_of_expected_requests

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -68,8 +68,8 @@ class TestMetric:
         metric1.init_tracker()
         metric2.init_tracker()
 
-        assert metric1.tracker == metric2.tracker
-        assert REGISTRY._names_to_collectors[metric1.fullname] == metric1.tracker
+        assert metric1._base_tracker == metric2._base_tracker
+        assert REGISTRY._names_to_collectors[metric1.fullname] == metric1._base_tracker
 
     def test_counter_metric_sets_labels(self):
         metric = CounterMetric(
@@ -163,7 +163,7 @@ class TestMetric:
         metric1.init_tracker()
         metric2.init_tracker()
 
-        assert metric1.tracker == metric2.tracker
+        assert metric1._base_tracker == metric2._base_tracker
         metric1 += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         result = re.findall(r'.*logprep_bla_total\{pipeline="1"\} 1\.0.*', metric_output)

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -294,7 +294,7 @@ class TestMetric(MetricTestCase):
         assert metric_type.collector_methods == covered
 
     def test_collector_methods_are_decorated_exactly_when_they_bind_lazily(self):
-        # decorated with @_collector_method <-> calls _lazy_bind_default_child() in body
+        # decorated with @_collector_method <-> calls _bind_default_child() in body
         module = ast.parse(inspect.getsource(metrics_module))
         for metric_type in METRIC_TYPES:
             class_node = next(
@@ -309,7 +309,7 @@ class TestMetric(MetricTestCase):
                     getattr(decorator, "id", None) == "_collector_method"
                     for decorator in method.decorator_list
                 )
-                binds_lazily = "_lazy_bind_default_child" in ast.dump(method)
+                binds_lazily = "_bind_default_child" in ast.dump(method)
                 assert decorated == binds_lazily, (
                     f"{metric_type.metric.__name__}.{method.name}: "
                     f"decorated={decorated} but binds_lazily={binds_lazily}"

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
 
+import asyncio
 import re
 from unittest import mock
 
@@ -25,17 +26,17 @@ class TestMetric:
     def setup_method(self):
         self.custom_registry = CollectorRegistry()
 
-    def test_init_tracker_returns_collector(self):
+    def test_init_collector_returns_collector(self):
         metric = CounterMetric(
             name="testmetric",
             description="empty description",
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
-        assert isinstance(metric.tracker, Counter)
+        metric.init_collector()
+        assert isinstance(metric._collector, Counter)
 
-    def test_init_tracker_does_not_raise_if_initialized_twice(self):
+    def test_init_collector_does_not_raise_if_initialized_twice(self):
         metric1 = CounterMetric(
             name="testmetric",
             description="empty description",
@@ -48,13 +49,13 @@ class TestMetric:
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric1.init_tracker()
-        metric2.init_tracker()
-        assert isinstance(metric1.tracker, Counter)
-        assert isinstance(metric2.tracker, Counter)
-        assert metric1.tracker == metric2.tracker
+        metric1.init_collector()
+        metric2.init_collector()
+        assert isinstance(metric1._collector, Counter)
+        assert isinstance(metric2._collector, Counter)
+        assert metric1._collector == metric2._collector
 
-    def test_init_tracker_reuses_collector_from_default_registry(self):
+    def test_init_collector_reuses_collector_from_default_registry(self):
         metric1 = CounterMetric(
             name="testmetric",
             description="empty description",
@@ -65,11 +66,11 @@ class TestMetric:
             description="empty description",
             labels={"A": "a"},
         )
-        metric1.init_tracker()
-        metric2.init_tracker()
+        metric1.init_collector()
+        metric2.init_collector()
 
-        assert metric1._base_tracker == metric2._base_tracker
-        assert REGISTRY._names_to_collectors[metric1.fullname] == metric1._base_tracker
+        assert metric1._collector == metric2._collector
+        assert REGISTRY._names_to_collectors[metric1.fullname] == metric1._collector
 
     def test_counter_metric_sets_labels(self):
         metric = CounterMetric(
@@ -78,8 +79,8 @@ class TestMetric:
             labels={"pipeline": "pipeline-1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
-        assert metric.tracker._labelnames == ("pipeline",)
+        metric.init_collector()
+        assert metric._collector._labelnames == ("pipeline",)
 
     def test_initialize_without_labels_initializes_defaults(self):
         metric = CounterMetric(
@@ -88,7 +89,7 @@ class TestMetric:
             registry=self.custom_registry,
         )
         with pytest.raises(ValueError, match="No label names were set when constructing"):
-            metric.init_tracker()
+            metric.init_collector()
 
     def test_initialize_with_empty_labels_initializes_default_labels(self):
         metric = CounterMetric(
@@ -98,7 +99,7 @@ class TestMetric:
             labels={},
         )
         with pytest.raises(ValueError, match="No label names were set when constructing"):
-            metric.init_tracker()
+            metric.init_collector()
 
     def test_counter_metric_increments_correctly(self):
         metric = CounterMetric(
@@ -107,7 +108,7 @@ class TestMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         assert 'logprep_bla_total{pipeline="1"} 1.0' in metric_output
@@ -119,13 +120,13 @@ class TestMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         assert 'logprep_bla_total{pipeline="1"} 2.0' in metric_output
 
-    def test_same_counter_counts_on_same_tracker(self):
+    def test_same_counter_counts_on_same_collector(self):
         metric1 = CounterMetric(
             name="bla",
             description="empty description",
@@ -138,16 +139,16 @@ class TestMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric1.init_tracker()
-        metric2.init_tracker()
-        assert metric1.tracker._labelnames == metric2.tracker._labelnames
+        metric1.init_collector()
+        metric2.init_collector()
+        assert metric1._collector._labelnames == metric2._collector._labelnames
         metric1 += 1
         metric2 += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         result = re.findall(r'.*logprep_bla_total\{pipeline="1"\} 2\.0.*', metric_output)
         assert len(result) == 1
 
-    def test_same_counter_with_different_label_values_counts_on_different_tracker(self):
+    def test_same_counter_with_different_label_values_counts_on_different_collector(self):
         metric1 = CounterMetric(
             name="bla",
             description="empty description",
@@ -160,10 +161,10 @@ class TestMetric:
             labels={"pipeline": "2"},
             registry=self.custom_registry,
         )
-        metric1.init_tracker()
-        metric2.init_tracker()
+        metric1.init_collector()
+        metric2.init_collector()
 
-        assert metric1._base_tracker == metric2._base_tracker
+        assert metric1._collector == metric2._collector
         metric1 += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         result = re.findall(r'.*logprep_bla_total\{pipeline="1"\} 1\.0.*', metric_output)
@@ -171,14 +172,14 @@ class TestMetric:
         result = re.findall(r'.*logprep_bla_total\{pipeline="2"\} 0\.0.*', metric_output)
         assert len(result) == 1
 
-    def test_init_tracker_raises_on_try_to_overwrite_tracker_with_different_type(self):
+    def test_init_collector_raises_on_try_to_overwrite_collector_with_different_type(self):
         metric = CounterMetric(
             name="bla",
             description="empty description",
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         with pytest.raises(ValueError, match="already exists with different type"):
             metric = HistogramMetric(
                 name="bla",
@@ -186,7 +187,261 @@ class TestMetric:
                 labels={"pipeline": "2"},
                 registry=self.custom_registry,
             )
-            metric.init_tracker()
+            metric.init_collector()
+
+    def test_initialized_is_true_only_after_init_collector(self):
+        metric = CounterMetric(
+            name="testmetric",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry,
+        )
+        assert not metric.initialized
+        metric.init_collector()
+        assert metric.initialized
+
+    @pytest.mark.parametrize(
+        "metric_class, method, argument, expected",
+        [
+            (CounterMetric, "inc", 3, 'logprep_bla_total{A="a"} 3.0'),
+            (GaugeMetric, "set", 5, 'logprep_bla{A="a"} 5.0'),
+            (GaugeMetric, "inc", 2, 'logprep_bla{A="a"} 2.0'),
+            (GaugeMetric, "dec", 2, 'logprep_bla{A="a"} -2.0'),
+            (HistogramMetric, "observe", 0.5, 'logprep_bla_count{A="a"} 1.0'),
+        ],
+    )
+    def test_collector_methods_write_to_the_default_child(
+        self, metric_class, method, argument, expected
+    ):
+        metric = metric_class(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        getattr(metric, method)(argument)
+        assert expected in generate_latest(self.custom_registry).decode("utf-8")
+
+    @pytest.mark.parametrize(
+        "metric_class, expected_methods",
+        [
+            (CounterMetric, {"inc"}),
+            (GaugeMetric, {"set", "inc", "dec"}),
+            (HistogramMetric, {"observe", "time"}),
+        ],
+    )
+    def test_collector_methods_are_bound_onto_the_instance(self, metric_class, expected_methods):
+        metric = metric_class(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry,
+        )
+        assert metric_class._collector_methods == expected_methods
+        assert not expected_methods & metric.__dict__.keys()
+        metric.init_collector()
+        assert expected_methods <= metric.__dict__.keys()
+
+    @pytest.mark.parametrize(
+        "metric_class, method, argument, expected",
+        [
+            (CounterMetric, "inc", 3, 'logprep_bla_total{A="a"} 3.0'),
+            (GaugeMetric, "set", 5, 'logprep_bla{A="a"} 5.0'),
+            (GaugeMetric, "inc", 2, 'logprep_bla{A="a"} 2.0'),
+            (GaugeMetric, "dec", 2, 'logprep_bla{A="a"} -2.0'),
+            (HistogramMetric, "observe", 0.5, 'logprep_bla_count{A="a"} 1.0'),
+        ],
+    )
+    def test_collector_methods_bind_lazily_without_label_injection(
+        self, metric_class, method, argument, expected
+    ):
+        metric = metric_class(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            inject_label_values=False,
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        assert method not in metric.__dict__
+        assert 'A="a"' not in generate_latest(self.custom_registry).decode("utf-8")
+        # the fallback on the class runs once, then replaces itself
+        getattr(metric, method)(argument)
+        assert method in metric.__dict__
+        assert expected in generate_latest(self.custom_registry).decode("utf-8")
+
+    def test_histogram_time_binds_lazily_without_label_injection(self):
+        metric = HistogramMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            inject_label_values=False,
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        assert "time" not in metric.__dict__
+        with metric.time():
+            pass
+        assert "time" in metric.__dict__
+        assert 'logprep_bla_count{A="a"} 1.0' in generate_latest(self.custom_registry).decode(
+            "utf-8"
+        )
+
+    @pytest.mark.parametrize(
+        "metric_class, expected",
+        [
+            (CounterMetric, 'logprep_bla_total{A="first"} 2.0'),
+            (GaugeMetric, 'logprep_bla{A="first"} 2.0'),
+            (HistogramMetric, 'logprep_bla_count{A="first"} 1.0'),
+        ],
+    )
+    def test_add_with_labels_writes_to_the_given_labels(self, metric_class, expected):
+        metric = metric_class(
+            name="bla",
+            description="empty description",
+            labels={"A": ""},
+            inject_label_values=False,
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        metric.add_with_labels(2, {"A": "first"})
+        assert expected in generate_latest(self.custom_registry).decode("utf-8")
+
+    @pytest.mark.parametrize(
+        "registry_is_set", [True, False], ids=["with_registry", "without_registry"]
+    )
+    def test_init_collector_reraises_if_it_cannot_recover(self, registry_is_set):
+        # the handler only recovers a collector that is already registered
+        metric = CounterMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry if registry_is_set else None,
+        )
+        metric._registry = self.custom_registry if registry_is_set else None
+        with mock.patch.object(
+            metric, "_init_collector", side_effect=ValueError("unrelated failure")
+        ):
+            with pytest.raises(ValueError, match="unrelated failure"):
+                metric.init_collector()
+        assert not metric.initialized
+
+    def test_registry_is_not_set_in_multiprocess_mode(self):
+        with mock_env({"PROMETHEUS_MULTIPROC_DIR": "/tmp"}):
+            metric = CounterMetric(name="bla", description="empty description", labels={"A": "a"})
+        assert metric._registry is None
+
+    def test_add_works_without_label_injection(self):
+        metric = CounterMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            inject_label_values=False,
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        metric += 2
+        assert 'logprep_bla_total{A="a"} 2.0' in generate_latest(self.custom_registry).decode(
+            "utf-8"
+        )
+
+    def test_collect_samples_returns_labels_and_values(self):
+        metric = CounterMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        metric += 3
+        samples = [sample for sample in metric.collect_samples() if sample.name.endswith("_total")]
+        assert [(sample.labels, sample.value) for sample in samples] == [({"A": "a"}, 3.0)]
+
+    def test_collect_samples_returns_every_labeled_child(self):
+        metric = CounterMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": ""},
+            registry=self.custom_registry,
+            inject_label_values=False,
+        )
+        metric.init_collector()
+        metric.add_with_labels(1, {"A": "first"})
+        metric.add_with_labels(2, {"A": "second"})
+        samples = [sample for sample in metric.collect_samples() if sample.name.endswith("_total")]
+        assert {sample.labels["A"]: sample.value for sample in samples} == {
+            "first": 1.0,
+            "second": 2.0,
+        }
+
+    def test_collect_samples_on_uninitialized_metric_raises(self):
+        metric = CounterMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a"},
+            registry=self.custom_registry,
+        )
+        with pytest.raises(AttributeError):
+            metric.collect_samples()
+
+    def test_child_collector_returns_initialized_child(self):
+        metric = GaugeMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a", "B": ""},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        child = metric.child_collector({"B": "b"})
+        assert child.initialized
+        assert child._collector is metric._collector
+        assert child.labels == {"A": "a", "B": "b"}
+
+    def test_child_collector_writes_to_its_own_labels(self):
+        metric = GaugeMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a", "B": ""},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        metric.child_collector({"B": "first"}).set(1)
+        metric.child_collector({"B": "second"}).set(2)
+        metric_output = generate_latest(self.custom_registry).decode("utf-8")
+        assert 'logprep_bla{A="a",B="first"} 1.0' in metric_output
+        assert 'logprep_bla{A="a",B="second"} 2.0' in metric_output
+        assert 'logprep_bla{A="a",B=""} 0.0' in metric_output
+
+    def test_child_collector_without_label_injection_registers_on_first_use(self):
+        metric = GaugeMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a", "B": ""},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        child = metric.child_collector({"B": "b"}, inject_label_values=False)
+        assert child.initialized
+        assert 'B="b"' not in generate_latest(self.custom_registry).decode("utf-8")
+        child.set(1)
+        assert 'logprep_bla{A="a",B="b"} 1.0' in generate_latest(self.custom_registry).decode(
+            "utf-8"
+        )
+
+    def test_child_collector_of_child_collector_keeps_merging_labels(self):
+        metric = GaugeMetric(
+            name="bla",
+            description="empty description",
+            labels={"A": "a", "B": "", "C": ""},
+            registry=self.custom_registry,
+        )
+        metric.init_collector()
+        grandchild = metric.child_collector({"B": "b"}).child_collector({"C": "c"})
+        grandchild.set(1)
+        assert 'logprep_bla{A="a",B="b",C="c"} 1.0' in generate_latest(self.custom_registry).decode(
+            "utf-8"
+        )
 
     def test_add_with_labels_none_value_raises_typeerror(self):
         metric = CounterMetric(
@@ -195,7 +450,7 @@ class TestMetric:
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         with pytest.raises(TypeError, match="not supported between instances of 'NoneType'"):
             metric.add_with_labels(None, {"A": "a"})
 
@@ -206,7 +461,7 @@ class TestMetric:
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         with pytest.raises(TypeError, match=" unsupported operand type(s) for |"):
             metric.add_with_labels(1, None)
 
@@ -215,15 +470,15 @@ class TestGaugeMetric:
     def setup_method(self):
         self.custom_registry = CollectorRegistry()
 
-    def test_init_tracker_returns_collector(self):
+    def test_init_collector_returns_collector(self):
         metric = GaugeMetric(
             name="testmetric",
             description="empty description",
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
-        assert isinstance(metric.tracker, Gauge)
+        metric.init_collector()
+        assert isinstance(metric._collector, Gauge)
 
     def test_gauge_metric_increments_correctly(self):
         metric = GaugeMetric(
@@ -232,7 +487,7 @@ class TestGaugeMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         assert 'logprep_bla{pipeline="1"} 1.0' in metric_output
@@ -244,7 +499,7 @@ class TestGaugeMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
@@ -255,15 +510,15 @@ class TestHistogramMetric:
     def setup_method(self):
         self.custom_registry = CollectorRegistry()
 
-    def test_init_tracker_returns_collector(self):
+    def test_init_collector_returns_collector(self):
         metric = HistogramMetric(
             name="testmetric",
             description="empty description",
             labels={"A": "a"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
-        assert isinstance(metric.tracker, Histogram)
+        metric.init_collector()
+        assert isinstance(metric._collector, Histogram)
 
     def test_gauge_metric_increments_correctly(self):
         metric = HistogramMetric(
@@ -272,7 +527,7 @@ class TestHistogramMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
         assert re.search(r'logprep_bla_sum\{pipeline="1"\} 1\.0', metric_output)
@@ -286,7 +541,7 @@ class TestHistogramMetric:
             labels={"pipeline": "1"},
             registry=self.custom_registry,
         )
-        metric.init_tracker()
+        metric.init_collector()
         metric += 1
         metric += 1
         metric_output = generate_latest(self.custom_registry).decode("utf-8")
@@ -341,11 +596,11 @@ class TestComponentMetrics:
     def test_init(self):
         assert self.metrics.test_metric_number_1 is not None
         assert isinstance(self.metrics.test_metric_number_1, CounterMetric)
-        assert self.metrics.test_metric_number_1.tracker is not None
-        assert isinstance(self.metrics.test_metric_number_1.tracker, Counter)
+        assert self.metrics.test_metric_number_1._collector is not None
+        assert isinstance(self.metrics.test_metric_number_1._collector, Counter)
 
     def test_label_values_injection(self):
-        assert self.metrics.test_metric_number_1.tracker._labelnames == (
+        assert self.metrics.test_metric_number_1._collector._labelnames == (
             "component",
             "name",
             "type",
@@ -353,13 +608,14 @@ class TestComponentMetrics:
         )
         metrics_output = generate_latest(self.metrics.custom_registry).decode("utf-8")
         assert (
-            'logprep_test_metric_number_1_total{component="test",description="test_description",name="test",type="test_type"} 0.0'
-            in metrics_output
+            "logprep_test_metric_number_1_total{"
+            'component="test",description="test_description",name="test",type="test_type"'
+            "} 0.0" in metrics_output
         )
         assert '"None"' not in metrics_output, "default labels should not be present"
 
     def test_no_label_values_injection(self):
-        assert self.metrics.test_metric_without_label_values.tracker._labelnames == (
+        assert self.metrics.test_metric_without_label_values._collector._labelnames == (
             "component",
             "name",
             "type",
@@ -497,6 +753,81 @@ class TestComponentMetrics:
             assert not re.search(
                 r"test_metric_histogram_bucket.* 2\.0", metric_output
             )  # regex is greedy
-            assert document == {}
-            # assert call on time.perf_counter to ensure that the correct decorator was accessed
+            assert not document
             mock_perf_counter.assert_called()
+
+    async def test_measure_time_measures_async_function(self):
+        @Metric.measure_time(metric_name="test_metric_histogram")
+        async def decorated_function(self, document):
+            await asyncio.sleep(0.001)
+
+        await decorated_function(self, {"test": "event"})
+
+        metric_output = generate_latest(self.metrics.custom_registry).decode("utf-8")
+        assert re.search(r"test_metric_histogram_count.* 1\.0", metric_output)
+        # a sync wrapper would only have timed how long the coroutine took to create
+        sum_sample = next(
+            sample
+            for sample in self.metrics.test_metric_histogram.collect_samples()
+            if sample.name.endswith("_sum")
+        )
+        assert sum_sample.value > 0.001
+
+    @mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"})
+    async def test_measure_time_appends_to_event_from_async_function(self):
+        @Metric.measure_time(metric_name="test_metric_histogram")
+        async def decorated_function(self, document):
+            pass
+
+        document = {"test": "event"}
+        await decorated_function(self, document)
+        assert document.get("processing_times", {}).get("test_rule") > 0
+
+    @pytest.mark.parametrize("append_to_event", ["", "1"])
+    def test_measure_time_measures_when_decorated_function_raises(self, append_to_event):
+        with mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": append_to_event}):
+
+            @Metric.measure_time(metric_name="test_metric_histogram")
+            def decorated_function(self, document):
+                raise ValueError("the decorated function failed")
+
+            document = {"test": "event"}
+            with pytest.raises(ValueError, match="the decorated function failed"):
+                decorated_function(self, document)
+
+        metric_output = generate_latest(self.metrics.custom_registry).decode("utf-8")
+        assert re.search(r"test_metric_histogram_count.* 1\.0", metric_output)
+        assert "processing_times" not in document, "there is no result to attribute a time to"
+
+    def test_measure_time_does_not_append_for_objects_that_are_neither_rule_nor_pipeline(self):
+        with mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"}):
+
+            @Metric.measure_time(metric_name="test_metric_histogram")
+            def decorated_function(self, document):
+                pass
+
+            unrelated = mock.Mock(spec=["metrics"])
+            unrelated.metrics = self.metrics
+            document = {"test": "event"}
+            decorated_function(unrelated, document)
+
+        metric_output = generate_latest(self.metrics.custom_registry).decode("utf-8")
+        assert re.search(r"test_metric_histogram_count.* 1\.0", metric_output)
+        assert "processing_times" not in document
+
+    @mock_env({"LOGPREP_APPEND_MEASUREMENT_TO_EVENT": "1"})
+    def test_measure_time_appends_pipeline_times_for_objects_without_rule_type(self):
+        @Metric.measure_time(metric_name="test_metric_histogram")
+        def decorated_function(self, document):
+            pass
+
+        class Pipelineish:  # the pipeline has no rule_type
+            metrics = self.metrics
+            _logprep_config = object()
+
+        document = {"test": "event"}
+        decorated_function(Pipelineish(), document)
+
+        processing_times = document.get("processing_times")
+        assert set(processing_times) == {"pipeline", "hostname"}
+        assert processing_times.get("pipeline") > 0

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -2,7 +2,9 @@
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
 
+import ast
 import asyncio
+import inspect
 import re
 from unittest import mock
 
@@ -16,309 +18,152 @@ from prometheus_client import (
     Histogram,
     generate_latest,
 )
+from prometheus_client.metrics import MetricWrapperBase
 
 from logprep.abc.component import Component
+from logprep.metrics import metrics as metrics_module
 from logprep.metrics.metrics import CounterMetric, GaugeMetric, HistogramMetric, Metric
 from tests.conftest import mock_env
 
 
-class TestMetric:
+@define(frozen=True, kw_only=True)
+class MetricType:
+    """Key aspects of a metric under test"""
+
+    metric: type[Metric]
+    collector: type[MetricWrapperBase]
+    value_series_suffix: str
+    collector_methods: set[str]
+
+    @property
+    def id(self) -> str:
+        return self.metric.__name__.removesuffix("Metric").lower()
+
+
+METRIC_TYPES = (
+    MetricType(
+        metric=CounterMetric,
+        collector=Counter,
+        value_series_suffix="_total",
+        collector_methods={"inc"},
+    ),
+    MetricType(
+        metric=GaugeMetric,
+        collector=Gauge,
+        value_series_suffix="",
+        collector_methods={"set", "inc", "dec"},
+    ),
+    MetricType(
+        metric=HistogramMetric,
+        collector=Histogram,
+        value_series_suffix="_sum",
+        collector_methods={"observe"},
+    ),
+)
+
+TYPE_CASES = [pytest.param(metric_type, id=metric_type.id) for metric_type in METRIC_TYPES]
+
+WRITE_CASES = [
+    pytest.param(
+        CounterMetric, "inc", 3, 'logprep_some_metric_name_total{A="a"} 3.0', id="counter_inc"
+    ),
+    pytest.param(GaugeMetric, "set", 5, 'logprep_some_metric_name{A="a"} 5.0', id="gauge_set"),
+    pytest.param(GaugeMetric, "inc", 2, 'logprep_some_metric_name{A="a"} 2.0', id="gauge_inc"),
+    pytest.param(GaugeMetric, "dec", 2, 'logprep_some_metric_name{A="a"} -2.0', id="gauge_dec"),
+    pytest.param(
+        HistogramMetric, "observe", 0.5, 'logprep_some_metric_name_count{A="a"} 1.0', id="histogram"
+    ),
+]
+
+
+ExampleMetric = CounterMetric
+"""One concrete metric class to test base class functionality; could be any of the above"""
+
+
+class MetricTestCase:
+    """Gives every test its own registry, so values do not leak."""
+
     def setup_method(self):
         self.custom_registry = CollectorRegistry()
 
-    def test_init_collector_returns_collector(self):
-        metric = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert isinstance(metric._collector, Counter)
+    def metric(self, metric_class, **kwargs):
+        kwargs.setdefault("name", "some_metric_name")
+        kwargs.setdefault("description", "empty description")
+        kwargs.setdefault("labels", {"A": "a"})
+        return metric_class(registry=self.custom_registry, **kwargs)
 
-    def test_init_collector_does_not_raise_if_initialized_twice(self):
-        metric1 = CounterMetric(
+    def exposition(self) -> str:
+        return generate_latest(self.custom_registry).decode("utf-8")
+
+    @staticmethod
+    def write(metric, method, argument):
+        getattr(metric, method)(argument)
+
+
+class TestMetric(MetricTestCase):
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_init_collector_creates_the_matching_collector(self, metric_type):
+        metric = self.metric(metric_type.metric, name="testmetric")
+        metric.init_collector()
+        assert isinstance(metric._collector, metric_type.collector)
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_init_collector_does_not_raise_if_initialized_twice(self, metric_type):
+        metric1 = self.metric(metric_type.metric, name="testmetric")
+        metric2 = self.metric(metric_type.metric, name="testmetric")
+        metric1.init_collector()
+        metric2.init_collector()
+        assert isinstance(metric1._collector, metric_type.collector)
+        assert isinstance(metric2._collector, metric_type.collector)
+        assert metric1._collector is metric2._collector
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_init_collector_reuses_collector_from_default_registry(self, metric_type):
+        metric1 = metric_type.metric(
             name="testmetric",
             description="empty description",
             labels={"A": "a"},
-            registry=self.custom_registry,
         )
-        metric2 = CounterMetric(
+        metric2 = metric_type.metric(
             name="testmetric",
             description="empty description",
             labels={"A": "a"},
-            registry=self.custom_registry,
         )
         metric1.init_collector()
         metric2.init_collector()
-        assert isinstance(metric1._collector, Counter)
-        assert isinstance(metric2._collector, Counter)
-        assert metric1._collector == metric2._collector
 
-    def test_init_collector_reuses_collector_from_default_registry(self):
-        metric1 = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-        )
-        metric2 = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-        )
-        metric1.init_collector()
-        metric2.init_collector()
+        assert metric1._collector is metric2._collector
+        assert REGISTRY._names_to_collectors[metric1.fullname] is metric1._collector
 
-        assert metric1._collector == metric2._collector
-        assert REGISTRY._names_to_collectors[metric1.fullname] == metric1._collector
-
-    def test_counter_metric_sets_labels(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "pipeline-1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert metric._collector._labelnames == ("pipeline",)
-
-    def test_initialize_without_labels_initializes_defaults(self):
-        metric = CounterMetric(
-            name="bla",
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    @pytest.mark.parametrize(
+        "labels",
+        [pytest.param(None, id="no_labels"), pytest.param({}, id="empty_labels")],
+    )
+    def test_init_collector_raises_without_label_names(self, labels, metric_type):
+        metric = metric_type.metric(
+            name="some_metric_name",
             description="empty description",
             registry=self.custom_registry,
+            **({} if labels is None else {"labels": labels}),
         )
         with pytest.raises(ValueError, match="No label names were set when constructing"):
             metric.init_collector()
-
-    def test_initialize_with_empty_labels_initializes_default_labels(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            registry=self.custom_registry,
-            labels={},
-        )
-        with pytest.raises(ValueError, match="No label names were set when constructing"):
-            metric.init_collector()
-
-    def test_counter_metric_increments_correctly(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert 'logprep_bla_total{pipeline="1"} 1.0' in metric_output
-
-    def test_counter_metric_increments_twice_adds_metric(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert 'logprep_bla_total{pipeline="1"} 2.0' in metric_output
-
-    def test_same_counter_counts_on_same_collector(self):
-        metric1 = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric2 = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric1.init_collector()
-        metric2.init_collector()
-        assert metric1._collector._labelnames == metric2._collector._labelnames
-        metric1 += 1
-        metric2 += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        result = re.findall(r'.*logprep_bla_total\{pipeline="1"\} 2\.0.*', metric_output)
-        assert len(result) == 1
-
-    def test_same_counter_with_different_label_values_counts_on_different_collector(self):
-        metric1 = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric2 = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "2"},
-            registry=self.custom_registry,
-        )
-        metric1.init_collector()
-        metric2.init_collector()
-
-        assert metric1._collector == metric2._collector
-        metric1 += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        result = re.findall(r'.*logprep_bla_total\{pipeline="1"\} 1\.0.*', metric_output)
-        assert len(result) == 1
-        result = re.findall(r'.*logprep_bla_total\{pipeline="2"\} 0\.0.*', metric_output)
-        assert len(result) == 1
 
     def test_init_collector_raises_on_try_to_overwrite_collector_with_different_type(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
+        counter = self.metric(CounterMetric, name="some_metric_name")
+        counter.init_collector()
+        histogram = self.metric(HistogramMetric, name="some_metric_name")
         with pytest.raises(ValueError, match="already exists with different type"):
-            metric = HistogramMetric(
-                name="bla",
-                description="empty description",
-                labels={"pipeline": "2"},
-                registry=self.custom_registry,
-            )
-            metric.init_collector()
-
-    def test_initialized_is_true_only_after_init_collector(self):
-        metric = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        assert not metric.initialized
-        metric.init_collector()
-        assert metric.initialized
+            histogram.init_collector()
 
     @pytest.mark.parametrize(
-        "metric_class, method, argument, expected",
-        [
-            (CounterMetric, "inc", 3, 'logprep_bla_total{A="a"} 3.0'),
-            (GaugeMetric, "set", 5, 'logprep_bla{A="a"} 5.0'),
-            (GaugeMetric, "inc", 2, 'logprep_bla{A="a"} 2.0'),
-            (GaugeMetric, "dec", 2, 'logprep_bla{A="a"} -2.0'),
-            (HistogramMetric, "observe", 0.5, 'logprep_bla_count{A="a"} 1.0'),
-        ],
-    )
-    def test_collector_methods_write_to_the_default_child(
-        self, metric_class, method, argument, expected
-    ):
-        metric = metric_class(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        getattr(metric, method)(argument)
-        assert expected in generate_latest(self.custom_registry).decode("utf-8")
-
-    @pytest.mark.parametrize(
-        "metric_class, expected_methods",
-        [
-            (CounterMetric, {"inc"}),
-            (GaugeMetric, {"set", "inc", "dec"}),
-            (HistogramMetric, {"observe", "time"}),
-        ],
-    )
-    def test_collector_methods_are_bound_onto_the_instance(self, metric_class, expected_methods):
-        metric = metric_class(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        assert metric_class._collector_methods == expected_methods
-        assert not expected_methods & metric.__dict__.keys()
-        metric.init_collector()
-        assert expected_methods <= metric.__dict__.keys()
-
-    @pytest.mark.parametrize(
-        "metric_class, method, argument, expected",
-        [
-            (CounterMetric, "inc", 3, 'logprep_bla_total{A="a"} 3.0'),
-            (GaugeMetric, "set", 5, 'logprep_bla{A="a"} 5.0'),
-            (GaugeMetric, "inc", 2, 'logprep_bla{A="a"} 2.0'),
-            (GaugeMetric, "dec", 2, 'logprep_bla{A="a"} -2.0'),
-            (HistogramMetric, "observe", 0.5, 'logprep_bla_count{A="a"} 1.0'),
-        ],
-    )
-    def test_collector_methods_bind_lazily_without_label_injection(
-        self, metric_class, method, argument, expected
-    ):
-        metric = metric_class(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            inject_label_values=False,
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert method not in metric.__dict__
-        assert 'A="a"' not in generate_latest(self.custom_registry).decode("utf-8")
-        # the fallback on the class runs once, then replaces itself
-        getattr(metric, method)(argument)
-        assert method in metric.__dict__
-        assert expected in generate_latest(self.custom_registry).decode("utf-8")
-
-    def test_histogram_time_binds_lazily_without_label_injection(self):
-        metric = HistogramMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            inject_label_values=False,
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert "time" not in metric.__dict__
-        with metric.time():
-            pass
-        assert "time" in metric.__dict__
-        assert 'logprep_bla_count{A="a"} 1.0' in generate_latest(self.custom_registry).decode(
-            "utf-8"
-        )
-
-    @pytest.mark.parametrize(
-        "metric_class, expected",
-        [
-            (CounterMetric, 'logprep_bla_total{A="first"} 2.0'),
-            (GaugeMetric, 'logprep_bla{A="first"} 2.0'),
-            (HistogramMetric, 'logprep_bla_count{A="first"} 1.0'),
-        ],
-    )
-    def test_add_with_labels_writes_to_the_given_labels(self, metric_class, expected):
-        metric = metric_class(
-            name="bla",
-            description="empty description",
-            labels={"A": ""},
-            inject_label_values=False,
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric.add_with_labels(2, {"A": "first"})
-        assert expected in generate_latest(self.custom_registry).decode("utf-8")
-
-    @pytest.mark.parametrize(
-        "registry_is_set", [True, False], ids=["with_registry", "without_registry"]
+        "registry_is_set",
+        [pytest.param(True, id="with_registry"), pytest.param(False, id="without_registry")],
     )
     def test_init_collector_reraises_if_it_cannot_recover(self, registry_is_set):
-        # the handler only recovers a collector that is already registered
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry if registry_is_set else None,
-        )
+        metric = self.metric(ExampleMetric)
         metric._registry = self.custom_registry if registry_is_set else None
         with mock.patch.object(
             metric, "_init_collector", side_effect=ValueError("unrelated failure")
@@ -327,43 +172,261 @@ class TestMetric:
                 metric.init_collector()
         assert not metric.initialized
 
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_initialized_is_true_only_after_init_collector(self, metric_type):
+        metric = self.metric(metric_type.metric, name="testmetric")
+        assert not metric.initialized
+        metric.init_collector()
+        assert metric.initialized
+
+    @mock_env({"PROMETHEUS_MULTIPROC_DIR": "/tmp"})
     def test_registry_is_not_set_in_multiprocess_mode(self):
-        with mock_env({"PROMETHEUS_MULTIPROC_DIR": "/tmp"}):
-            metric = CounterMetric(name="bla", description="empty description", labels={"A": "a"})
+        metric = ExampleMetric(name="some_metric_name", description="empty")
         assert metric._registry is None
 
-    def test_add_works_without_label_injection(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            inject_label_values=False,
-            registry=self.custom_registry,
-        )
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_metric_sets_labels(self, metric_type):
+        metric = self.metric(metric_type.metric, labels={"pipeline": "pipeline-1"})
         metric.init_collector()
-        metric += 2
-        assert 'logprep_bla_total{A="a"} 2.0' in generate_latest(self.custom_registry).decode(
-            "utf-8"
-        )
+        assert metric._collector._labelnames == ("pipeline",)
+
+    @pytest.mark.parametrize(
+        "metric_class, method, expected",
+        [
+            pytest.param(
+                CounterMetric,
+                "inc",
+                'logprep_some_metric_name_total{pipeline="1"} 3.0',
+                id="counter_sums",
+            ),
+            pytest.param(
+                GaugeMetric,
+                "set",
+                'logprep_some_metric_name{pipeline="1"} 2.0',
+                id="gauge_keeps_the_last",
+            ),
+            pytest.param(
+                HistogramMetric,
+                "observe",
+                'logprep_some_metric_name_sum{pipeline="1"} 3.0',
+                id="histogram_sums",
+            ),
+        ],
+    )
+    def test_two_metrics_with_the_same_labels_produce_the_same_metric(
+        self, metric_class, method, expected
+    ):
+        metric1 = self.metric(metric_class, labels={"pipeline": "1"})
+        metric2 = self.metric(metric_class, labels={"pipeline": "1"})
+        metric1.init_collector()
+        metric2.init_collector()
+        assert metric1._collector._labelnames == metric2._collector._labelnames
+        getattr(metric1, method)(1)
+        getattr(metric2, method)(2)
+        # exactly one series, so both metrics really wrote to the same child
+        assert len(re.findall(re.escape(expected), self.exposition())) == 1
+
+    @pytest.mark.parametrize(
+        "metric_class, method, expected1, expected2",
+        [
+            pytest.param(
+                CounterMetric,
+                "inc",
+                'logprep_some_metric_name_total{pipeline="1"} 1.0',
+                'logprep_some_metric_name_total{pipeline="2"} 2.0',
+                id="counter",
+            ),
+            pytest.param(
+                GaugeMetric,
+                "set",
+                'logprep_some_metric_name{pipeline="1"} 1.0',
+                'logprep_some_metric_name{pipeline="2"} 2.0',
+                id="gauge",
+            ),
+            pytest.param(
+                HistogramMetric,
+                "observe",
+                'logprep_some_metric_name_sum{pipeline="1"} 1.0',
+                'logprep_some_metric_name_sum{pipeline="2"} 2.0',
+                id="histogram",
+            ),
+        ],
+    )
+    def test_different_label_values_write_to_different_children(
+        self, metric_class, method, expected1, expected2
+    ):
+        metric1 = self.metric(metric_class, labels={"pipeline": "1"})
+        metric2 = self.metric(metric_class, labels={"pipeline": "2"})
+        metric1.init_collector()
+        metric2.init_collector()
+
+        assert metric1._collector == metric2._collector
+        getattr(metric1, method)(1)
+        getattr(metric2, method)(2)
+        metric_output = self.exposition()
+        assert expected1 in metric_output
+        assert expected2 in metric_output
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_collector_methods_are_bound_onto_the_instance(self, metric_type):
+        expected_methods = metric_type.collector_methods
+        metric = self.metric(metric_type.metric)
+        assert metric_type.metric._collector_methods == expected_methods
+        assert not expected_methods & metric.__dict__.keys()
+        metric.init_collector()
+        assert expected_methods <= metric.__dict__.keys()
+
+    @pytest.mark.parametrize("metric_class, method, argument, expected", WRITE_CASES)
+    def test_collector_methods_bind_and_write_on_first_call(
+        self, metric_class, method, argument, expected
+    ):
+        metric = self.metric(metric_class, inject_label_values=False)
+        metric.init_collector()
+        assert method not in metric.__dict__
+        assert 'A="a"' not in self.exposition()
+        self.write(metric, method, argument)
+        assert method in metric.__dict__
+        assert expected in self.exposition()
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_every_collector_method_has_a_write_case(self, metric_type):
+        covered = {case.values[1] for case in WRITE_CASES if case.values[0] is metric_type.metric}
+        assert metric_type.collector_methods == covered
+
+    def test_collector_methods_are_decorated_exactly_when_they_bind_lazily(self):
+        # decorated with @_collector_method <-> calls _lazy_bind_default_child() in body
+        module = ast.parse(inspect.getsource(metrics_module))
+        for metric_type in METRIC_TYPES:
+            class_node = next(
+                node
+                for node in module.body
+                if isinstance(node, ast.ClassDef) and node.name == metric_type.metric.__name__
+            )
+            for method in class_node.body:
+                if not isinstance(method, ast.FunctionDef):
+                    continue
+                decorated = any(
+                    getattr(decorator, "id", None) == "_collector_method"
+                    for decorator in method.decorator_list
+                )
+                binds_lazily = "_lazy_bind_default_child" in ast.dump(method)
+                assert decorated == binds_lazily, (
+                    f"{metric_type.metric.__name__}.{method.name}: "
+                    f"decorated={decorated} but binds_lazily={binds_lazily}"
+                )
+
+    @pytest.mark.parametrize("metric_class, method, argument, expected", WRITE_CASES)
+    def test_collector_methods_write_to_the_default_child(
+        self, metric_class, method, argument, expected
+    ):
+        metric = self.metric(metric_class)
+        metric.init_collector()
+        self.write(metric, method, argument)
+        assert expected in self.exposition()
+
+    @pytest.mark.parametrize(
+        "metric_class, method, writes, expected",
+        [
+            pytest.param(
+                CounterMetric,
+                "inc",
+                (3, 1, 2),
+                'logprep_some_metric_name_total{A="a"} 6.0',
+                id="counter_sums",
+            ),
+            pytest.param(
+                GaugeMetric,
+                "set",
+                (3, 1, 2),
+                'logprep_some_metric_name{A="a"} 2.0',
+                id="gauge_keeps_the_last",
+            ),
+            pytest.param(
+                GaugeMetric,
+                "inc",
+                (3, 1, 2),
+                'logprep_some_metric_name{A="a"} 6.0',
+                id="gauge_sums",
+            ),
+            pytest.param(
+                HistogramMetric,
+                "observe",
+                (3, 1, 2),
+                'logprep_some_metric_name_sum{A="a"} 6.0',
+                id="histogram_sums",
+            ),
+        ],
+    )
+    def test_repeated_writes_follow_the_semantics_of_the_metric_type(
+        self, metric_class, method, writes, expected
+    ):
+        metric = self.metric(metric_class)
+        metric.init_collector()
+        for write in writes:
+            getattr(metric, method)(write)
+        assert expected in self.exposition()
+
+    def test_histogram_exposes_sum_count_and_buckets(self):
+        metric = self.metric(HistogramMetric)
+        metric.init_collector()
+        metric.observe(1)
+        metric.observe(2)
+        metric.observe(3)
+        metric_output = self.exposition()
+        assert re.search(r'logprep_some_metric_name_sum\{A="a"\} 6\.0', metric_output)
+        assert re.search(r'logprep_some_metric_name_count\{A="a"\} 3\.0', metric_output)
+        assert re.search(r'logprep_some_metric_name_bucket\{A="a",le=".*"\} \d+', metric_output)
+
+    @pytest.mark.parametrize(
+        "metric_class, method, argument, expected",
+        [
+            pytest.param(CounterMetric, "inc", 3, 3, id="counter"),
+            pytest.param(GaugeMetric, "set", 5, 5, id="gauge_set"),
+            pytest.param(GaugeMetric, "dec", 2, -2, id="gauge_dec"),
+            pytest.param(HistogramMetric, "observe", 0.5, 0.5, id="histogram"),
+        ],
+    )
+    def test_value_reads_the_series_of_the_metric_type(
+        self, metric_class, method, argument, expected
+    ):
+        metric = self.metric(metric_class)
+        metric.init_collector()
+        assert metric.value == 0
+        getattr(metric, method)(argument)
+        assert metric.value == expected
+
+    def test_value_sums_the_labeled_children(self):
+        metric = self.metric(GaugeMetric, labels={"A": ""}, inject_label_values=False)
+        metric.init_collector()
+        metric.child_collector({"A": "first"}).set(1)
+        metric.child_collector({"A": "second"}).set(2)
+        assert metric.value == 3
+
+    def test_histogram_value_is_the_sum_and_count_is_the_number_of_observations(self):
+        metric = self.metric(HistogramMetric)
+        metric.init_collector()
+        metric.observe(0.5)
+        metric.observe(1.5)
+        assert metric.value == 2.0
+        assert metric.count == 2
+
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_every_metric_type_declares_its_value_series(self, metric_type):
+        # inherited from the base a new type would silently read the wrong series
+        declared = metric_type.metric.__dict__["_value_series_suffix"]
+        assert declared == metric_type.value_series_suffix
 
     def test_collect_samples_returns_labels_and_values(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(ExampleMetric)
         metric.init_collector()
-        metric += 3
+        metric.inc(3)
         samples = [sample for sample in metric.collect_samples() if sample.name.endswith("_total")]
         assert [(sample.labels, sample.value) for sample in samples] == [({"A": "a"}, 3.0)]
 
     def test_collect_samples_returns_every_labeled_child(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
+        metric = self.metric(
+            ExampleMetric,
             labels={"A": ""},
-            registry=self.custom_registry,
             inject_label_values=False,
         )
         metric.init_collector()
@@ -375,23 +438,14 @@ class TestMetric:
             "second": 2.0,
         }
 
-    def test_collect_samples_on_uninitialized_metric_raises(self):
-        metric = CounterMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        with pytest.raises(AttributeError):
+    @pytest.mark.parametrize("metric_type", TYPE_CASES)
+    def test_collect_samples_on_uninitialized_metric_raises(self, metric_type):
+        metric = self.metric(metric_type.metric)
+        with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'collect'"):
             metric.collect_samples()
 
     def test_child_collector_returns_initialized_child(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a", "B": ""},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(GaugeMetric, labels={"A": "a", "B": ""})
         metric.init_collector()
         child = metric.child_collector({"B": "b"})
         assert child.initialized
@@ -399,162 +453,65 @@ class TestMetric:
         assert child.labels == {"A": "a", "B": "b"}
 
     def test_child_collector_writes_to_its_own_labels(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a", "B": ""},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(GaugeMetric, labels={"A": "a", "B": ""})
         metric.init_collector()
         metric.child_collector({"B": "first"}).set(1)
         metric.child_collector({"B": "second"}).set(2)
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert 'logprep_bla{A="a",B="first"} 1.0' in metric_output
-        assert 'logprep_bla{A="a",B="second"} 2.0' in metric_output
-        assert 'logprep_bla{A="a",B=""} 0.0' in metric_output
+        metric_output = self.exposition()
+        assert 'logprep_some_metric_name{A="a",B="first"} 1.0' in metric_output
+        assert 'logprep_some_metric_name{A="a",B="second"} 2.0' in metric_output
+        assert 'logprep_some_metric_name{A="a",B=""} 0.0' in metric_output
 
     def test_child_collector_without_label_injection_registers_on_first_use(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a", "B": ""},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(GaugeMetric, labels={"A": "a", "B": ""})
         metric.init_collector()
         child = metric.child_collector({"B": "b"}, inject_label_values=False)
         assert child.initialized
-        assert 'B="b"' not in generate_latest(self.custom_registry).decode("utf-8")
+        assert 'B="b"' not in self.exposition()
         child.set(1)
-        assert 'logprep_bla{A="a",B="b"} 1.0' in generate_latest(self.custom_registry).decode(
-            "utf-8"
-        )
+        assert 'logprep_some_metric_name{A="a",B="b"} 1.0' in self.exposition()
 
     def test_child_collector_of_child_collector_keeps_merging_labels(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"A": "a", "B": "", "C": ""},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(GaugeMetric, labels={"A": "a", "B": "", "C": ""})
         metric.init_collector()
         grandchild = metric.child_collector({"B": "b"}).child_collector({"C": "c"})
         grandchild.set(1)
-        assert 'logprep_bla{A="a",B="b",C="c"} 1.0' in generate_latest(self.custom_registry).decode(
-            "utf-8"
-        )
+        assert 'logprep_some_metric_name{A="a",B="b",C="c"} 1.0' in self.exposition()
+
+    @pytest.mark.parametrize(
+        "metric_class, expected",
+        [
+            pytest.param(
+                CounterMetric, 'logprep_some_metric_name_total{A="first"} 2.0', id="counter"
+            ),
+            pytest.param(GaugeMetric, 'logprep_some_metric_name{A="first"} 2.0', id="gauge"),
+            pytest.param(
+                HistogramMetric, 'logprep_some_metric_name_count{A="first"} 1.0', id="histogram"
+            ),
+        ],
+    )
+    def test_add_with_labels_writes_to_the_given_labels(self, metric_class, expected):
+        metric = self.metric(metric_class, labels={"A": ""}, inject_label_values=False)
+        metric.init_collector()
+        metric.add_with_labels(2, {"A": "first"})
+        assert expected in self.exposition()
 
     def test_add_with_labels_none_value_raises_typeerror(self):
-        metric = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(ExampleMetric, name="testmetric")
         metric.init_collector()
         with pytest.raises(TypeError, match="not supported between instances of 'NoneType'"):
             metric.add_with_labels(None, {"A": "a"})
 
     def test_add_with_labels_none_labels_raises_typeerror(self):
-        metric = CounterMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
+        metric = self.metric(ExampleMetric, name="testmetric")
         metric.init_collector()
-        with pytest.raises(TypeError, match=" unsupported operand type(s) for |"):
+        with pytest.raises(TypeError, match=r"unsupported operand type\(s\)"):
             metric.add_with_labels(1, None)
-
-
-class TestGaugeMetric:
-    def setup_method(self):
-        self.custom_registry = CollectorRegistry()
-
-    def test_init_collector_returns_collector(self):
-        metric = GaugeMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert isinstance(metric._collector, Gauge)
-
-    def test_gauge_metric_increments_correctly(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert 'logprep_bla{pipeline="1"} 1.0' in metric_output
-
-    def test_gauge_metric_increment_twice_sets_metric(self):
-        metric = GaugeMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert 'logprep_bla{pipeline="1"} 1.0' in metric_output
-
-
-class TestHistogramMetric:
-    def setup_method(self):
-        self.custom_registry = CollectorRegistry()
-
-    def test_init_collector_returns_collector(self):
-        metric = HistogramMetric(
-            name="testmetric",
-            description="empty description",
-            labels={"A": "a"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        assert isinstance(metric._collector, Histogram)
-
-    def test_gauge_metric_increments_correctly(self):
-        metric = HistogramMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert re.search(r'logprep_bla_sum\{pipeline="1"\} 1\.0', metric_output)
-        assert re.search(r'logprep_bla_count\{pipeline="1"\} 1\.0', metric_output)
-        assert re.search(r'logprep_bla_bucket\{le=".*",pipeline="1"\} \d+', metric_output)
-
-    def test_gauge_metric_increment_twice_sets_metric(self):
-        metric = HistogramMetric(
-            name="bla",
-            description="empty description",
-            labels={"pipeline": "1"},
-            registry=self.custom_registry,
-        )
-        metric.init_collector()
-        metric += 1
-        metric += 1
-        metric_output = generate_latest(self.custom_registry).decode("utf-8")
-        assert re.search(r'logprep_bla_sum\{pipeline="1"\} 2\.0', metric_output)
-        assert re.search(r'logprep_bla_count\{pipeline="1"\} 2\.0', metric_output)
-        assert re.search(r'logprep_bla_bucket\{le=".*",pipeline="1"\} \d+', metric_output)
 
 
 class TestComponentMetrics:
     @define(kw_only=True)
     class Metrics(Component.Metrics):
-        """test class"""
-
         custom_registry = CollectorRegistry()
 
         test_metric_number_1: CounterMetric = field(

--- a/tests/unit/ng/component/base.py
+++ b/tests/unit/ng/component/base.py
@@ -12,7 +12,6 @@ import pytest
 import schedule
 from attrs import asdict
 from attrs.exceptions import FrozenInstanceError
-from prometheus_client import Counter, Gauge, Histogram
 
 from logprep.factory import Factory
 from logprep.metrics.metrics import Metric
@@ -138,9 +137,7 @@ class BaseComponentTestCase(ABC, Generic[ComponentTypeT]):
             )
             metric_name = metric_name.replace("logprep_", "")
             metric_attribute = getattr(self.object.metrics, metric_name)
-            assert metric_attribute.tracker is not None
-            possibile_tracker_types = (Counter, Gauge, Histogram)
-            assert isinstance(metric_attribute.tracker, possibile_tracker_types)
+            assert metric_attribute.initialized
 
     def test_all_metric_attributes_are_tested(self):
         if self.object.__class__.Metrics is Component.Metrics:

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -693,7 +693,7 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
         await self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
         # asserts entering context manager in metrics.metrics.Metric.measure_time
-        mock_metric.assert_has_calls([mock.call.tracker.labels().time().__enter__()])
+        mock_metric.assert_has_calls([mock.call.time().__enter__()])
 
     async def test_input_iterator(self):
         batch_events = [

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -693,7 +693,7 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
         await self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
         # asserts entering context manager in metrics.metrics.Metric.measure_time
-        mock_metric.assert_has_calls([mock.call.time().__enter__()])
+        mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     async def test_input_iterator(self):
         batch_events = [

--- a/tests/unit/ng/connector/base.py
+++ b/tests/unit/ng/connector/base.py
@@ -365,18 +365,15 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
             return_value=self._create_log_event({"event:": "test_event"}, original=b"")
         )
 
-        self.object.metrics.number_of_processed_events = 0
-
         await self.object.get_next(0.01)
 
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     async def test_connector_metrics_does_not_count_if_no_event_was_retrieved(self):
         self.object._get_event = mock.AsyncMock(return_value=None)
 
-        self.object.metrics.number_of_processed_events = 0
         assert await self.object.get_next(0.01) is None
-        assert self.object.metrics.number_of_processed_events == 0
+        assert self.object.metrics.number_of_processed_events.value == 0
 
     async def test_get_next_adds_timestamp_if_configured(self):
         self.object = self._create_test_instance(
@@ -671,16 +668,14 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
                 {"message": "test message"}, b'{"message":"test message"}'
             )
         )
-        self.object.metrics.number_of_processed_events = 0
         await self.object.get_next(0.01)
 
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     async def test_get_next_does_not_count_number_of_processed_events_if_event_is_none(self):
-        self.object.metrics.number_of_processed_events = 0
         self.object._get_event = mock.AsyncMock(return_value=None)
         await self.object.get_next(0.01)
-        assert self.object.metrics.number_of_processed_events == 0
+        assert self.object.metrics.number_of_processed_events.value == 0
 
     async def test_get_next_has_time_measurement(self):
         mock_metric = mock.MagicMock()
@@ -692,7 +687,6 @@ class BaseInputTestCase(BaseConnectorTestCase[InputTypeT], typing.Generic[InputT
         )
         await self.object.get_next(0.01)
         assert isinstance(self.object.metrics.processing_time_per_event, mock.MagicMock)
-        # asserts entering context manager in metrics.metrics.Metric.measure_time
         mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     async def test_input_iterator(self):
@@ -762,41 +756,37 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
     @pytest.mark.parametrize(("count"), [pytest.param(n, id=f"{n} events") for n in [0, 1, 2, 5]])
     async def test_store_counts_processed_events(self, count, mock_output_delivery_for_events):
         await self.object.setup()
-        self.object.metrics.number_of_processed_events = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
         mock_output_delivery_for_events([[True for _ in events]])
         await self.object.store(events)
 
-        assert self.object.metrics.number_of_processed_events == count
+        assert self.object.metrics.number_of_processed_events.value == count
 
     @pytest.mark.parametrize(("count"), [pytest.param(n, id=f"{n} events") for n in [0, 1, 2, 5]])
     async def test_store_counts_error_events(self, count, mock_output_delivery_for_events):
         await self.object.setup()
-        self.object.metrics.number_of_errors = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
         mock_output_delivery_for_events([[False for _ in events]])
         await self.object.store(events)
 
-        assert self.object.metrics.number_of_errors == count
+        assert self.object.metrics.number_of_errors.value == count
 
     @pytest.mark.parametrize(("count"), [pytest.param(n, id=f"{n} events") for n in [0, 1, 2, 5]])
     async def test_store_counts_error_events_for_client_failures(
         self, count, mock_output_delivery_for_events
     ):
         await self.object.setup()
-        self.object.metrics.number_of_errors = 0
 
         events = [self._create_log_event({"message": f"test {i}"}) for i in range(count)]
         mock_output_delivery_for_events([Exception("unexpected client failure")])
         await self.object.store(events)
 
-        assert self.object.metrics.number_of_errors == count
+        assert self.object.metrics.number_of_errors.value == count
 
     async def test_store_handles_uncaught_exception(self):
         await self.object.setup()
-        self.object.metrics.number_of_errors = 0
 
         event_with_target = self._create_log_event({"message": "test 1"}, output_target="something")
         event_without_target = self._create_log_event({"message": "test 1"}, output_target=None)
@@ -806,6 +796,6 @@ class BaseOutputTestCase(BaseConnectorTestCase[OutputTypeT], typing.Generic[Outp
             mock_write.side_effect = failure_reason
             await self.object.store([event_with_target, event_without_target])
 
-        assert self.object.metrics.number_of_errors == 2
+        assert self.object.metrics.number_of_errors.value == 2
         assert event_with_target.errors == [failure_reason]
         assert event_without_target.errors == [failure_reason]

--- a/tests/unit/ng/connector/test_confluent_kafka_input.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_input.py
@@ -515,8 +515,7 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
     )
     async def test_offset_metrics_not_initialized_with_default_label_values(self, metric_name):
         metric = getattr(self.object.metrics, metric_name)
-        metric_object = metric.tracker.collect()[0]
-        assert len(metric_object.samples) == 0
+        assert len(metric.collect_samples()) == 0
 
     async def test_lost_callback_counts_warnings_and_logs(self, mock_consumer):
         await self.object.setup()

--- a/tests/unit/ng/connector/test_confluent_kafka_input.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_input.py
@@ -139,13 +139,12 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
             _ = Factory.create({"test connector": kafka_config})
 
     async def test_error_callback_logs_error(self):
-        self.object.metrics.number_of_errors = 0
         with mock.patch("logging.Logger.error") as mock_error:
             test_error = Exception("test error")
             await self.object._error_callback(test_error)
             mock_error.assert_called()
             mock_error.assert_called_with("%s: %s", self.object.description, test_error)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     async def test_stats_callback_sets_metric_objetc_attributes(self):
         librdkafka_metrics = tuple(
@@ -163,10 +162,9 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
             assert getattr(self.object.metrics, metric) == metric_value, metric
 
     async def test_stats_set_age_metric_explicitly(self):
-        self.object.metrics.librdkafka_age = 0
         json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         await self.object._stats_callback(json_string)
-        assert self.object.metrics.librdkafka_age == 1337
+        assert self.object.metrics.librdkafka_age.value == 1337
 
     async def test_kafka_config_is_immutable(self):
         await self.object.setup()
@@ -378,15 +376,13 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
         assert "Input record value is not a valid json string" in error_event.data["errors"]
 
     async def test_commit_callback_raises_warning_error_and_counts_failures(self):
-        self.object.metrics.commit_failures = 0
         with pytest.raises(InputWarning, match="Could not commit offsets"):
             await self.object._commit_callback(Exception, [mock.MagicMock()])
-        assert self.object.metrics.commit_failures == 1
+        assert self.object.metrics.commit_failures.value == 1
 
     async def test_commit_callback_counts_commit_success(self):
-        self.object.metrics.commit_success = 0
         await self.object._commit_callback(None, [mock.MagicMock()])
-        assert self.object.metrics.commit_success == 1
+        assert self.object.metrics.commit_success.value == 1
 
     async def test_commit_callback_sets_committed_offsets(self):
         self.object.metrics.committed_offsets.add_with_labels = mock.MagicMock()
@@ -519,14 +515,13 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
 
     async def test_lost_callback_counts_warnings_and_logs(self, mock_consumer):
         await self.object.setup()
-        self.object.metrics.number_of_warnings = 0
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
             with mock.patch.object(self.object, "_commit_tracker") as tracker:
                 await self.object._lost_callback(mock_consumer, mock_partitions)
                 tracker.unregister_partition.assert_called()
         mock_warning.assert_called()
-        assert self.object.metrics.number_of_warnings == 1
+        assert self.object.metrics.number_of_warnings.value == 1
 
     async def test_assign_callback_sets_offsets_and_logs_info(self, mock_consumer, mock_tracker):
         await self.object.setup()
@@ -556,7 +551,6 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
     async def test_revoke_callback_logs_warning_and_counts(self, mock_tracker):
         await self.object.setup()
 
-        self.object.metrics.number_of_warnings = 0
         self.object.output_connector = mock.AsyncMock()
         mock_partitions = [mock.MagicMock()]
         with mock.patch("logging.Logger.warning") as mock_warning:
@@ -564,7 +558,7 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
 
         mock_warning.assert_called()
         mock_tracker.unregister_partition.assert_called()
-        assert self.object.metrics.number_of_warnings == 1
+        assert self.object.metrics.number_of_warnings.value == 1
 
     async def test_revoke_callback_logs_error_if_consumer_closed(
         self, mock_consumer, mock_tracker, caplog
@@ -607,6 +601,5 @@ class TestConfluentKafkaInput(BaseInputTestCase[ConfluentKafkaInput]):
         mock_consumer.list_topics.side_effect = KafkaException("test error")
 
         await self.object.setup()
-        self.object.metrics.number_of_errors = 0
         assert not await self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1

--- a/tests/unit/ng/connector/test_confluent_kafka_output.py
+++ b/tests/unit/ng/connector/test_confluent_kafka_output.py
@@ -75,13 +75,12 @@ class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
             _ = Factory.create({"test connector": kafka_config})
 
     async def test_error_callback_logs_error(self):
-        self.object.metrics.number_of_errors = 0
         with mock.patch("logging.Logger.error") as mock_error:
             test_error = Exception("test error")
             self.object._error_callback(test_error)
             mock_error.assert_called()
             mock_error.assert_called_with("%s: %s", self.object.description, test_error)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     async def test_stats_callback_sets_metric_object_attributes(self):
         librdkafka_metrics = tuple(
@@ -99,10 +98,9 @@ class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
             assert getattr(self.object.metrics, metric) == metric_value, metric
 
     async def test_stats_set_age_metric_explicitly(self):
-        self.object.metrics.librdkafka_age = 0
         json_string = Path(KAFKA_STATS_JSON_PATH).read_text("utf8")
         self.object._stats_callback(json_string)
-        assert self.object.metrics.librdkafka_age == 1337
+        assert self.object.metrics.librdkafka_age.value == 1337
 
     async def test_kafka_config_is_immutable(self):
         self.object.setup()
@@ -198,20 +196,17 @@ class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
         mock_error.assert_called()
 
     async def test_health_counts_metrics_on_kafka_exception(self):
-        self.object.metrics.number_of_errors = 0
         self.object._admin = mock.MagicMock()
         self.object._admin.list_topics.side_effect = KafkaException("test error")
         assert not await self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     async def test_shutdown_logs_and_counts_error_if_queue_not_fully_flushed(self):
-        self.object.metrics.number_of_errors = 0
         self.object._producer = mock.MagicMock()
         self.object._producer.flush.return_value = 1
         with mock.patch("logging.Logger.error") as mock_error:
             self.object.shut_down()
         mock_error.assert_called()
-        self.object.metrics.number_of_errors = 1
 
     async def test_health_returns_bool(self):
         with mock.patch.object(self.object, "_admin"):
@@ -247,39 +242,35 @@ class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
         admin_client.assert_called_with(expected_admin_client_config)
 
     async def test_store_handles_errors(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object, "_producer") as mock_producer:
             mock_producer.produce.side_effect = Exception("test error")
             self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_custom_handles_errors(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object, "_producer") as mock_producer:
             mock_producer.produce.side_effect = Exception("test error")
             self.object._store_custom(event, "target_topic")
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_handles_errors_failed_event(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object, "_producer") as mock_producer:
             mock_producer.produce.side_effect = Exception("test error")
             self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_custom_handles_errors_failed_event(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object, "_producer") as mock_producer:
             mock_producer.produce.side_effect = Exception("test error")
             self.object._store_custom(event, "target_topic")
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_shutdown_flushes_output(self):
@@ -309,10 +300,9 @@ class TestConfluentKafkaOutput(BaseOutputTestCase[ConfluentKafkaOutput]):
         kafka_error = mock.MagicMock()
         kafka_error.__str__ = mock.MagicMock(return_value="Kafka delivery error")
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
-        self.object.metrics.number_of_errors = 0
         self.object.on_delivery(event, kafka_error, kafka_message)
         assert len(event.errors) == 1
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert re.search(
             r"Message delivery failed: Kafka delivery error",
             caplog.text,

--- a/tests/unit/ng/connector/test_console_output.py
+++ b/tests/unit/ng/connector/test_console_output.py
@@ -50,7 +50,6 @@ class TestConsoleOutput(BaseOutputTestCase):
         mock_pprint.assert_called()
 
     def test_store_handles_errors(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent(
             {"message": "test message"},
             original=b"",
@@ -60,12 +59,11 @@ class TestConsoleOutput(BaseOutputTestCase):
             mocked_function.side_effect = Exception("Test exception")
             self.object.store(event)
         mocked_function.assert_called()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED
 
     def test_store_custom_handles_errors(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent(
             {"message": "test message"},
             original=b"",
@@ -76,12 +74,11 @@ class TestConsoleOutput(BaseOutputTestCase):
             mocked_function.side_effect = Exception("Test exception")
             self.object.store_custom(event, "stdout")
         mocked_function.assert_called()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED, f"{event.state} should be FAILED"
 
     def test_store_handles_errors_failed_event(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent(
             {"message": "test message"},
             original=b"",
@@ -92,12 +89,11 @@ class TestConsoleOutput(BaseOutputTestCase):
             mocked_function.side_effect = Exception("Test exception")
             self.object.store(event)
         mocked_function.assert_called()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED
 
     def test_store_custom_handles_errors_failed_event(self):
-        self.object.metrics.number_of_errors = 0
         event = LogEvent(
             {"message": "test message"},
             original=b"",
@@ -108,6 +104,6 @@ class TestConsoleOutput(BaseOutputTestCase):
             mocked_function.side_effect = Exception("Test exception")
             self.object.store_custom(event, "stdout")
         mocked_function.assert_called()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED, f"{event.state} should be FAILED"

--- a/tests/unit/ng/connector/test_dummy_output.py
+++ b/tests/unit/ng/connector/test_dummy_output.py
@@ -92,43 +92,37 @@ class TestDummyOutput(BaseOutputTestCase[DummyOutput]):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
         connector = Factory.create({"Test Instance Name": config})
-        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         await connector.store_batch([event], target="custom_target")
-        assert connector.metrics.number_of_errors == 1
+        assert connector.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_handles_errors_failed_event(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
         connector = Factory.create({"Test Instance Name": config})
-        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         await connector.store_batch([event])
-        assert connector.metrics.number_of_errors == 1
+        assert connector.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_batch_handles_errors_failed_event(self):
         config = deepcopy(self.CONFIG)
         config.update({"exceptions": ["FatalOutputError"]})
         connector = Factory.create({"Test Instance Name": config})
-        connector.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         await connector.store_batch([event], target="custom_target")
-        assert connector.metrics.number_of_errors == 1
+        assert connector.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_do_nothing_does_nothing(self):
         config = deepcopy(self.CONFIG)
         config.update({"do_nothing": True})
         connector = Factory.create({"Test Instance Name": config})
-        connector.metrics.number_of_errors = 0
-        connector.metrics.number_of_warnings = 0
-        connector.metrics.number_of_processed_events = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         await connector.store_batch([event], target="custom_target")
-        assert connector.metrics.number_of_errors == 0
-        assert connector.metrics.number_of_warnings == 0
-        assert connector.metrics.number_of_processed_events == 0
+        assert connector.metrics.number_of_errors.value == 0
+        assert connector.metrics.number_of_warnings.value == 0
+        assert connector.metrics.number_of_processed_events.value == 0
         assert len(event.errors) == 0
         assert len(event.warnings) == 0

--- a/tests/unit/ng/connector/test_http_input.py
+++ b/tests/unit/ng/connector/test_http_input.py
@@ -530,20 +530,18 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
         assert instance.target.startswith("http://")
 
     async def test_get_event_sets_message_backlog_size_metric(self, instance):
-        instance.metrics.message_backlog_size = 0
         random_number = random.randint(1, 100)
         for number in range(random_number):
             instance.messages.put_nowait({"message": f"my message{number}"})
         await instance.get_next(0.001)
-        assert instance.metrics.message_backlog_size == random_number
+        assert instance.metrics.message_backlog_size.value == random_number
 
     async def test_endpoints_count_requests(self, instance, client):
-        instance.metrics.number_of_http_requests = 0
         await instance.setup()
         random_number = random.randint(1, 100)
         for number in range(random_number):
             await client.post("/json", json={"message": f"my message{number}"})
-        assert instance.metrics.number_of_http_requests == random_number
+        assert instance.metrics.number_of_http_requests.value == random_number
 
     @pytest.mark.parametrize("endpoint", ["json", "plaintext", "jsonl"])
     async def test_endpoint_handles_gzip_compression(self, endpoint, client):
@@ -643,11 +641,10 @@ class TestHttpConnector(BaseInputTestCase[HttpInput]):
                 mock_logger.assert_called()
 
     async def test_health_counts_errors(self, instance, health_server):
-        instance.metrics.number_of_errors = 0
         responses = {instance.health_endpoints[0]: 500}
         async with health_server(instance, responses):
             assert not await instance.health()
-        assert instance.metrics.number_of_errors == 1
+        assert instance.metrics.number_of_errors.value == 1
 
     async def test_health_endpoints_are_shortened(self):
         expected_matching_regexes = (

--- a/tests/unit/ng/connector/test_json_input.py
+++ b/tests/unit/ng/connector/test_json_input.py
@@ -870,7 +870,7 @@ class TestJsonInput(BaseInputTestCase):
             connector.get_next(0.01)
             assert isinstance(connector.metrics.processing_time_per_event, mock.MagicMock)
             # asserts entering context manager in metrics.metrics.Metric.measure_time
-            mock_metric.assert_has_calls([mock.call.tracker.labels().time().__enter__()])
+            mock_metric.assert_has_calls([mock.call.time().__enter__()])
 
     async def test_raises_exception_if_not_a_dict(self):
         return_value = ["no dict"]

--- a/tests/unit/ng/connector/test_json_input.py
+++ b/tests/unit/ng/connector/test_json_input.py
@@ -870,7 +870,7 @@ class TestJsonInput(BaseInputTestCase):
             connector.get_next(0.01)
             assert isinstance(connector.metrics.processing_time_per_event, mock.MagicMock)
             # asserts entering context manager in metrics.metrics.Metric.measure_time
-            mock_metric.assert_has_calls([mock.call.time().__enter__()])
+            mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     async def test_raises_exception_if_not_a_dict(self):
         return_value = ["no dict"]

--- a/tests/unit/ng/connector/test_json_input.py
+++ b/tests/unit/ng/connector/test_json_input.py
@@ -449,12 +449,10 @@ class TestJsonInput(BaseInputTestCase):
             connector.pipeline_index = 1
             connector.setup()
 
-            connector.metrics.number_of_processed_events = 0
-
             with mock.patch.object(connector, "_get_event", return_value=return_value):
                 connector.get_next(0.01)
 
-            assert connector.metrics.number_of_processed_events == 1
+            assert connector.metrics.number_of_processed_events.value == 1
 
     async def test_get_next_adds_timestamp_if_configured(self):
         return_value = ({"any": "content"}, None, None)
@@ -850,10 +848,9 @@ class TestJsonInput(BaseInputTestCase):
             connector.pipeline_index = 1
             connector.setup()
             connector._get_event = mock.MagicMock(return_value=return_value)
-            connector.metrics.number_of_processed_events = 0
             connector.get_next(0.01)
 
-            assert connector.metrics.number_of_processed_events == 1
+            assert connector.metrics.number_of_processed_events.value == 1
 
     async def test_get_next_has_time_measurement(self):
         return_value = ({"message": "test message"}, b'{"message": "test message"}', None)
@@ -869,7 +866,6 @@ class TestJsonInput(BaseInputTestCase):
             connector._get_event = mock.MagicMock(return_value=return_value)
             connector.get_next(0.01)
             assert isinstance(connector.metrics.processing_time_per_event, mock.MagicMock)
-            # asserts entering context manager in metrics.metrics.Metric.measure_time
             mock_metric.assert_has_calls([mock.call.observe(mock.ANY)])
 
     async def test_raises_exception_if_not_a_dict(self):
@@ -959,10 +955,9 @@ class TestJsonInput(BaseInputTestCase):
             connector.pipeline_index = 1
             connector.setup()
 
-            connector.metrics.number_of_processed_events = 0
             connector._get_event = mock.MagicMock(return_value=(None, None, None))
             connector.get_next(0.01)
-            assert connector.metrics.number_of_processed_events == 0
+            assert connector.metrics.number_of_processed_events.value == 0
 
     async def test_get_next_does_not_count_number_of_processed_events_if_event_is_none(self):
         with self.patch_documents_property(document={}):
@@ -972,10 +967,9 @@ class TestJsonInput(BaseInputTestCase):
             connector.pipeline_index = 1
             connector.setup()
 
-            connector.metrics.number_of_processed_events = 0
             connector._get_event = mock.MagicMock(return_value=(None, None, None))
             connector.get_next(0.01)
-            assert connector.metrics.number_of_processed_events == 0
+            assert connector.metrics.number_of_processed_events.value == 0
 
     async def test_add_full_event_to_target_field_without_clear(self):
         return_value = ({"any": "content"}, None, None)

--- a/tests/unit/ng/connector/test_jsonl_output.py
+++ b/tests/unit/ng/connector/test_jsonl_output.py
@@ -84,11 +84,10 @@ class TestJsonlOutputOutput(BaseOutputTestCase):
 
     @mock.patch("builtins.open")
     async def test_store_counts_processed_events(self, _):  # pylint: disable=arguments-differ
-        self.object.metrics.number_of_processed_events = 0
         await self.object.store(
             LogEvent({"message": "my event message"}, original=b""), input_meta=InputMeta()
         )
-        assert self.object.metrics.number_of_processed_events == 1
+        assert self.object.metrics.number_of_processed_events.value == 1
 
     @mock.patch("builtins.open")
     async def test_store_calls_batch_finished_callback_without_errors(
@@ -101,50 +100,46 @@ class TestJsonlOutputOutput(BaseOutputTestCase):
 
     async def test_store_handles_errors(self):
         """you have to override this method in some output implementations depending on the implementation of the store and write_backlog methods."""
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch(
             "logprep.ng.connector.jsonl.output.JsonlOutput._write_json",
             side_effect=Exception("Test error"),
         ):
             await self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED
 
     async def test_store_custom_handles_errors(self):
         """you have to override this method in some output implementations depending on the implementation of the store and write_backlog methods."""
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch(
             "logprep.ng.connector.jsonl.output.JsonlOutput._write_json",
             side_effect=Exception("Test error"),
         ):
             await self.object.store_custom(event, target="custom_target")
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
 
     async def test_store_handles_errors_failed_event(self):
         """you have to override this method in some output implementations depending on the implementation of the store and write_backlog methods."""
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch(
             "logprep.ng.connector.jsonl.output.JsonlOutput._write_json",
             side_effect=Exception("Test error"),
         ):
             await self.object.store(event)
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1
         # assert event.state == EventStateType.FAILED
 
     async def test_store_custom_handles_errors_failed_event(self):
         """you have to override this method in some output implementations depending on the implementation of the store and write_backlog methods."""
-        self.object.metrics.number_of_errors = 0
         event = LogEvent({"message": "test message"}, original=b"", input_meta=InputMeta())
         with mock.patch(
             "logprep.ng.connector.jsonl.output.JsonlOutput._write_json",
             side_effect=Exception("Test error"),
         ):
             await self.object.store_custom(event, target="custom_target")
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
         assert len(event.errors) == 1

--- a/tests/unit/ng/connector/test_opensearch_output.py
+++ b/tests/unit/ng/connector/test_opensearch_output.py
@@ -436,43 +436,37 @@ class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
 
     async def test_metrics_count_bulk_requests_documents_and_rejections(self, mock_client):
         mock_client.bulk.side_effect = [_bulk_response(201, 429), _bulk_response(200)]
-        self.object.metrics.number_of_bulk_requests = 0
-        self.object.metrics.number_of_document_rejections = 0
-        self.object.metrics.documents_per_bulk_request = 0
         events = self._create_log_events(2)
 
         await self._setup_and_store(events)
 
-        assert self.object.metrics.number_of_bulk_requests == 2
-        assert self.object.metrics.number_of_document_rejections == 1
-        assert self.object.metrics.documents_per_bulk_request == 2 + 1
+        assert self.object.metrics.number_of_bulk_requests.value == 2
+        assert self.object.metrics.number_of_document_rejections.value == 1
+        assert self.object.metrics.documents_per_bulk_request.value == 2 + 1
 
     async def test_metrics_count_bytes_sent(self, mock_client):
         mock_client.bulk.return_value = _bulk_response(201)
-        self.object.metrics.number_of_bytes_sent = 0
         event = self._create_log_event({"message": "test message"})
 
         await self._setup_and_store([event])
 
         sent_body = mock_client.bulk.await_args.kwargs["body"]
-        assert self.object.metrics.number_of_bytes_sent == len(sent_body)
+        assert self.object.metrics.number_of_bytes_sent.value == len(sent_body)
 
     async def test_metrics_count_connection_failures(self, mock_client):
         mock_client.bulk.side_effect = [CONNECTION_ERROR, CONNECTION_ERROR, _bulk_response(201)]
-        self.object.metrics.number_of_connection_failures = 0
         event = self._create_log_event({"message": "test message"})
 
         await self._setup_and_store([event])
 
-        assert self.object.metrics.number_of_connection_failures == 2
+        assert self.object.metrics.number_of_connection_failures.value == 2
 
     async def test_metrics_count_serialization_errors(self):
-        self.object.metrics.number_of_serialization_errors = 0
         unserializable = self._create_log_event({"message": object()})
 
         await self._setup_and_store([unserializable])
 
-        assert self.object.metrics.number_of_serialization_errors == 1
+        assert self.object.metrics.number_of_serialization_errors.value == 1
 
     async def test_health_returns_true_on_success(self, mock_client):
         mock_client.cluster.health.return_value = {"status": "green"}
@@ -493,11 +487,10 @@ class TestOpenSearchOutput(BaseOutputTestCase[OpensearchOutput]):
             mock_error.assert_called()
 
     async def test_health_counts_metrics_on_failure(self, mock_client):
-        self.object.metrics.number_of_errors = 0
         mock_client.cluster.health.side_effect = SearchException
         await self.object.setup()
         assert not await self.object.health()
-        assert self.object.metrics.number_of_errors == 1
+        assert self.object.metrics.number_of_errors.value == 1
 
     async def test_health_returns_false_on_cluster_status_not_green(self, mock_client):
         mock_client.cluster.health.return_value = {"status": "yellow"}

--- a/tests/unit/ng/processor/amides/test_amides.py
+++ b/tests/unit/ng/processor/amides/test_amides.py
@@ -38,10 +38,6 @@ class TestAmides(BaseProcessorTestCase[Amides]):
     ]
 
     async def test_process_event_malicious_process_command_line(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         await self.object.setup()
         document = {
             "winlog": {
@@ -59,16 +55,12 @@ class TestAmides(BaseProcessorTestCase[Amides]):
             "attributions"
         )
         assert len(result["attributions"]) == 10
-        assert self.object.metrics.total_cmdlines == 1
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.num_cache_entries == 1
-        assert self.object.metrics.cache_load == 0.2
+        assert self.object.metrics.total_cmdlines.value == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
 
     async def test_process_event_benign_process_command_line(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         await self.object.setup()
         document = {
             "winlog": {
@@ -84,10 +76,10 @@ class TestAmides(BaseProcessorTestCase[Amides]):
         assert result["confidence"] < self.CONFIG.get("decision_threshold") and not result.get(
             "attributions"
         )
-        assert self.object.metrics.total_cmdlines == 1
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.num_cache_entries == 1
-        assert self.object.metrics.cache_load == 0.2
+        assert self.object.metrics.total_cmdlines.value == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
 
     no_pc_events = [
         {"winlog": {"event_id": 6005, "provider_name": "Microsoft-Windows-Sysmon"}},
@@ -98,24 +90,16 @@ class TestAmides(BaseProcessorTestCase[Amides]):
 
     @pytest.mark.parametrize("document", no_pc_events)
     async def test_process_event_no_process_creation_events(self, document):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         await self.object.setup()
         event = LogEvent(document, original=b"", input_meta=InputMeta())
         await self.object.process(event)
         assert not document.get("amides")
-        assert self.object.metrics.total_cmdlines == 0
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-        assert self.object.metrics.cache_load == 0.0
+        assert self.object.metrics.total_cmdlines.value == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
+        assert self.object.metrics.cache_load.value == 0.0
 
     async def test_process_event_without_command_line_field(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         await self.object.setup()
         document = {
             "winlog": {"event_id": 1, "provider_name": "Microsoft-Windows-Sysmon"},
@@ -124,17 +108,12 @@ class TestAmides(BaseProcessorTestCase[Amides]):
         event = LogEvent(document, original=b"", input_meta=InputMeta())
         await self.object.process(event)
         assert not document.get("amides")
-        assert self.object.metrics.total_cmdlines == 0
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-        assert self.object.metrics.cache_load == 0.0
+        assert self.object.metrics.total_cmdlines.value == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
+        assert self.object.metrics.cache_load.value == 0.0
 
     async def test_classification_results_from_cache(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         await self.object.setup()
         document = {
             "winlog": {
@@ -150,17 +129,11 @@ class TestAmides(BaseProcessorTestCase[Amides]):
         await self.object.process(other_event)
 
         assert other_document.get("amides") == document.get("amides")
-        assert self.object.metrics.total_cmdlines == 2
-        # we mock the metrics with integer operations, so the assertions
-        # are a little bit weird:
-        # we assert for 2 because we add two times the same cache result
-        # the underlying metric implementation sets the values instead of adding
-        # them
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.num_cache_entries == 2
-        assert self.object.metrics.cache_load == 0.4
-        # end strange mock
-        assert self.object.metrics.cached_results == 1
+        assert self.object.metrics.total_cmdlines.value == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
+        assert self.object.metrics.cached_results.value == 1
 
     async def test_process_event_raise_duplication_error(self):
         await self.object.setup()

--- a/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/ng/processor/generic_resolver/test_generic_resolver.py
@@ -251,8 +251,6 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         assert document.data == expected
 
     async def test_resolve_from_cache_with_large_enough_cache(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["max_cache_entries"] = 10
         self.object = Factory.create({"generic_resolver": config})
@@ -271,31 +269,25 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         )
         await self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
+
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 1
-
-        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
-
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_2, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 4
-        assert self.object.metrics.cached_results == 2
-        assert self.object.metrics.num_cache_entries == 4
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 2
 
     async def test_resolve_from_cache_with_cache_smaller_than_results(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["max_cache_entries"] = 1
         self.object = Factory.create({"generic_resolver": config})
@@ -314,27 +306,23 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         )
         await self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
+
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 1
-
-        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
-
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_2, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 4
-        assert self.object.metrics.cached_results == 2
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
     async def test_resolve_without_cache(self):
         config = deepcopy(self.CONFIG)
@@ -355,31 +343,25 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         )
         await self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
+
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-
-        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
-
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         await self.object.process(LogEvent(event_2, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
     async def test_resolve_from_cache_with_update_interval(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["cache_metrics_interval"] = 2
         config["max_cache_entries"] = 10
@@ -399,30 +381,26 @@ class TestGenericResolver(BaseProcessorTestCase[GenericResolver]):
         )
         await self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
+
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-
-        await self.object.process(LogEvent(event_1, original=b"", input_meta=InputMeta()))
-
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_2, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         await self.object.process(LogEvent(event_2, original=b"", input_meta=InputMeta()))
 
-        assert self.object.metrics.new_results == 3
-        assert self.object.metrics.cached_results == 3
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 2
+        assert self.object.metrics.num_cache_entries.value == 2

--- a/tests/unit/ng/processor/pseudonymizer/test_pseudonymizer.py
+++ b/tests/unit/ng/processor/pseudonymizer/test_pseudonymizer.py
@@ -163,14 +163,11 @@ class TestPseudonymizer(BaseProcessorTestCase[Pseudonymizer]):
             }
         }
         await self._load_rule(rule_dict)
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
         event = LogEvent(event, original=b"", input_meta=InputMeta())
         await self.object.process(event)
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
     async def test_resolve_from_cache_pseudonymize_urls(self):
         rule_dict = {
@@ -189,16 +186,13 @@ class TestPseudonymizer(BaseProcessorTestCase[Pseudonymizer]):
             "and_pseudo_this": "https://www.pseudo.this.de",
         }
         await self._load_rule(rule_dict)
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
         event = LogEvent(event, original=b"", input_meta=InputMeta())
         await self.object.process(event)
         # 1 subdomains -> pseudonym_cache, 1 url -> url_cache
-        assert self.object.metrics.new_results == 2
+        assert self.object.metrics.new_results.value == 2
         # second url is cached, no string pseudonymization needed
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2, "same as new results"
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 2, "same as new results"
 
     @pytest.mark.parametrize(
         "url, expected",
@@ -425,15 +419,11 @@ class TestPseudonymizer(BaseProcessorTestCase[Pseudonymizer]):
         }
         await self._load_rule(rule_dict)
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
         event = LogEvent(event, original=b"", input_meta=InputMeta())
         await self.object.process(deepcopy(event))
         await self.object.process(deepcopy(event))
         await self.object.process(event)
         # because the event is the same, the result is cached
-        # metrics are mocked by integers and incremented by cache_info results
-        assert self.object.metrics.new_results == 3
-        assert self.object.metrics.cached_results == 3
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 2
+        assert self.object.metrics.num_cache_entries.value == 1

--- a/tests/unit/processor/amides/test_amides.py
+++ b/tests/unit/processor/amides/test_amides.py
@@ -35,10 +35,6 @@ class TestAmides(BaseProcessorTestCase):
     ]
 
     def test_process_event_malicious_process_command_line(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         self.object.setup()
         document = {
             "winlog": {
@@ -56,16 +52,12 @@ class TestAmides(BaseProcessorTestCase):
             "attributions"
         )
         assert len(result["attributions"]) == 10
-        assert self.object.metrics.total_cmdlines == 1
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.num_cache_entries == 1
-        assert self.object.metrics.cache_load == 0.2
+        assert self.object.metrics.total_cmdlines.value == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
 
     def test_process_event_benign_process_command_line(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         self.object.setup()
         document = {
             "winlog": {
@@ -80,10 +72,10 @@ class TestAmides(BaseProcessorTestCase):
         assert result["confidence"] < self.CONFIG.get("decision_threshold") and not result.get(
             "attributions"
         )
-        assert self.object.metrics.total_cmdlines == 1
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.num_cache_entries == 1
-        assert self.object.metrics.cache_load == 0.2
+        assert self.object.metrics.total_cmdlines.value == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
 
     no_pc_events = [
         {"winlog": {"event_id": 6005, "provider_name": "Microsoft-Windows-Sysmon"}},
@@ -94,24 +86,16 @@ class TestAmides(BaseProcessorTestCase):
 
     @pytest.mark.parametrize("document", no_pc_events)
     def test_process_event_no_process_creation_events(self, document):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         self.object.setup()
 
         self.object.process(document)
         assert not document.get("amides")
-        assert self.object.metrics.total_cmdlines == 0
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-        assert self.object.metrics.cache_load == 0.0
+        assert self.object.metrics.total_cmdlines.value == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
+        assert self.object.metrics.cache_load.value == 0.0
 
     def test_process_event_without_command_line_field(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         self.object.setup()
         document = {
             "winlog": {"event_id": 1, "provider_name": "Microsoft-Windows-Sysmon"},
@@ -120,17 +104,12 @@ class TestAmides(BaseProcessorTestCase):
 
         self.object.process(document)
         assert not document.get("amides")
-        assert self.object.metrics.total_cmdlines == 0
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-        assert self.object.metrics.cache_load == 0.0
+        assert self.object.metrics.total_cmdlines.value == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
+        assert self.object.metrics.cache_load.value == 0.0
 
     def test_classification_results_from_cache(self):
-        self.object.metrics.total_cmdlines = 0
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
-        self.object.metrics.cache_load = 0.0
         self.object.setup()
         document = {
             "winlog": {
@@ -145,17 +124,11 @@ class TestAmides(BaseProcessorTestCase):
         self.object.process(other_document)
 
         assert other_document.get("amides") == document.get("amides")
-        assert self.object.metrics.total_cmdlines == 2
-        # we mock the metrics with integer operations, so the assertions
-        # are a little bit weird:
-        # we assert for 2 because we add two times the same cache result
-        # the underlying metric implementation sets the values instead of adding
-        # them
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.num_cache_entries == 2
-        assert self.object.metrics.cache_load == 0.4
-        # end strange mock
-        assert self.object.metrics.cached_results == 1
+        assert self.object.metrics.total_cmdlines.value == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
+        assert self.object.metrics.cache_load.value == 0.2
+        assert self.object.metrics.cached_results.value == 1
 
     def test_process_event_raise_duplication_error(self):
         self.object.setup()

--- a/tests/unit/processor/generic_resolver/test_generic_resolver.py
+++ b/tests/unit/processor/generic_resolver/test_generic_resolver.py
@@ -855,8 +855,6 @@ class TestGenericResolver(BaseProcessorTestCase):
         assert document == expected
 
     def test_resolve_from_cache_with_large_enough_cache(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["max_cache_entries"] = 10
         self.object = Factory.create({"generic_resolver": config})
@@ -873,31 +871,25 @@ class TestGenericResolver(BaseProcessorTestCase):
         )
         self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        self.object.process(event)
+
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process(event)
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 1
-
-        self.object.process(event)
-
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process({"to_resolve": "bar"})
 
-        assert self.object.metrics.new_results == 4
-        assert self.object.metrics.cached_results == 2
-        assert self.object.metrics.num_cache_entries == 4
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 2
 
     def test_resolve_from_cache_with_cache_smaller_than_results(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["max_cache_entries"] = 1
         self.object = Factory.create({"generic_resolver": config})
@@ -914,27 +906,23 @@ class TestGenericResolver(BaseProcessorTestCase):
         )
         self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        self.object.process(event)
+
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process(event)
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 1
-
-        self.object.process(event)
-
-        assert self.object.metrics.new_results == 2
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process({"to_resolve": "bar"})
 
-        assert self.object.metrics.new_results == 4
-        assert self.object.metrics.cached_results == 2
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
     def test_resolve_without_cache(self):
         config = deepcopy(self.CONFIG)
@@ -953,31 +941,25 @@ class TestGenericResolver(BaseProcessorTestCase):
         )
         self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        self.object.process(event)
+
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         self.object.process(event)
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-
-        self.object.process(event)
-
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         self.object.process({"to_resolve": "bar"})
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
     def test_resolve_from_cache_with_update_interval(self):
-        """The metrics are mocked and their values are the sum of previously added cache values,
-        instead of being the current cache values."""
         config = deepcopy(self.CONFIG)
         config["cache_metrics_interval"] = 2
         config["max_cache_entries"] = 10
@@ -996,30 +978,26 @@ class TestGenericResolver(BaseProcessorTestCase):
         )
         self.object.setup()
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
+        self.object.process(event)
+
+        assert self.object.metrics.new_results.value == 0
+        assert self.object.metrics.cached_results.value == 0
+        assert self.object.metrics.num_cache_entries.value == 0
 
         self.object.process(event)
 
-        assert self.object.metrics.new_results == 0
-        assert self.object.metrics.cached_results == 0
-        assert self.object.metrics.num_cache_entries == 0
-
-        self.object.process(event)
-
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process(other_event)
 
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
         self.object.process(other_event)
 
-        assert self.object.metrics.new_results == 3
-        assert self.object.metrics.cached_results == 3
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 2
+        assert self.object.metrics.cached_results.value == 2
+        assert self.object.metrics.num_cache_entries.value == 2

--- a/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
+++ b/tests/unit/processor/pseudonymizer/test_pseudonymizer.py
@@ -825,13 +825,10 @@ class TestPseudonymizer(BaseProcessorTestCase):
             }
         }
         self._load_rule(rule_dict)
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
         self.object.process(event)
-        assert self.object.metrics.new_results == 1
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 1
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 1
 
     def test_resolve_from_cache_pseudonymize_urls(self):
         rule_dict = {
@@ -850,15 +847,12 @@ class TestPseudonymizer(BaseProcessorTestCase):
             "and_pseudo_this": "https://www.pseudo.this.de",
         }
         self._load_rule(rule_dict)
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
         self.object.process(event)
         # 1 subdomains -> pseudonym_cache, 1 url -> url_cache
-        assert self.object.metrics.new_results == 2
+        assert self.object.metrics.new_results.value == 2
         # second url is cached, no string pseudonymization needed
-        assert self.object.metrics.cached_results == 1
-        assert self.object.metrics.num_cache_entries == 2, "same as new results"
+        assert self.object.metrics.cached_results.value == 1
+        assert self.object.metrics.num_cache_entries.value == 2, "same as new results"
 
     @pytest.mark.parametrize(
         "url, expected",
@@ -1093,15 +1087,10 @@ class TestPseudonymizer(BaseProcessorTestCase):
         }
         self._load_rule(rule_dict)
 
-        self.object.metrics.new_results = 0
-        self.object.metrics.cached_results = 0
-        self.object.metrics.num_cache_entries = 0
-
         self.object.process(deepcopy(event))
         self.object.process(deepcopy(event))
         self.object.process(event)
         # because the event is the same, the result is cached
-        # metrics are mocked by integers and incremented by cache_info results
-        assert self.object.metrics.new_results == 3
-        assert self.object.metrics.cached_results == 3
-        assert self.object.metrics.num_cache_entries == 3
+        assert self.object.metrics.new_results.value == 1
+        assert self.object.metrics.cached_results.value == 2
+        assert self.object.metrics.num_cache_entries.value == 1

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -59,14 +59,11 @@ class TestRunner:
     def test_iteration_sets_error_queue_size(self, runner):
         with mock.patch.object(runner, "_manager") as mock_manager:
             mock_manager.restart_count = 0
-            runner.metrics.number_of_events_in_error_queue = 0
             mock_manager.should_exit.side_effect = [False, False, True]
             mock_manager.error_queue.qsize.return_value = 42
             with pytest.raises(SystemExit):
                 runner.start()
-            assert (
-                runner.metrics.number_of_events_in_error_queue == 84
-            )  # because of mocking with int
+            assert runner.metrics.number_of_events_in_error_queue.value == 42
 
     def test_iteration_calls_should_exit(self, runner):
         with mock.patch.object(runner, "_manager") as mock_manager:

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -788,9 +788,7 @@ output:
     dummy:
         type: dummy_output
 """)
-        with mock.patch.object(
-            config._metrics.config_refresh_interval, "add_with_labels"
-        ) as mock_add:
+        with mock.patch.object(config._metrics.config_refresh_interval, "__add__") as mock_add:
             config.reload()
         assert "Successfully reloaded" in caplog.text
         mock_add.assert_called_once_with(66, {"logprep": "unset", "config": "unset"})
@@ -837,7 +835,7 @@ output:
 """)
         with mock.patch("logprep.util.configuration.GaugeMetric.add_with_labels") as mock_add:
             Configuration.from_sources([str(config_path)])
-        assert mock_add.call_count == 3, "version_info and config_refresh_interval and ???"
+        assert mock_add.call_count == 2, "version_info and config_refresh_interval"
 
     def test_reload_logs_error_on_invalid_processor_config(self, config_path, caplog):
         caplog.set_level("DEBUG")

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -685,8 +685,6 @@ pipeline:
     def test_reload_reloads_complete_config_if_different_config(self, config_path, caplog):
         caplog.set_level("INFO")
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         assert config.version == "1"
         assert config.process_count == 3
         config_path.write_text("""
@@ -708,8 +706,10 @@ output:
         assert config.process_count == 2, "process count should be updated"
         assert "Successfully reloaded" in caplog.text
         assert "Configuration version: second_version" in caplog.text
-        assert config._metrics.number_of_config_refreshes == 1, "one config refresh"
-        assert config._metrics.number_of_config_refresh_failures == 0, "no config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 1, "one config refresh"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 0
+        ), "no config refresh failure"
 
     def test_reload_sets_config_refresh_interval_none(self, config_path, caplog):
         caplog.set_level("INFO")
@@ -732,21 +732,19 @@ output:
     def test_reload_always_reloads(self, config_path, caplog):
         caplog.set_level("INFO")
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         config.process_count = 99
         config_path.write_text(config.as_yaml())
         config.process_count = 2
         config.reload()
         assert "Successfully reloaded configuration" in caplog.text
         assert config.process_count == 99
-        assert config._metrics.number_of_config_refreshes == 1, "config refresh"
-        assert config._metrics.number_of_config_refresh_failures == 0, "config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 1, "config refresh"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 0
+        ), "config refresh failure"
 
     def test_reload_logs_error_on_invalid_config(self, config_path, caplog):
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         assert config.version == "1"
         config_path.write_text("""
 version: second_version
@@ -767,8 +765,10 @@ output:
         assert "Failed to reload configuration" in caplog.text
         assert "THIS SHOULD BE AN INT" in caplog.text
         assert config.version == "1", "version should not change"
-        assert config._metrics.number_of_config_refreshes == 0, "no config refresh"
-        assert config._metrics.number_of_config_refresh_failures == 1, "one config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 0, "no config refresh"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 1
+        ), "one config refresh failure"
 
     def test_reload_exposes_config_refresh_interval_metric(self, config_path, caplog):
         caplog.set_level("INFO")
@@ -842,8 +842,6 @@ output:
     def test_reload_logs_error_on_invalid_processor_config(self, config_path, caplog):
         caplog.set_level("DEBUG")
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         assert config.version == "1", "version should be 1"
         config_path.write_text("""
 version: second_version
@@ -871,32 +869,32 @@ output:
         assert "Failed to reload configuration" in caplog.text
         assert "THIS SHOULD BE A VALID PROCESSOR" in caplog.text
         assert config.version == "1", "version should not change"
-        assert config._metrics.number_of_config_refreshes == 0, "no config refresh"
-        assert config._metrics.number_of_config_refresh_failures == 1, "one config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 0, "no config refresh"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 1
+        ), "one config refresh failure"
 
     def test_reload_logs_warning_on_getter_exception_and_computes_new_refresh_interval(
         self, config_path, caplog
     ):
         caplog.set_level("WARNING")
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         config.config_refresh_interval = 40
-        config._metrics.config_refresh_interval = 40  # set to primitive type
         assert config.version == "1", "version should be 1"
         config_path.unlink()  # causes FileNotFoundError
         config.reload()
         assert "Failed to load configuration" in caplog.text
         assert config.config_refresh_interval == 10, "refresh interval should be divided by 4"
-        assert config._metrics.config_refresh_interval == 50, "should be += new value"
-        assert config._metrics.number_of_config_refreshes == 0, "no config refresh"
-        assert config._metrics.number_of_config_refresh_failures == 1, "one config refresh failure"
+        assert config._metrics.config_refresh_interval.value == 10, "gauge holds the new interval"
+        assert config._metrics.number_of_config_refreshes.value == 0, "no config refresh"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 1
+        ), "one config refresh failure"
 
     def test_reload_with_errors_does_not_set_interval_le_5_seconds(self, config_path, caplog):
         caplog.set_level("WARNING")
         config = Configuration.from_sources([str(config_path)])
         config.config_refresh_interval = 8
-        config._metrics.config_refresh_interval = 0  # set to primitive type
         assert config.version == "1", "version should be 1"
         config_path.unlink()  # causes FileNotFoundError
         config.reload()
@@ -904,15 +902,13 @@ output:
         assert (
             config.config_refresh_interval == 5
         ), "refresh interval should not be less than 5 seconds"
-        assert config._metrics.config_refresh_interval == 5, "should be set to 5 seconds"
+        assert config._metrics.config_refresh_interval.value == 5, "should be set to 5 seconds"
 
     def test_reload_resets_origin_refresh_interval_after_error_is_fixed_and_logs_recovery(
         self, config_path, caplog
     ):
         caplog.set_level("INFO")
         config = Configuration.from_sources([str(config_path)])
-        config._metrics.number_of_config_refreshes = 0
-        config._metrics.number_of_config_refresh_failures = 0
         config.config_refresh_interval = 8
         assert config.version == "1", "version should be 1"
         config_path.unlink()  # causes FileNotFoundError
@@ -927,16 +923,20 @@ output:
         assert caplog.text.count("Config refresh recovered from failing source") == 1
         assert caplog.text.count("Config refresh interval is set to: 8 seconds") == 2
         assert config.config_refresh_interval == 8, "refresh interval should be reset to origin"
-        assert config._metrics.number_of_config_refreshes == 1, "refresh after recovering"
-        assert config._metrics.number_of_config_refresh_failures == 1, "config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 1, "refresh after recovering"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 1
+        ), "config refresh failure"
 
         config.reload()
         assert caplog.text.count("Failed to load configuration") == 1
         assert caplog.text.count("Config refresh recovered from failing source") == 1
         assert caplog.text.count("Config refresh interval is set to: 8 seconds") == 4
         assert config.config_refresh_interval == 8, "refresh interval should be reset to origin"
-        assert config._metrics.number_of_config_refreshes == 2, "refresh after recovering"
-        assert config._metrics.number_of_config_refresh_failures == 1, "config refresh failure"
+        assert config._metrics.number_of_config_refreshes.value == 2, "refresh after recovering"
+        assert (
+            config._metrics.number_of_config_refresh_failures.value == 1
+        ), "config refresh failure"
 
     def test_as_dict_returns_config(self):
         config = Configuration.from_sources([path_to_config, path_to_only_output_config])

--- a/tests/unit/util/test_configuration.py
+++ b/tests/unit/util/test_configuration.py
@@ -788,10 +788,12 @@ output:
     dummy:
         type: dummy_output
 """)
-        with mock.patch.object(config._metrics.config_refresh_interval, "__add__") as mock_add:
-            config.reload()
+        config.reload()
         assert "Successfully reloaded" in caplog.text
-        mock_add.assert_called_once_with(66, {"logprep": "unset", "config": "unset"})
+        samples = config._metrics.config_refresh_interval.collect_samples()
+        assert [(sample.labels, sample.value) for sample in samples] == [
+            ({"logprep": "unset", "config": "unset"}, 66)
+        ]
 
     def test_reload_exposes_version_info_metric(self, config_path, caplog):
         caplog.set_level("INFO")


### PR DESCRIPTION
## Description

* metrics: cache labeled child metric collectors
* metrics: avoid heavy time context manager and hardwire passtrough metric collector methods on wrapper class
* metrics: remove `__add__` interface from metrics and use the passthrough instead
* metrics: consolidate `measure_time` and `measure_time_async` in single decorator
* tests: add mock_env decorator support for async functions

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

- pytest

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1016.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->