### PR TITLE
fix: mixed-type scenarios in lucene range expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Breaking
 * restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
 * handle non-string `concatenator` source fields with `ProcessingWarning` instead of `ProcessingCriticalError`
+* filter: rework range expressions to allow mixed types and type coercion
+* filter: drop support for `inf`/`nan` in range expressions
+* filter: add support for `*` (open boundary) in range expressions
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 ### Breaking
 * restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
 * handle non-string `concatenator` source fields with `ProcessingWarning` instead of `ProcessingCriticalError`
-* filter: rework range expressions to allow mixed types and type coercion
-* filter: drop support for `inf`/`nan` in range expressions
-* filter: add support for `*` (open boundary) in range expressions
+* filter: allow mixed numeric range boundaries and type coercion for range matching
+* filter: unquoted asterisks (`*`) in range expressions are now considered open boundaries
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
@@ -12,6 +11,7 @@
 * generic_adder: add support for templated http urls & content_field
 * generic_resolver: add content_field support
 * field_name_replacer: add new `field_name_replacer` processor to replace occurences of strings in key names
+* filter: add support for `*` (open boundary) in range expressions
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
@@ -37,6 +37,7 @@
 * generic_adder: allow `None` as valid input via `add`
 * grokker: allow fallback matches without named fields
 * filter: fix lucene range expressions not matching on mixed-type scenarios
+* filter: treat `inf`/`nan` as string values instead of numeric range boundaries
 
 ## 20.0.0
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 ### Breaking
 * restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
 * handle non-string `concatenator` source fields with `ProcessingWarning` instead of `ProcessingCriticalError`
-* filter: allow mixed numeric range boundaries and type coercion for range matching
-* filter: unquoted asterisks (`*`) in range expressions are now considered open boundaries
+* filter: field values are now automatically coerced in range matches
 
 ### Features
 * add support for fractional UNIX timestamps in the `timestamper` processor while preserving supported integer timestamp normalization.
@@ -12,6 +11,7 @@
 * generic_resolver: add content_field support
 * field_name_replacer: add new `field_name_replacer` processor to replace occurences of strings in key names
 * filter: add support for `*` (open boundary) in range expressions
+* filter: allow mixed numeric range boundaries and type coercion for range matching
 
 ### Improvements
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * ng: fix error output structure to stay consistent with non-ng
 * generic_adder: allow `None` as valid input via `add`
 * grokker: allow fallback matches without named fields
+* filter: fix lucene range expressions not matching on mixed-type scenarios
 
 ## 20.0.0
 ### Breaking

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -357,9 +357,12 @@ class NumericRangeFilterExpression(RangeBasedFilterExpression[int | float]):
 
         if isinstance(value, str):
             try:
-                value = float(value)
+                value = int(value)
             except ValueError:
-                return False
+                try:
+                    value = float(value)
+                except ValueError:
+                    return False
         # bool is a subclass of int, but must not be treated as numeric here
         elif isinstance(value, bool) or not isinstance(value, (int, float)):
             return False

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -297,33 +297,47 @@ class RangeBasedFilterExpression(KeyBasedFilterExpression, Generic[RangeBoundary
     def __init__(
         self,
         key: Sequence[str],
-        lower_bound: RangeBoundary,
-        upper_bound: RangeBoundary,
+        lower_bound: RangeBoundary | None,
+        upper_bound: RangeBoundary | None,
         include_lower_bound: bool = True,
         include_upper_bound: bool = True,
     ):
         super().__init__(key)
-        self._lower_bound: RangeBoundary = lower_bound
-        self._upper_bound: RangeBoundary = upper_bound
+        self._lower_bound: RangeBoundary | None = lower_bound
+        self._upper_bound: RangeBoundary | None = upper_bound
         self._include_lower_bound = include_lower_bound
         self._include_upper_bound = include_upper_bound
 
     def __repr__(self) -> str:
         opening_bracket = "[" if self._include_lower_bound else "{"
         closing_bracket = "]" if self._include_upper_bound else "}"
+        lower = self._format_bound(self._lower_bound)
+        upper = self._format_bound(self._upper_bound)
 
         return (
             f"{self.key_as_dotted_string}:"
-            f"{opening_bracket}{self._lower_bound} TO {self._upper_bound}"
+            f"{opening_bracket}{lower} TO {upper}"
             f"{closing_bracket}"
         )
 
+    def _format_bound(self, bound: RangeBoundary | None) -> str:
+        """Render a bound for repr, disambiguating an open side from a literal "*" value."""
+        if bound is None:
+            return "*"
+        if bound == "*":
+            return '"*"'
+        return str(bound)
+
     def _matches_lower_bound(self, value: RangeBoundary) -> bool:
+        if self._lower_bound is None:
+            return True
         if self._include_lower_bound:
             return value >= self._lower_bound
         return value > self._lower_bound
 
     def _matches_upper_bound(self, value: RangeBoundary) -> bool:
+        if self._upper_bound is None:
+            return True
         if self._include_upper_bound:
             return value <= self._upper_bound
         return value < self._upper_bound
@@ -336,40 +350,55 @@ class RangeBasedFilterExpression(KeyBasedFilterExpression, Generic[RangeBoundary
 
 
 class NumericRangeFilterExpression(RangeBasedFilterExpression[int | float]):
-    """Range based filter expression that matches for integers."""
+    """Range based filter expression that matches numeric values."""
 
     def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
-        if not isinstance(value, (int, float)):
-            if isinstance(value, str):
-                try:
-                    value = float(value)
-                except ValueError:
-                    return False
-            else:
+        if isinstance(value, str):
+            try:
+                value = float(value)
+            except ValueError:
                 return False
-        elif isinstance(value, bool):
-            # bool is a subclass of int
+        # bool is a subclass of int, but must not be treated as numeric here
+        elif isinstance(value, bool) or not isinstance(value, (int, float)):
             return False
 
         return self._matches_range(value)
 
 
 class StringRangeFilterExpression(RangeBasedFilterExpression[str]):
-    """Range based filter expression that matches for strings.
-
-    String ranges are compared lexicographically.
+    """
+    Range based filter expression that matches for strings, ints, and floats.
+    String ranges are compared lexicographically. Numerical values (int/float)
+    are converted to their string representation before comparing.
     """
 
     def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
-        # avoid comparing strings with other value types, which would raise a TypeError
-        if not isinstance(value, str):
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, (int, float)):
+            value = str(value)
+        elif not isinstance(value, str):
             return False
 
         return self._matches_range(value)
+
+    def _format_bound(self, bound: str | None) -> str:
+        """
+        Quote a numeric-looking bound, distinguishing it from a numeric range in repr
+        (e.g. ``["1" TO "10"]`` and ``[1 TO 10]``).
+        """
+        if bound is not None and bound != "*":
+            try:
+                float(bound)
+            except ValueError:
+                pass
+            else:
+                return f'"{bound}"'
+        return super()._format_bound(bound)
 
 
 class RegExFilterExpression(KeyValueBasedFilterExpression):

--- a/logprep/filter/expression/filter_expression.py
+++ b/logprep/filter/expression/filter_expression.py
@@ -5,9 +5,9 @@ from abc import ABC, abstractmethod
 from itertools import chain, zip_longest
 from typing import Any, Generic, Sequence, TypeVar
 
-from logprep.util.helper import field_list_to_dotted_field
+from logprep.util.helper import FieldValue, field_list_to_dotted_field
 
-RangeBoundary = TypeVar("RangeBoundary", int, float, str)
+RangeBoundary = TypeVar("RangeBoundary", int | float, str)
 
 
 class FilterExpressionError(Exception):
@@ -36,7 +36,7 @@ class FilterExpression(ABC):
         """
         self.children = children
 
-    def matches(self, document: dict) -> bool:
+    def matches(self, document: dict[str, FieldValue]) -> bool:
         """Receives a document and returns True if it is matched by the expression.
 
         This is a thin wrapper that only ensures that document is a dict and returns False in case a
@@ -63,7 +63,7 @@ class FilterExpression(ABC):
             return False
 
     @abstractmethod
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         """Receives a dictionary and must return True/False
 
         Based on whether the document matches the given expression.
@@ -82,12 +82,12 @@ class FilterExpression(ABC):
         """
 
     @staticmethod
-    def _get_value(key: Sequence[str], document: dict) -> Any:
+    def _get_value(key: Sequence[str], document: dict[str, FieldValue]) -> FieldValue:
         """Return the value for the given key from the document."""
         if not key:
             raise KeyDoesNotExistError
 
-        current = document
+        current: FieldValue = document
         for item in key:
             if not isinstance(current, dict):
                 raise KeyDoesNotExistError
@@ -116,7 +116,7 @@ class Always(FilterExpression):
             return "*"
         return ""
 
-    def does_match(self, document: dict):
+    def does_match(self, document: dict[str, FieldValue]):
         return self._value
 
 
@@ -129,14 +129,14 @@ class Not(FilterExpression):
     def __repr__(self) -> str:
         return f"NOT ({repr(self.children[0])})"
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         return not self.children[0].matches(document)
 
 
 class CompoundFilterExpression(FilterExpression):
     """Base class of filter expressions that combine other filter expressions."""
 
-    def does_match(self, document: dict):
+    def does_match(self, document: dict[str, FieldValue]):
         raise NotImplementedError
 
 
@@ -146,7 +146,7 @@ class And(CompoundFilterExpression):
     def __repr__(self) -> str:
         return f'({" AND ".join([str(exp) for exp in self.children])})'
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         return all((expression.matches(document) for expression in self.children))
 
 
@@ -156,7 +156,7 @@ class Or(CompoundFilterExpression):
     def __repr__(self) -> str:
         return f'({" OR ".join([str(exp) for exp in self.children])})'
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         return any((expression.matches(document) for expression in self.children))
 
 
@@ -204,7 +204,7 @@ class KeyValueBasedFilterExpression(KeyBasedFilterExpression):
 class StringFilterExpression(KeyValueBasedFilterExpression):
     """Key value filter expression that matches for a string."""
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
         if isinstance(value, list):
@@ -240,7 +240,7 @@ class WildcardStringFilterExpression(KeyValueBasedFilterExpression):
     def _normalize_regex(regex: str) -> str:
         return f"^{regex}$"
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
         if isinstance(value, list):
@@ -276,7 +276,7 @@ class SigmaFilterExpression(WildcardStringFilterExpression):
 class IntegerFilterExpression(KeyValueBasedFilterExpression):
     """Key value filter expression that matches for an integer."""
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
         return value == self._expected_value
@@ -285,7 +285,7 @@ class IntegerFilterExpression(KeyValueBasedFilterExpression):
 class FloatFilterExpression(KeyValueBasedFilterExpression):
     """Key value filter expression that matches for a float."""
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
         return value == self._expected_value
@@ -331,29 +331,26 @@ class RangeBasedFilterExpression(KeyBasedFilterExpression, Generic[RangeBoundary
     def _matches_range(self, value: RangeBoundary) -> bool:
         return self._matches_lower_bound(value) and self._matches_upper_bound(value)
 
-    def does_match(self, document: dict):
+    def does_match(self, document: dict[str, FieldValue]):
         raise NotImplementedError
 
 
-class IntegerRangeFilterExpression(RangeBasedFilterExpression[int]):
+class NumericRangeFilterExpression(RangeBasedFilterExpression[int | float]):
     """Range based filter expression that matches for integers."""
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
-        if not isinstance(value, int) or isinstance(value, bool):
-            return False
-
-        return self._matches_range(value)
-
-
-class FloatRangeFilterExpression(RangeBasedFilterExpression[float]):
-    """Range based filter expression that matches for floats."""
-
-    def does_match(self, document: dict) -> bool:
-        value = self._get_value(self.key, document)
-
-        if not isinstance(value, float) or isinstance(value, bool):
+        if not isinstance(value, (int, float)):
+            if isinstance(value, str):
+                try:
+                    value = float(value)
+                except ValueError:
+                    return False
+            else:
+                return False
+        elif isinstance(value, bool):
+            # bool is a subclass of int
             return False
 
         return self._matches_range(value)
@@ -365,10 +362,10 @@ class StringRangeFilterExpression(RangeBasedFilterExpression[str]):
     String ranges are compared lexicographically.
     """
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
-        # Avoid comparing strings with other value types, which would raise a TypeError.
+        # avoid comparing strings with other value types, which would raise a TypeError
         if not isinstance(value, str):
             return False
 
@@ -403,7 +400,7 @@ class RegExFilterExpression(KeyValueBasedFilterExpression):
         pattern = "" if pattern is None else pattern
         return rf"{flag}^{pattern}{end_token}"
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
 
         if isinstance(value, list):
@@ -417,7 +414,7 @@ class Exists(KeyBasedFilterExpression):
     def __repr__(self) -> str:
         return f"{self.key_as_dotted_string}: *"
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         if not self.key:
             return False
 
@@ -428,7 +425,7 @@ class Exists(KeyBasedFilterExpression):
                     sub_field not in current.keys()
                 ):  # .keys() is important as it is used to "check" for dict
                     return False
-                current = current[sub_field]
+                current = current[sub_field]  # type: ignore
             # Don't check for dict instance, instead just "try" for better performance
         except AttributeError as error:
             if "has no attribute 'keys'" not in error.args[0]:
@@ -444,6 +441,6 @@ class Null(KeyBasedFilterExpression):
     def __repr__(self) -> str:
         return f"{self.key_as_dotted_string}:{None}"
 
-    def does_match(self, document: dict) -> bool:
+    def does_match(self, document: dict[str, FieldValue]) -> bool:
         value = self._get_value(self.key, document)
         return value is None

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -74,7 +74,7 @@ holding :code:`"24"` matches :code:`[18 TO 65]`).
 A range mixing a numeric and a non-numeric boundary, such as :code:`[1 TO bar]`,
 falls back to a lexicographic string range instead.
 
-String range matches integer and floating-point field values too,
+String ranges match integer and floating-point field values too,
 by converting them to their string form before comparing
 (e.g. a field holding the integer :code:`5` matches :code:`[1 TO bar]`,
 since :code:`str(5)` is between :code:`"1"` and :code:`"bar"` lexicographically).
@@ -496,7 +496,7 @@ class LuceneTransformer:
             except ValueError as exc:
                 raise ValueError(f"failed to parse '{value}' as int/float") from exc
 
-        if not math.isfinite(parsed_value):
+        if isinstance(parsed_value, float) and not math.isfinite(parsed_value):
             raise ValueError(f"'{value}' is not a finite numerical value")
 
         return parsed_value

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -218,12 +218,11 @@ from logprep.filter.expression.filter_expression import (
     And,
     Exists,
     FilterExpression,
-    FloatRangeFilterExpression,
-    IntegerRangeFilterExpression,
 )
 from logprep.filter.expression.filter_expression import Not as NotExpression
 from logprep.filter.expression.filter_expression import (
     Null,
+    NumericRangeFilterExpression,
     Or,
     RangeBoundary,
     RegExFilterExpression,
@@ -407,8 +406,7 @@ class LuceneTransformer:
         upper_value = self._get_range_boundary_value(expr.high)
 
         for range_parser in (
-            self._parse_integer_range,
-            self._parse_float_range,
+            self._parse_numeric_range,
             self._parse_string_range,
         ):
             range_filter_expression = range_parser(
@@ -433,7 +431,7 @@ class LuceneTransformer:
         include_lower_bound: bool,
         include_upper_bound: bool,
         expr: Range,
-    ) -> IntegerRangeFilterExpression | None:
+    ) -> NumericRangeFilterExpression | None:
         """Create an integer range expression if both boundaries are integers."""
         try:
             lower_bound = int(lower_value)
@@ -443,7 +441,7 @@ class LuceneTransformer:
 
         LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
 
-        return IntegerRangeFilterExpression(
+        return NumericRangeFilterExpression(
             key,
             lower_bound,
             upper_bound,
@@ -452,29 +450,40 @@ class LuceneTransformer:
         )
 
     @staticmethod
-    def _parse_float_range(
+    def _parse_finite_numeric_value(value: str) -> int | float:
+        parsed_value: int | float
+        try:
+            parsed_value = int(value)
+        except ValueError:
+            try:
+                parsed_value = float(value)
+            except ValueError as exc:
+                raise ValueError(f"failed to parse '{value}' as int/float") from exc
+
+        if not math.isfinite(parsed_value):
+            raise ValueError(f"'{value}' is not a finite numerical value")
+
+        return parsed_value
+
+    @staticmethod
+    def _parse_numeric_range(
         key: Sequence[str],
         lower_value: str,
         upper_value: str,
         include_lower_bound: bool,
         include_upper_bound: bool,
         expr: Range,
-    ) -> FloatRangeFilterExpression | None:
+    ) -> NumericRangeFilterExpression | None:
         """Create a float range expression if both boundaries are finite numbers."""
         try:
-            lower_bound = float(lower_value)
-            upper_bound = float(upper_value)
+            lower_bound = LuceneTransformer._parse_finite_numeric_value(lower_value)
+            upper_bound = LuceneTransformer._parse_finite_numeric_value(upper_value)
         except ValueError:
             return None
 
-        if not math.isfinite(lower_bound) or not math.isfinite(upper_bound):
-            raise LuceneFilterError(
-                f'The expression "{expr}" is invalid. ' "Range boundaries must be finite numbers."
-            )
-
         LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
 
-        return FloatRangeFilterExpression(
+        return NumericRangeFilterExpression(
             key,
             lower_bound,
             upper_bound,

--- a/logprep/filter/lucene_filter.py
+++ b/logprep/filter/lucene_filter.py
@@ -1,5 +1,4 @@
 # pylint: disable=anomalous-backslash-in-string
-# pylint: disable=too-many-positional-arguments
 # pylint: disable=too-many-return-statements
 r"""
 Filter
@@ -65,11 +64,23 @@ Range-Filter
 
 It is possible to use range expressions to match integer, floating-point, and
 string values. Square brackets include a boundary, while curly brackets exclude
-a boundary. String ranges are compared lexicographically.
+a boundary. A range is only treated as numeric if all non-open boundaries parse as
+finite integers or floats; any other range is compared lexicographically as a
+string range instead.
 
-The lower and upper boundaries of a range must have the same type. Mixed ranges
-such as integer-to-float, integer-to-string, or float-to-string are not
-supported.
+Numeric range boundaries may freely mix integers and floats, and match integer,
+floating-point, and numeric-looking string values in documents (e.g. a field
+holding :code:`"24"` matches :code:`[18 TO 65]`).
+A range mixing a numeric and a non-numeric boundary, such as :code:`[1 TO bar]`,
+falls back to a lexicographic string range instead.
+
+String range matches integer and floating-point field values too,
+by converting them to their string form before comparing
+(e.g. a field holding the integer :code:`5` matches :code:`[1 TO bar]`,
+since :code:`str(5)` is between :code:`"1"` and :code:`"bar"` lexicographically).
+In both directions, boolean values are never coerced.
+Note that :code:`5.0` is represented as :code:`"5.0"` which affects matching in
+string ranges.
 
 
 ..  code-block:: yaml
@@ -141,6 +152,22 @@ required, for example, for ISO-8601 timestamps with timezone offsets:
     filter: 'timestamp:["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]'
 
 
+Quoting a numeric-looking boundary forces a lexicographic string comparison
+instead of a numeric one, even though the text looks like a number:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'id:["1" TO "10"]'
+
+
+The example compares :code:`id` as a string, not as the numeric range
+:code:`[1 TO 10]` - so :code:`"2"` doesn't match, since it sorts after
+:code:`"10"` lexicographically. Quoting either boundary is enough to force the
+whole range to string comparison.
+
 Range expressions can also be used within field groups:
 
 
@@ -151,9 +178,37 @@ Range expressions can also be used within field groups:
     filter: 'temperature:([18.5 TO 25.0])'
 
 
-Open boundaries using :code:`*`, non-finite numeric boundaries, mixed boundary
-types, and unquoted boundaries containing Lucene special characters are not
-supported.
+An open boundary using an unquoted :code:`*` means "no restriction" on that
+side of the range:
+
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'age:[18 TO *]'
+
+
+The example matches log messages in which the value of :code:`age` is greater
+than or equal to :code:`18`, with no upper limit.
+
+The special case :code:`[* TO *]` matches all values of any type:
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Example
+
+    filter: 'age:[* TO *]'
+
+
+The example matches any log message in which :code:`age` is present, no
+matter what value or type it holds. A quoted :code:`"*"` is a literal asterisk,
+not an open boundary, and is matched or compared like any other value.
+
+Unquoted boundaries containing Lucene special characters are not supported.
+Terms such as :code:`nan` or :code:`inf` are not treated as numbers, so a
+range using one (or mixing a numeric and a non-numeric boundary) falls back
+to a lexicographic string comparison rather than being rejected.
 
 RegEx-Filter
 ------------
@@ -239,11 +294,11 @@ logger = logging.getLogger("LuceneFilter")
 
 
 class LuceneFilterError(LogprepException):
-    """Base class for LuceneFilter related exceptions."""
+    """Base class for LuceneFilter related exceptions"""
 
 
 class LuceneFilter:
-    """A filter that allows using lucene query strings."""
+    """A filter that allows using lucene query strings"""
 
     last_quotation_pattern = re.compile(r'((?:\\)+")$')
     quote_escaping_pattern = re.compile(r'(?:\\)+"')
@@ -287,7 +342,7 @@ class LuceneFilter:
 
     @staticmethod
     def _add_lucene_escaping(string: str) -> str:
-        """Escape double quotes so that the string can be parsed by lucene."""
+        """Escape double quotes so that the string can be parsed by lucene"""
 
         string = LuceneFilter._make_uneven_double_quotes_escaping(string)
         string = LuceneFilter._escape_ends_of_expressions(string)
@@ -337,7 +392,7 @@ class LuceneFilter:
 
 
 class LuceneTransformer:
-    """A transformer that converts a luqum tree into a FilterExpression."""
+    """A transformer that converts a luqum tree into a FilterExpression"""
 
     _special_fields_map: dict[str, type[RegExFilterExpression] | type[SigmaFilterExpression]] = {
         "regex_fields": RegExFilterExpression,
@@ -402,55 +457,36 @@ class LuceneTransformer:
         raise LuceneFilterError(f'The expression "{str(tree)}" is invalid!')
 
     def _parse_range(self, key: Sequence[str], expr: Range) -> FilterExpression:
-        lower_value = self._get_range_boundary_value(expr.low)
-        upper_value = self._get_range_boundary_value(expr.high)
+        lower = self._get_range_boundary(expr.low)
+        upper = self._get_range_boundary(expr.high)
 
-        for range_parser in (
-            self._parse_numeric_range,
-            self._parse_string_range,
-        ):
-            range_filter_expression = range_parser(
-                key,
-                lower_value,
-                upper_value,
-                expr.include_low,
-                expr.include_high,
-                expr,
-            )
+        if lower is None and upper is None:
+            # [* TO *] translates to "field exists"
+            return Exists(key)
 
-            if range_filter_expression is not None:
-                return range_filter_expression
+        quoted = self._is_quoted_boundary(expr.low) or self._is_quoted_boundary(expr.high)
 
-        raise LuceneFilterError(f'The expression "{expr}" is invalid!')
+        if not quoted:
+            numeric_range = self._parse_numeric_range(key, lower, upper, expr)
+            if numeric_range is not None:
+                return numeric_range
+
+        return self._parse_string_range(key, lower, upper, expr)
 
     @staticmethod
-    def _parse_integer_range(
-        key: Sequence[str],
-        lower_value: str,
-        upper_value: str,
-        include_lower_bound: bool,
-        include_upper_bound: bool,
-        expr: Range,
-    ) -> NumericRangeFilterExpression | None:
-        """Create an integer range expression if both boundaries are integers."""
-        try:
-            lower_bound = int(lower_value)
-            upper_bound = int(upper_value)
-        except ValueError:
+    def _is_quoted_boundary(token: luqum.tree) -> bool:
+        """Return whether a range boundary was written as a quoted phrase"""
+        return isinstance(token, Phrase)
+
+    @staticmethod
+    def _get_range_boundary(token: luqum.tree) -> str | None:
+        """Return a range boundary's value, or `None` if it is an open, unquoted `*`"""
+        if isinstance(token, Word) and token.value == "*":
             return None
-
-        LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
-
-        return NumericRangeFilterExpression(
-            key,
-            lower_bound,
-            upper_bound,
-            include_lower_bound,
-            include_upper_bound,
-        )
+        return LuceneTransformer._get_range_boundary_value(token)
 
     @staticmethod
-    def _parse_finite_numeric_value(value: str) -> int | float:
+    def _parse_numeric(value: str) -> int | float:
         parsed_value: int | float
         try:
             parsed_value = int(value)
@@ -468,66 +504,36 @@ class LuceneTransformer:
     @staticmethod
     def _parse_numeric_range(
         key: Sequence[str],
-        lower_value: str,
-        upper_value: str,
-        include_lower_bound: bool,
-        include_upper_bound: bool,
+        lower: str | None,
+        upper: str | None,
         expr: Range,
     ) -> NumericRangeFilterExpression | None:
-        """Create a float range expression if both boundaries are finite numbers."""
+        """Create a numeric range if the non-None boundaries parse as finite int/float"""
         try:
-            lower_bound = LuceneTransformer._parse_finite_numeric_value(lower_value)
-            upper_bound = LuceneTransformer._parse_finite_numeric_value(upper_value)
+            lower_numeric = LuceneTransformer._parse_numeric(lower) if lower is not None else None
+            upper_numeric = LuceneTransformer._parse_numeric(upper) if upper is not None else None
         except ValueError:
             return None
 
-        LuceneTransformer._validate_range_boundaries(lower_bound, upper_bound, expr)
+        if lower_numeric is not None and upper_numeric is not None:
+            LuceneTransformer._validate_range_boundaries(lower_numeric, upper_numeric, expr)
 
         return NumericRangeFilterExpression(
-            key,
-            lower_bound,
-            upper_bound,
-            include_lower_bound,
-            include_upper_bound,
+            key, lower_numeric, upper_numeric, expr.include_low, expr.include_high
         )
 
     @staticmethod
     def _parse_string_range(
         key: Sequence[str],
-        lower_value: str,
-        upper_value: str,
-        include_lower_bound: bool,
-        include_upper_bound: bool,
+        lower: str | None,
+        upper: str | None,
         expr: Range,
-    ) -> StringRangeFilterExpression | None:
-        """Create a lexicographic string range expression for non-numeric boundaries."""
-        if lower_value == "*" or upper_value == "*":
-            raise LuceneFilterError(f'The expression "{expr}" is invalid!')
+    ) -> StringRangeFilterExpression:
+        """Create a lexicographic string range"""
+        if lower is not None and upper is not None:
+            LuceneTransformer._validate_range_boundaries(lower, upper, expr)
 
-        if LuceneTransformer._is_finite_numeric_range_boundary(
-            lower_value
-        ) or LuceneTransformer._is_finite_numeric_range_boundary(upper_value):
-            return None
-
-        LuceneTransformer._validate_range_boundaries(lower_value, upper_value, expr)
-
-        return StringRangeFilterExpression(
-            key,
-            lower_value,
-            upper_value,
-            include_lower_bound,
-            include_upper_bound,
-        )
-
-    @staticmethod
-    def _is_finite_numeric_range_boundary(value: str) -> bool:
-        """Return whether a range boundary can be interpreted as a finite number."""
-        try:
-            numeric_value = float(value)
-        except ValueError:
-            return False
-
-        return math.isfinite(numeric_value)
+        return StringRangeFilterExpression(key, lower, upper, expr.include_low, expr.include_high)
 
     @staticmethod
     def _get_range_boundary_value(token: luqum.tree) -> str:
@@ -573,7 +579,7 @@ class LuceneTransformer:
 
         if lower_bound > upper_bound:
             raise LuceneFilterError(
-                "The lower range boundary must not exceed " f'the upper range boundary: "{expr}"'
+                f'The lower range boundary must not exceed the upper range boundary: "{expr}"'
             )
 
     def _create_field_group_expression(
@@ -689,7 +695,7 @@ class LuceneTransformer:
 
     @staticmethod
     def _remove_lucene_escaping(string: str) -> str:
-        """Remove previously added lucene escaping."""
+        """Remove previously added lucene escaping"""
         string = LuceneTransformer._remove_escaping_from_end_of_expression(string)
         string = LuceneTransformer._remove_uneven_double_quotes_escaping(string)
         string = LuceneTransformer._remove_one_escaping_from_quotes(string)
@@ -738,7 +744,7 @@ class LuceneTransformer:
 
     @staticmethod
     def _remove_one_escaping_from_quotes(string: str) -> str:
-        """Remove one backslash from quotes, since it is only used by lucene but not filters."""
+        """Remove one backslash from quotes, since it is only used by lucene but not filters"""
         matches = LuceneTransformer.find_unescaping_quote_pattern.findall(string)
         if matches is None:
             return string

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -246,16 +246,36 @@ class TestNumericRangeFilterExpression(ValueBasedFilterExpressionTest):
         self.filter = NumericRangeFilterExpression(["key1", "key2"], 23, 42)
         self.filter_identical = NumericRangeFilterExpression(["key1", "key2"], 23, 42)
 
-    def test_string_representation(self):
-        assert str(self.filter) == "key1.key2:[23 TO 42]"
+    @pytest.mark.parametrize(
+        ["value", "expected"],
+        [
+            pytest.param(22, False, id="below-lower-bound"),
+            pytest.param(23, True, id="lower-bound-inclusive"),
+            pytest.param(30, True, id="int-in-range"),
+            pytest.param(42, True, id="upper-bound-inclusive"),
+            pytest.param(43, False, id="above-upper-bound"),
+            pytest.param(24.0, True, id="float-in-range"),
+            pytest.param("24", True, id="numeric-string-in-range"),
+            pytest.param("100", False, id="numeric-string-out-of-range"),
+            pytest.param("abc", False, id="non-numeric-string"),
+        ],
+    )
+    def test_does_match(self, value, expected):
+        assert self.filter.matches({"key1": {"key2": value}}) == expected
 
-    def test_string_representation_with_float_bounds(self):
-        numeric_range = NumericRangeFilterExpression(["key1", "key2"], 23.0, 42.0)
-        assert str(numeric_range) == "key1.key2:[23.0 TO 42.0]"
-
-    def test_string_representation_with_open_bound(self):
-        open_upper = NumericRangeFilterExpression(["key1", "key2"], 23, None)
-        assert str(open_upper) == "key1.key2:[23 TO *]"
+    @pytest.mark.parametrize(
+        ["lower", "upper", "expected"],
+        [
+            pytest.param(23, 42, "key1.key2:[23 TO 42]", id="int-bounds"),
+            pytest.param(23.0, 42.0, "key1.key2:[23.0 TO 42.0]", id="float-bounds"),
+            pytest.param(23.0, 42, "key1.key2:[23.0 TO 42]", id="mixed-bounds"),
+            pytest.param(None, 42, "key1.key2:[* TO 42]", id="lower-open-bound"),
+            pytest.param(23.0, None, "key1.key2:[23.0 TO *]", id="upper-open-bound"),
+        ],
+    )
+    def test_string_representation(self, lower, upper, expected):
+        numeric_range = NumericRangeFilterExpression(["key1", "key2"], lower, upper)
+        assert str(numeric_range) == expected
 
     def test_open_lower_bound_matches_any_value_up_to_upper_bound(self):
         open_lower = NumericRangeFilterExpression(["key1", "key2"], None, 42)
@@ -269,19 +289,6 @@ class TestNumericRangeFilterExpression(ValueBasedFilterExpressionTest):
         assert open_upper.matches({"key1": {"key2": 10**9}})
         assert not open_upper.matches({"key1": {"key2": 22}})
 
-    def test_does_not_match_if_value_is_below_lower_bound(self):
-        assert not self.filter.matches({"key1": {"key2": 23 - 1}})
-
-    def test_does_not_match_if_value_is_above_upper_bound(self):
-        assert not self.filter.matches({"key1": {"key2": 42 + 1}})
-
-    def test_does_match_when_value_is_in_range_as_int(self):
-        for i in range(23, 43):
-            assert self.filter.matches({"key1": {"key2": i}})
-
-    def test_does_match_when_value_is_in_range_as_float(self):
-        assert self.filter.matches({"key1": {"key2": 24.0}})
-
     def test_does_not_match_when_value_is_bool(self):
         assert isinstance(True, int) and int(True) == 1
         assert isinstance(False, int) and int(False) == 0
@@ -290,53 +297,40 @@ class TestNumericRangeFilterExpression(ValueBasedFilterExpressionTest):
         assert not zero_to_one.matches({"key1": {"key2": True}})
         assert not zero_to_one.matches({"key1": {"key2": False}})
 
-    def test_does_match_when_value_is_numeric_string(self):
-        assert self.filter.matches({"key1": {"key2": "24"}})
-
-    def test_does_not_match_when_numeric_string_is_out_of_range(self):
-        assert not self.filter.matches({"key1": {"key2": "100"}})
-
-    def test_does_not_match_when_value_is_non_numeric_string(self):
-        assert not self.filter.matches({"key1": {"key2": "abc"}})
-
 
 class TestStringRangeFilterExpression(ValueBasedFilterExpressionTest):
     def setup_method(self, _):
         self.filter = StringRangeFilterExpression(["key1", "key2"], "bar", "foo")
         self.filter_identical = StringRangeFilterExpression(["key1", "key2"], "bar", "foo")
 
-    def test_string_representation(self):
-        assert str(self.filter) == "key1.key2:[bar TO foo]"
+    @pytest.mark.parametrize(
+        ["value", "expected"],
+        [
+            pytest.param("baa", False, id="below-lower-bound"),
+            pytest.param("bar", True, id="lower-bound-inclusive"),
+            pytest.param("car", True, id="string-in-range"),
+            pytest.param("foo", True, id="upper-bound-inclusive"),
+            pytest.param("fop", False, id="above-upper-bound"),
+            pytest.param([], False, id="list"),
+            pytest.param({}, False, id="dict"),
+        ],
+    )
+    def test_does_match(self, value, expected):
+        assert self.filter.matches({"key1": {"key2": value}}) == expected
 
-    def test_string_representation_quotes_numeric_looking_bounds(self):
-        numeric_looking = StringRangeFilterExpression(["key1", "key2"], "1", "10")
-        assert str(numeric_looking) == 'key1.key2:["1" TO "10"]'
-
-    def test_does_not_match_if_value_is_below_lower_bound(self):
-        assert not self.filter.matches({"key1": {"key2": "baa"}})
-
-    def test_does_not_match_if_value_is_above_upper_bound(self):
-        assert not self.filter.matches({"key1": {"key2": "fop"}})
-
-    def test_does_match_when_value_is_in_range(self):
-        assert self.filter.matches({"key1": {"key2": "car"}})
-
-    def test_does_not_match_when_value_is_bool(self):
-        az_range = StringRangeFilterExpression(["key1", "key2"], "A", "Z")
-        assert not az_range.matches({"key1": {"key2": True}})
-        assert not az_range.matches({"key1": {"key2": False}})
-
-    def test_does_match_when_value_is_int_in_range(self):
-        digits_range = StringRangeFilterExpression(["key1", "key2"], "1", "9")
-        assert digits_range.matches({"key1": {"key2": 5}})
-
-    def test_does_match_when_value_is_float_in_range(self):
-        digits_range = StringRangeFilterExpression(["key1", "key2"], "1", "9")
-        assert digits_range.matches({"key1": {"key2": 5.5}})
-
-    def test_does_not_match_when_value_is_list_or_dict(self):
-        assert not self.filter.matches({"key1": {"key2": []}})
-        assert not self.filter.matches({"key1": {"key2": {}}})
+    @pytest.mark.parametrize(
+        ["lower", "upper", "expected"],
+        [
+            pytest.param("bar", "foo", "key1.key2:[bar TO foo]", id="standard-bounds"),
+            pytest.param(None, "foo", "key1.key2:[* TO foo]", id="lower-open-bound"),
+            pytest.param("bar", None, "key1.key2:[bar TO *]", id="upper-open-bound"),
+            pytest.param("*", "*", 'key1.key2:["*" TO "*"]', id="asterisk-bounds"),
+            pytest.param("-10.5", "10", 'key1.key2:["-10.5" TO "10"]', id="numeric-bounds"),
+        ],
+    )
+    def test_string_representation(self, lower, upper, expected):
+        numeric_range = StringRangeFilterExpression(["key1", "key2"], lower, upper)
+        assert str(numeric_range) == expected
 
 
 class TestRegExFilterExpression(ValueBasedFilterExpressionTest):

--- a/tests/unit/filter/test_filter_expression.py
+++ b/tests/unit/filter/test_filter_expression.py
@@ -13,15 +13,15 @@ from logprep.filter.expression.filter_expression import (
     Exists,
     FilterExpression,
     FloatFilterExpression,
-    FloatRangeFilterExpression,
     IntegerFilterExpression,
-    IntegerRangeFilterExpression,
     KeyDoesNotExistError,
     Not,
+    NumericRangeFilterExpression,
     Or,
     RegExFilterExpression,
     SigmaFilterExpression,
     StringFilterExpression,
+    StringRangeFilterExpression,
     WildcardStringFilterExpression,
 )
 from logprep.filter.lucene_filter import LuceneFilter
@@ -241,13 +241,33 @@ class TestFloatFilterExpression(ValueBasedFilterExpressionTest):
         assert self.filter.matches({"key1": {"key2": self.expected_value}})
 
 
-class TestIntegerRangeFilterExpression(ValueBasedFilterExpressionTest):
+class TestNumericRangeFilterExpression(ValueBasedFilterExpressionTest):
     def setup_method(self, _):
-        self.filter = IntegerRangeFilterExpression(["key1", "key2"], 23, 42)
-        self.filter_identical = IntegerRangeFilterExpression(["key1", "key2"], 23, 42)
+        self.filter = NumericRangeFilterExpression(["key1", "key2"], 23, 42)
+        self.filter_identical = NumericRangeFilterExpression(["key1", "key2"], 23, 42)
 
     def test_string_representation(self):
         assert str(self.filter) == "key1.key2:[23 TO 42]"
+
+    def test_string_representation_with_float_bounds(self):
+        numeric_range = NumericRangeFilterExpression(["key1", "key2"], 23.0, 42.0)
+        assert str(numeric_range) == "key1.key2:[23.0 TO 42.0]"
+
+    def test_string_representation_with_open_bound(self):
+        open_upper = NumericRangeFilterExpression(["key1", "key2"], 23, None)
+        assert str(open_upper) == "key1.key2:[23 TO *]"
+
+    def test_open_lower_bound_matches_any_value_up_to_upper_bound(self):
+        open_lower = NumericRangeFilterExpression(["key1", "key2"], None, 42)
+        assert open_lower.matches({"key1": {"key2": -(10**9)}})
+        assert open_lower.matches({"key1": {"key2": 42}})
+        assert not open_lower.matches({"key1": {"key2": 43}})
+
+    def test_open_upper_bound_matches_any_value_from_lower_bound(self):
+        open_upper = NumericRangeFilterExpression(["key1", "key2"], 23, None)
+        assert open_upper.matches({"key1": {"key2": 23}})
+        assert open_upper.matches({"key1": {"key2": 10**9}})
+        assert not open_upper.matches({"key1": {"key2": 22}})
 
     def test_does_not_match_if_value_is_below_lower_bound(self):
         assert not self.filter.matches({"key1": {"key2": 23 - 1}})
@@ -255,31 +275,68 @@ class TestIntegerRangeFilterExpression(ValueBasedFilterExpressionTest):
     def test_does_not_match_if_value_is_above_upper_bound(self):
         assert not self.filter.matches({"key1": {"key2": 42 + 1}})
 
-    def test_does_not_match_when_value_is_in_range_but_as_float(self):
-        assert not self.filter.matches({"key1": {"key2": 24.0}})
-
-    def test_does_match_when_value_is_in_range(self):
+    def test_does_match_when_value_is_in_range_as_int(self):
         for i in range(23, 43):
             assert self.filter.matches({"key1": {"key2": i}})
 
+    def test_does_match_when_value_is_in_range_as_float(self):
+        assert self.filter.matches({"key1": {"key2": 24.0}})
 
-class TestFloatRangeFilterExpression(ValueBasedFilterExpressionTest):
+    def test_does_not_match_when_value_is_bool(self):
+        assert isinstance(True, int) and int(True) == 1
+        assert isinstance(False, int) and int(False) == 0
+
+        zero_to_one = NumericRangeFilterExpression(["key1", "key2"], 0, 1)
+        assert not zero_to_one.matches({"key1": {"key2": True}})
+        assert not zero_to_one.matches({"key1": {"key2": False}})
+
+    def test_does_match_when_value_is_numeric_string(self):
+        assert self.filter.matches({"key1": {"key2": "24"}})
+
+    def test_does_not_match_when_numeric_string_is_out_of_range(self):
+        assert not self.filter.matches({"key1": {"key2": "100"}})
+
+    def test_does_not_match_when_value_is_non_numeric_string(self):
+        assert not self.filter.matches({"key1": {"key2": "abc"}})
+
+
+class TestStringRangeFilterExpression(ValueBasedFilterExpressionTest):
     def setup_method(self, _):
-        self.filter = FloatRangeFilterExpression(["key1", "key2"], 23.0, 42.0)
-        self.filter_identical = FloatRangeFilterExpression(["key1", "key2"], 23.0, 42.0)
+        self.filter = StringRangeFilterExpression(["key1", "key2"], "bar", "foo")
+        self.filter_identical = StringRangeFilterExpression(["key1", "key2"], "bar", "foo")
 
     def test_string_representation(self):
-        assert str(self.filter) == "key1.key2:[23.0 TO 42.0]"
+        assert str(self.filter) == "key1.key2:[bar TO foo]"
+
+    def test_string_representation_quotes_numeric_looking_bounds(self):
+        numeric_looking = StringRangeFilterExpression(["key1", "key2"], "1", "10")
+        assert str(numeric_looking) == 'key1.key2:["1" TO "10"]'
 
     def test_does_not_match_if_value_is_below_lower_bound(self):
-        assert not self.filter.matches({"key1": {"key2": 23.0 - 1.0}})
+        assert not self.filter.matches({"key1": {"key2": "baa"}})
 
     def test_does_not_match_if_value_is_above_upper_bound(self):
-        assert not self.filter.matches({"key1": {"key2": 42.0 + 1.0}})
+        assert not self.filter.matches({"key1": {"key2": "fop"}})
 
     def test_does_match_when_value_is_in_range(self):
-        for i in range(23, 43):
-            assert self.filter.matches({"key1": {"key2": float(i)}})
+        assert self.filter.matches({"key1": {"key2": "car"}})
+
+    def test_does_not_match_when_value_is_bool(self):
+        az_range = StringRangeFilterExpression(["key1", "key2"], "A", "Z")
+        assert not az_range.matches({"key1": {"key2": True}})
+        assert not az_range.matches({"key1": {"key2": False}})
+
+    def test_does_match_when_value_is_int_in_range(self):
+        digits_range = StringRangeFilterExpression(["key1", "key2"], "1", "9")
+        assert digits_range.matches({"key1": {"key2": 5}})
+
+    def test_does_match_when_value_is_float_in_range(self):
+        digits_range = StringRangeFilterExpression(["key1", "key2"], "1", "9")
+        assert digits_range.matches({"key1": {"key2": 5.5}})
+
+    def test_does_not_match_when_value_is_list_or_dict(self):
+        assert not self.filter.matches({"key1": {"key2": []}})
+        assert not self.filter.matches({"key1": {"key2": {}}})
 
 
 class TestRegExFilterExpression(ValueBasedFilterExpressionTest):
@@ -851,7 +908,7 @@ class TestLuceneRepresentation:
                 id="integer-field-group-ranges-with-and-to-other-field",
             ),
             pytest.param(
-                "temperature:([18.5 TO 25.0] OR [33.5 TO 55.0]) " "AND status:[ok TO stable]",
+                "temperature:([18.5 TO 25.0] OR [33.5 TO 55.0]) AND status:[ok TO stable]",
                 (
                     {"temperature": 20.0, "status": "ok"},
                     {"temperature": 40.0, "status": "stable"},

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -27,6 +27,7 @@ from logprep.filter.lucene_filter import (
 
 
 @pytest.fixture(
+    name="range_query",
     params=(
         pytest.param(
             "key:{range_expression}",
@@ -36,9 +37,9 @@ from logprep.filter.lucene_filter import (
             "key:({range_expression})",
             id="field-group-range",
         ),
-    )
+    ),
 )
-def range_query(request):
+def fixture_range_query(request):
     def create_query(range_expression: str) -> str:
         return request.param.format(range_expression=range_expression)
 
@@ -927,16 +928,10 @@ class TestLueceneFilter:
         ("range_expression", "matching_value", "wrong_values"),
         (
             pytest.param(
-                "[0 TO 10]",
-                5,
-                ("5", 5.0, object()),
-                id="integer-range-does-not-match-non-integer-document-values",
-            ),
-            pytest.param(
-                "[0.1 TO 8.5]",
+                "[-3 TO 8.5]",
                 5.0,
-                ("5.0", 5, object()),
-                id="float-range-does-not-match-non-float-document-values",
+                ("5.0", 5, [], {}),
+                id="numeric-range-does-not-match-non-float-document-values",
             ),
             pytest.param(
                 "[bar TO foo]",
@@ -986,6 +981,18 @@ class TestLueceneFilter:
             pytest.param(
                 "[1.5 TO 1.5}",
                 id="exclusive-upper-float-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{1.0 TO 1}",
+                id="exclusive-mixed-numeric-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "{1.0 TO 1]",
+                id="exclusive-lower-mixed-numeric-range-with-equal-boundaries",
+            ),
+            pytest.param(
+                "[1.0 TO 1}",
+                id="exclusive-upper-mixed-numeric-range-with-equal-boundaries",
             ),
             pytest.param(
                 "{abc TO abc}",
@@ -1046,6 +1053,22 @@ class TestLueceneFilter:
             pytest.param(
                 "[-1.5 TO 1.5}",
                 id="float-inclusive-exclusive-range",
+            ),
+            pytest.param(
+                "[-1 TO 1.0]",
+                id="mixed-numeric-inclusive-range",
+            ),
+            pytest.param(
+                "{-1 TO 1.0}",
+                id="mixed-numeric-exclusive-range",
+            ),
+            pytest.param(
+                "{-1 TO 1.0]",
+                id="mixed-numeric-exclusive-inclusive-range",
+            ),
+            pytest.param(
+                "[-1 TO 1.0}",
+                id="mixed-numeric-inclusive-exclusive-range",
             ),
             pytest.param(
                 "[bar TO foo]",
@@ -1352,26 +1375,6 @@ class TestLueceneFilter:
             ),
         ):
             LuceneFilter.create(range_query(range_expression))
-
-    def test_created_range_filter_prefers_integer_range_over_string_range(
-        self,
-        range_query,
-    ):
-        lucene_filter = LuceneFilter.create(range_query("[1 TO 10]"))
-
-        assert lucene_filter.matches({"key": 2})
-        assert lucene_filter.matches({"key": 10})
-        assert not lucene_filter.matches({"key": "2"})
-
-    def test_created_range_filter_prefers_float_range_over_string_range(
-        self,
-        range_query,
-    ):
-        lucene_filter = LuceneFilter.create(range_query("[1.5 TO 10.5]"))
-
-        assert lucene_filter.matches({"key": 2.0})
-        assert lucene_filter.matches({"key": 10.5})
-        assert not lucene_filter.matches({"key": "2.0"})
 
     @pytest.mark.parametrize(
         ("range_expression", "matching_values", "non_matching_values"),

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -29,14 +29,8 @@ from logprep.filter.lucene_filter import (
 @pytest.fixture(
     name="range_query",
     params=(
-        pytest.param(
-            "key:{range_expression}",
-            id="search-field-range",
-        ),
-        pytest.param(
-            "key:({range_expression})",
-            id="field-group-range",
-        ),
+        pytest.param("key:{range_expression}", id="search-field-range"),
+        pytest.param("key:({range_expression})", id="field-group-range"),
     ),
 )
 def fixture_range_query(request):
@@ -601,37 +595,37 @@ class TestLueceneFilter:
                 "[0 TO 10]",
                 (0, 5, 10),
                 (-1, 11),
-                id="positive-integer-range-including-boundaries",
+                id="pos-int-range-incl-bounds",
             ),
             pytest.param(
                 "[-10 TO -1]",
                 (-10, -5, -1),
                 (-11, 0),
-                id="negative-integer-range",
+                id="neg-int-range",
             ),
             pytest.param(
                 "[-10 TO 10]",
                 (-10, 0, 10),
                 (-11, 11),
-                id="integer-range-across-zero",
+                id="int-range-across-zero",
             ),
             pytest.param(
                 "[0 TO 0]",
                 (0,),
                 (-1, 1),
-                id="single-integer-value-range",
+                id="single-int-value-range",
             ),
             pytest.param(
                 "[2147483647 TO 2147483648]",
                 (2147483647, 2147483648),
                 (2147483646, 2147483649),
-                id="integer-values-above-32-bit-boundary",
+                id="int-values-above-32-bit-bound",
             ),
             pytest.param(
                 "[-9223372036854775809 TO -9223372036854775808]",
                 (-9223372036854775809, -9223372036854775808),
                 (-9223372036854775810, -9223372036854775807),
-                id="integer-values-below-64-bit-boundary",
+                id="int-values-below-64-bit-bound",
             ),
         ),
     )
@@ -657,13 +651,13 @@ class TestLueceneFilter:
                 "[0.1 TO 8.5]",
                 (0.1, 5.0, 8.5),
                 (0.099, 8.501),
-                id="positive-float-range-including-boundaries",
+                id="pos-float-range-incl-bounds",
             ),
             pytest.param(
                 "[-8.5 TO -0.1]",
                 (-8.5, -4.2, -0.1),
                 (-8.501, 0),
-                id="negative-float-range",
+                id="neg-float-range",
             ),
             pytest.param(
                 "[-1.5 TO 1.5]",
@@ -687,7 +681,7 @@ class TestLueceneFilter:
                 "[-1.0e3 TO -1.0e-3]",
                 (-1000.0, -1.0, -0.001),
                 (-1000.1, 0.0),
-                id="negative-scientific-notation",
+                id="neg-scientific-notation",
             ),
         ),
     )
@@ -713,7 +707,7 @@ class TestLueceneFilter:
                 "[bar TO foo]",
                 ("bar", "baz", "foo"),
                 ("aaa", "zoo"),
-                id="string-range-including-boundaries",
+                id="string-range-incl-bounds",
             ),
             pytest.param(
                 "[a TO z]",
@@ -763,43 +757,43 @@ class TestLueceneFilter:
                 "[0 TO 10]",
                 (0, 5, 10),
                 (-1, 11),
-                id="integer-inclusive-lower-inclusive-upper",
+                id="int-incl-lower-incl-upper",
             ),
             pytest.param(
                 "{0 TO 10}",
                 (1, 5, 9),
                 (-1, 0, 10, 11),
-                id="integer-exclusive-lower-exclusive-upper",
+                id="int-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{0 TO 10]",
                 (1, 5, 10),
                 (-1, 0, 11),
-                id="integer-exclusive-lower-inclusive-upper",
+                id="int-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[0 TO 10}",
                 (0, 5, 9),
                 (-1, 10, 11),
-                id="integer-inclusive-lower-exclusive-upper",
+                id="int-incl-lower-excl-upper",
             ),
             pytest.param(
                 "{-10 TO -1}",
                 (-9, -5, -2),
                 (-10, -1, 0),
-                id="negative-integer-exclusive-lower-exclusive-upper",
+                id="neg-int-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{-10 TO -1]",
                 (-9, -5, -1),
                 (-10, 0),
-                id="negative-integer-exclusive-lower-inclusive-upper",
+                id="neg-int-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[-10 TO -1}",
                 (-10, -5, -2),
                 (-11, -1, 0),
-                id="negative-integer-inclusive-lower-exclusive-upper",
+                id="neg-int-incl-lower-excl-upper",
             ),
         ),
     )
@@ -825,43 +819,43 @@ class TestLueceneFilter:
                 "[0.1 TO 8.5]",
                 (0.1, 5.0, 8.5),
                 (0.099, 8.501),
-                id="float-inclusive-lower-inclusive-upper",
+                id="float-incl-lower-incl-upper",
             ),
             pytest.param(
                 "{0.1 TO 8.5}",
                 (0.101, 5.0, 8.499),
                 (0.1, 8.5),
-                id="float-exclusive-lower-exclusive-upper",
+                id="float-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{0.1 TO 8.5]",
                 (0.101, 5.0, 8.5),
                 (0.1, 8.501),
-                id="float-exclusive-lower-inclusive-upper",
+                id="float-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[0.1 TO 8.5}",
                 (0.1, 5.0, 8.499),
                 (0.099, 8.5),
-                id="float-inclusive-lower-exclusive-upper",
+                id="float-incl-lower-excl-upper",
             ),
             pytest.param(
                 "{-8.5 TO -0.1}",
                 (-8.499, -4.2, -0.101),
                 (-8.5, -0.1, 0),
-                id="negative-float-exclusive-lower-exclusive-upper",
+                id="neg-float-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{-8.5 TO -0.1]",
                 (-8.499, -4.2, -0.1),
                 (-8.5, 0),
-                id="negative-float-exclusive-lower-inclusive-upper",
+                id="neg-float-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[-8.5 TO -0.1}",
                 (-8.5, -4.2, -0.101),
                 (-8.501, -0.1, 0),
-                id="negative-float-inclusive-lower-exclusive-upper",
+                id="neg-float-incl-lower-excl-upper",
             ),
         ),
     )
@@ -887,25 +881,25 @@ class TestLueceneFilter:
                 "[bar TO foo]",
                 ("bar", "baz", "foo"),
                 ("aaa", "zoo"),
-                id="string-inclusive-lower-inclusive-upper",
+                id="string-incl-lower-incl-upper",
             ),
             pytest.param(
                 "{bar TO foo}",
                 ("baz", "faa"),
                 ("bar", "foo", "aaa", "zoo"),
-                id="string-exclusive-lower-exclusive-upper",
+                id="string-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{bar TO foo]",
                 ("baz", "foo"),
                 ("bar", "aaa", "zoo"),
-                id="string-exclusive-lower-inclusive-upper",
+                id="string-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[bar TO foo}",
                 ("bar", "baz"),
                 ("foo", "aaa", "zoo"),
-                id="string-inclusive-lower-exclusive-upper",
+                id="string-incl-lower-excl-upper",
             ),
         ),
     )
@@ -930,14 +924,14 @@ class TestLueceneFilter:
             pytest.param(
                 "[-3 TO 8.5]",
                 5.0,
-                ("5.0", 5, [], {}),
-                id="numeric-range-does-not-match-non-float-document-values",
+                ("abc", True, False, [], {}),
+                id="numeric-range-does-not-match-non-numeric-document-values",
             ),
             pytest.param(
                 "[bar TO foo]",
                 "baz",
-                (5, 5.0, object()),
-                id="string-range-does-not-match-non-string-document-values",
+                (True, False, [], {}, object()),
+                id="string-range-does-not-match-non-convertible-document-values",
             ),
         ),
     )
@@ -955,57 +949,46 @@ class TestLueceneFilter:
         for wrong_value in wrong_values:
             assert not lucene_filter.matches({"key": wrong_value})
 
+    def test_created_numeric_range_filter_matches_int_float_and_numeric_string_document_values(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query("[1 TO 10]"))
+
+        assert lucene_filter.matches({"key": 2})
+        assert lucene_filter.matches({"key": 2.0})
+        assert lucene_filter.matches({"key": 10})
+        assert lucene_filter.matches({"key": "2"})
+        assert not lucene_filter.matches({"key": "20"})
+        assert not lucene_filter.matches({"key": "abc"})
+
+    def test_created_string_range_filter_matches_int_and_float_document_values(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query("[1 TO bar]"))
+
+        assert lucene_filter.matches({"key": 5})
+        assert lucene_filter.matches({"key": 5.5})
+        assert lucene_filter.matches({"key": "5"})
+        assert not lucene_filter.matches({"key": -5})
+        assert not lucene_filter.matches({"key": True})
+
     @pytest.mark.parametrize(
         "range_expression",
         (
-            pytest.param(
-                "{0 TO 0}",
-                id="exclusive-integer-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{0 TO 0]",
-                id="exclusive-lower-integer-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "[0 TO 0}",
-                id="exclusive-upper-integer-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{1.5 TO 1.5}",
-                id="exclusive-float-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{1.5 TO 1.5]",
-                id="exclusive-lower-float-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "[1.5 TO 1.5}",
-                id="exclusive-upper-float-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{1.0 TO 1}",
-                id="exclusive-mixed-numeric-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{1.0 TO 1]",
-                id="exclusive-lower-mixed-numeric-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "[1.0 TO 1}",
-                id="exclusive-upper-mixed-numeric-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{abc TO abc}",
-                id="exclusive-string-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "{abc TO abc]",
-                id="exclusive-lower-string-range-with-equal-boundaries",
-            ),
-            pytest.param(
-                "[abc TO abc}",
-                id="exclusive-upper-string-range-with-equal-boundaries",
-            ),
+            pytest.param("{0 TO 0}", id="excl-int-range-eq-bounds"),
+            pytest.param("{0 TO 0]", id="excl-lower-int-range-eq-bounds"),
+            pytest.param("[0 TO 0}", id="excl-upper-int-range-eq-bounds"),
+            pytest.param("{1.5 TO 1.5}", id="excl-float-range-eq-bounds"),
+            pytest.param("{1.5 TO 1.5]", id="excl-lower-float-range-eq-bounds"),
+            pytest.param("[1.5 TO 1.5}", id="excl-upper-float-range-eq-bounds"),
+            pytest.param("{1.0 TO 1}", id="excl-mixed-numeric-range-eq-bounds"),
+            pytest.param("{1.0 TO 1]", id="excl-lower-mixed-numeric-range-eq-bounds"),
+            pytest.param("[1.0 TO 1}", id="excl-upper-mixed-numeric-range-eq-bounds"),
+            pytest.param("{abc TO abc}", id="excl-string-range-eq-bounds"),
+            pytest.param("{abc TO abc]", id="excl-lower-string-range-eq-bounds"),
+            pytest.param("[abc TO abc}", id="excl-upper-string-range-eq-bounds"),
         ),
     )
     def test_created_exclusive_range_with_equal_boundaries_matches_no_value(
@@ -1022,70 +1005,22 @@ class TestLueceneFilter:
     @pytest.mark.parametrize(
         "range_expression",
         (
-            pytest.param(
-                "[0 TO 10]",
-                id="integer-inclusive-range",
-            ),
-            pytest.param(
-                "{0 TO 10}",
-                id="integer-exclusive-range",
-            ),
-            pytest.param(
-                "{0 TO 10]",
-                id="integer-exclusive-inclusive-range",
-            ),
-            pytest.param(
-                "[0 TO 10}",
-                id="integer-inclusive-exclusive-range",
-            ),
-            pytest.param(
-                "[-1.5 TO 1.5]",
-                id="float-inclusive-range",
-            ),
-            pytest.param(
-                "{-1.5 TO 1.5}",
-                id="float-exclusive-range",
-            ),
-            pytest.param(
-                "{-1.5 TO 1.5]",
-                id="float-exclusive-inclusive-range",
-            ),
-            pytest.param(
-                "[-1.5 TO 1.5}",
-                id="float-inclusive-exclusive-range",
-            ),
-            pytest.param(
-                "[-1 TO 1.0]",
-                id="mixed-numeric-inclusive-range",
-            ),
-            pytest.param(
-                "{-1 TO 1.0}",
-                id="mixed-numeric-exclusive-range",
-            ),
-            pytest.param(
-                "{-1 TO 1.0]",
-                id="mixed-numeric-exclusive-inclusive-range",
-            ),
-            pytest.param(
-                "[-1 TO 1.0}",
-                id="mixed-numeric-inclusive-exclusive-range",
-            ),
-            pytest.param(
-                "[bar TO foo]",
-                id="string-inclusive-range",
-            ),
-            pytest.param(
-                "{bar TO foo}",
-                id="string-exclusive-range",
-            ),
-            pytest.param(
-                "{bar TO foo]",
-                id="string-exclusive-inclusive-range",
-            ),
-            pytest.param(
-                "[bar TO foo}",
-                id="string-inclusive-exclusive-range",
-            ),
+            pytest.param("[0 TO 10]", id="int-incl-range"),
+            pytest.param("{0 TO 10}", id="int-excl-range"),
+            pytest.param("{0 TO 10]", id="int-excl-incl-range"),
+            pytest.param("[0 TO 10}", id="int-incl-excl-range"),
+            pytest.param("[-1.5 TO 1.5]", id="float-incl-range"),
+            pytest.param("{-1.5 TO 1.5}", id="float-excl-range"),
+            pytest.param("{-1.5 TO 1.5]", id="float-excl-incl-range"),
+            pytest.param("[-1.5 TO 1.5}", id="float-incl-excl-range"),
+            pytest.param("[-1 TO 1.0]", id="mixed-numeric-incl-range"),
+            pytest.param("{-1 TO 1.0}", id="mixed-numeric-excl-range"),
+            pytest.param("{-1 TO 1.0]", id="mixed-numeric-excl-incl-range"),
+            pytest.param("[-1 TO 1.0}", id="mixed-numeric-incl-excl-range"),
+            pytest.param("[bar TO foo]", id="string-incl-range"),
+            pytest.param("{bar TO foo}", id="string-excl-range"),
+            pytest.param("{bar TO foo]", id="string-excl-incl-range"),
+            pytest.param("[bar TO foo}", id="string-incl-excl-range"),
         ),
     )
     def test_created_range_filter_does_not_match_missing_field(
@@ -1101,54 +1036,24 @@ class TestLueceneFilter:
     @pytest.mark.parametrize(
         "range_expression",
         (
-            pytest.param(
-                "[10 TO 0]",
-                id="reversed-inclusive-integer-range",
-            ),
-            pytest.param(
-                "{10 TO 0}",
-                id="reversed-exclusive-integer-range",
-            ),
-            pytest.param(
-                "{10 TO 0]",
-                id="reversed-exclusive-inclusive-integer-range",
-            ),
-            pytest.param(
-                "[10 TO 0}",
-                id="reversed-inclusive-exclusive-integer-range",
-            ),
-            pytest.param(
-                "[10.5 TO -1.5]",
-                id="reversed-inclusive-float-range",
-            ),
-            pytest.param(
-                "{10.5 TO -1.5}",
-                id="reversed-exclusive-float-range",
-            ),
-            pytest.param(
-                "{10.5 TO -1.5]",
-                id="reversed-exclusive-inclusive-float-range",
-            ),
-            pytest.param(
-                "[10.5 TO -1.5}",
-                id="reversed-inclusive-exclusive-float-range",
-            ),
-            pytest.param(
-                "[foo TO bar]",
-                id="reversed-inclusive-string-range",
-            ),
-            pytest.param(
-                "{foo TO bar}",
-                id="reversed-exclusive-string-range",
-            ),
-            pytest.param(
-                "{foo TO bar]",
-                id="reversed-exclusive-inclusive-string-range",
-            ),
-            pytest.param(
-                "[foo TO bar}",
-                id="reversed-inclusive-exclusive-string-range",
-            ),
+            pytest.param("[10 TO 0]", id="reverse-incl-int-range"),
+            pytest.param("{10 TO 0}", id="reverse-excl-int-range"),
+            pytest.param("{10 TO 0]", id="reverse-excl-incl-int-range"),
+            pytest.param("[10 TO 0}", id="reverse-incl-excl-int-range"),
+            pytest.param("[10.5 TO -1.5]", id="reverse-incl-float-range"),
+            pytest.param("{10.5 TO -1.5}", id="reverse-excl-float-range"),
+            pytest.param("{10.5 TO -1.5]", id="reverse-excl-incl-float-range"),
+            pytest.param("[10.5 TO -1.5}", id="reverse-incl-excl-float-range"),
+            pytest.param("[foo TO bar]", id="reverse-incl-string-range"),
+            pytest.param("{foo TO bar}", id="reverse-excl-string-range"),
+            pytest.param("{foo TO bar]", id="reverse-excl-incl-string-range"),
+            pytest.param("[foo TO bar}", id="reverse-incl-excl-string-range"),
+            pytest.param("[foo TO 10]", id="reverse-string-lower-and-int-upper-bound"),
+            pytest.param("{foo TO 10}", id="reverse-excl-string-lower-and-int-upper-bound"),
+            pytest.param("[foo TO 10.5]", id="reverse-string-lower-and-float-upper-bound"),
+            pytest.param("{foo TO 10.5}", id="reverse-excl-string-lower-and-float-upper-bound"),
+            pytest.param("[nan TO 10]", id="reverse-nan-lower-and-int-upper-bound"),
+            pytest.param("{nan TO 10}", id="reverse-excl-nan-lower-and-int-upper-bound"),
         ),
     )
     def test_create_rejects_range_with_reversed_boundaries(
@@ -1172,13 +1077,13 @@ class TestLueceneFilter:
                 "[0 TO 10.5]",
                 (0.0, 5.5, 10.5),
                 (-0.1, 10.6),
-                id="integer-lower-float-upper-boundary",
+                id="int-lower-float-upper-bound",
             ),
             pytest.param(
                 "[-10.5 TO 10]",
                 (-10.5, 0.0, 10.0),
                 (-10.6, 10.1),
-                id="float-lower-integer-upper-boundary",
+                id="float-lower-int-upper-bound",
             ),
         ),
     )
@@ -1198,183 +1103,194 @@ class TestLueceneFilter:
             assert not lucene_filter.matches({"key": value})
 
     @pytest.mark.parametrize(
-        "range_expression",
+        ("range_expression", "matching_values", "non_matching_values"),
         (
             pytest.param(
                 "[1 TO bar]",
-                id="integer-lower-and-string-upper-bound",
-            ),
-            pytest.param(
-                "{1 TO bar}",
-                id="exclusive-integer-lower-and-string-upper-bound",
-            ),
-            pytest.param(
-                "{1 TO bar]",
-                id="exclusive-inclusive-integer-lower-and-string-upper-bound",
-            ),
-            pytest.param(
-                "[1 TO bar}",
-                id="inclusive-exclusive-integer-lower-and-string-upper-bound",
-            ),
-            pytest.param(
-                "[foo TO 10]",
-                id="string-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "{foo TO 10}",
-                id="exclusive-string-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "{foo TO 10]",
-                id="exclusive-inclusive-string-lower-and-integer-upper-bound",
-            ),
-            pytest.param(
-                "[foo TO 10}",
-                id="inclusive-exclusive-string-lower-and-integer-upper-bound",
+                ("1", "5", "bar"),
+                ("0", "baz"),
+                id="int-lower-and-string-upper-bound",
             ),
             pytest.param(
                 "[1.5 TO bar]",
+                ("1.5", "5", "bar"),
+                ("1.4", "baz"),
                 id="float-lower-and-string-upper-bound",
             ),
             pytest.param(
-                "{1.5 TO bar}",
-                id="exclusive-float-lower-and-string-upper-bound",
+                "[0 TO nan]",
+                ("0", "5", "nan"),
+                ("-1", "nao"),
+                id="int-lower-and-nan-upper-bound",
             ),
             pytest.param(
-                "{1.5 TO bar]",
-                id="exclusive-inclusive-float-lower-and-string-upper-bound",
+                "[-inf TO 10]",
+                ("-inf", "0", "10"),
+                ("11", "a"),
+                id="neg-infinity-lower-and-int-upper-bound",
             ),
             pytest.param(
-                "[1.5 TO bar}",
-                id="inclusive-exclusive-float-lower-and-string-upper-bound",
+                "[0 TO inf]",
+                ("0", "5", "inf"),
+                ("-1", "infinity"),
+                id="int-lower-and-pos-infinity-upper-bound",
             ),
             pytest.param(
-                "[foo TO 10.5]",
-                id="string-lower-and-float-upper-bound",
+                "[-inf TO inf]",
+                ("-inf", "0", "inf"),
+                ("infinity", "zzz"),
+                id="both-bounds-non-finite-terms",
             ),
             pytest.param(
-                "{foo TO 10.5}",
-                id="exclusive-string-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "{foo TO 10.5]",
-                id="exclusive-inclusive-string-lower-and-float-upper-bound",
-            ),
-            pytest.param(
-                "[foo TO 10.5}",
-                id="inclusive-exclusive-string-lower-and-float-upper-bound",
+                "[nan TO nan]",
+                ("nan",),
+                ("Nan", "0", "nanana"),
+                id="eq-non-finite-term-bounds",
             ),
         ),
     )
-    def test_create_rejects_mixed_numeric_and_string_range_boundaries(
+    def test_created_range_filter_falls_back_to_string_range_for_non_numeric_boundaries(
         self,
         range_query,
         range_expression,
+        matching_values,
+        non_matching_values,
     ):
-        with pytest.raises(
-            LuceneFilterError,
-            match=re.escape(f'The expression "{range_expression}" is invalid!'),
-        ):
-            LuceneFilter.create(range_query(range_expression))
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
 
     @pytest.mark.parametrize(
-        "range_expression",
+        ("range_expression", "matching_values", "non_matching_values"),
         (
             pytest.param(
                 "[* TO 10]",
-                id="open-lower-bound",
+                (-1000, -1, 0, 10),
+                (11,),
+                id="open-lower-bound-numeric",
             ),
             pytest.param(
                 "{* TO 10}",
-                id="exclusive-open-lower-bound",
+                (-1000, 9),
+                (10, 11),
+                id="excl-open-lower-bound-numeric",
             ),
             pytest.param(
                 "[1 TO *]",
-                id="open-upper-bound",
+                (1, 5, 1000),
+                (0,),
+                id="open-upper-bound-numeric",
             ),
             pytest.param(
                 "{1 TO *}",
-                id="exclusive-open-upper-bound",
-            ),
-            pytest.param(
-                "[* TO *]",
-                id="fully-open-range",
-            ),
-            pytest.param(
-                "{* TO *}",
-                id="exclusive-fully-open-range",
+                (2,),
+                (0, 1),
+                id="excl-open-upper-bound-numeric",
             ),
             pytest.param(
                 "[* TO foo]",
+                ("", "a", "foo"),
+                ("fop", "zzz"),
                 id="open-lower-string-upper-bound",
             ),
             pytest.param(
                 "[foo TO *]",
+                ("foo", "zzz"),
+                ("", "e", "fon"),
                 id="string-lower-open-upper-bound",
             ),
         ),
     )
-    def test_create_rejects_open_range(
+    def test_created_range_filter_treats_open_boundary_as_unbounded(
         self,
         range_query,
         range_expression,
+        matching_values,
+        non_matching_values,
     ):
-        with pytest.raises(
-            LuceneFilterError,
-            match=re.escape(f'The expression "{range_expression}" is invalid!'),
-        ):
-            LuceneFilter.create(range_query(range_expression))
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in matching_values:
+            assert lucene_filter.matches({"key": value})
+
+        for value in non_matching_values:
+            assert not lucene_filter.matches({"key": value})
 
     @pytest.mark.parametrize(
         "range_expression",
         (
-            pytest.param(
-                "[nan TO 10]",
-                id="nan-lower-bound",
-            ),
-            pytest.param(
-                "{nan TO 10}",
-                id="exclusive-nan-lower-bound",
-            ),
-            pytest.param(
-                "[0 TO nan]",
-                id="nan-upper-bound",
-            ),
-            pytest.param(
-                "{0 TO nan}",
-                id="exclusive-nan-upper-bound",
-            ),
-            pytest.param(
-                "[-inf TO 10]",
-                id="negative-infinity-lower-bound",
-            ),
-            pytest.param(
-                "{-inf TO 10}",
-                id="exclusive-negative-infinity-lower-bound",
-            ),
-            pytest.param(
-                "[0 TO inf]",
-                id="positive-infinity-upper-bound",
-            ),
-            pytest.param(
-                "{0 TO inf}",
-                id="exclusive-positive-infinity-upper-bound",
-            ),
+            pytest.param("[* TO *]", id="incl"),
+            pytest.param("{* TO *}", id="excl"),
+            pytest.param("{* TO *]", id="excl-incl"),
+            pytest.param("[* TO *}", id="incl-excl"),
         ),
     )
-    def test_create_rejects_non_finite_range_boundaries(
+    def test_created_range_filter_treats_fully_open_range_as_field_exists(
         self,
         range_query,
         range_expression,
     ):
-        with pytest.raises(
-            LuceneFilterError,
-            match=re.escape(
-                f'The expression "{range_expression}" is invalid. '
-                "Range boundaries must be finite numbers."
-            ),
-        ):
-            LuceneFilter.create(range_query(range_expression))
+        lucene_filter = LuceneFilter.create(range_query(range_expression))
+
+        for value in ["a", 5, 5.5, True, False, [], {}, None]:
+            assert lucene_filter.matches({"key": value})
+
+        assert not lucene_filter.matches({})
+        assert not lucene_filter.matches({"other": 1})
+
+    def test_created_range_filter_treats_quoted_asterisk_as_literal_value(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query('["*" TO bar]'))
+
+        assert not lucene_filter.matches({"key": "!"}), "! < * and thus should not match"
+        assert lucene_filter.matches({"key": "*"})
+        assert lucene_filter.matches({"key": "aaa"})
+        assert not lucene_filter.matches({"key": "baz"})
+
+    def test_open_and_literal_asterisk_boundaries_are_distinguishable_in_repr(
+        self,
+        range_query,
+    ):
+        open_range = LuceneFilter.create(range_query("[* TO bar]"))
+        literal_range = LuceneFilter.create(range_query('["*" TO bar]'))
+
+        assert str(open_range) != str(literal_range)
+
+    def test_created_range_filter_quoting_forces_lexicographic_comparison(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query('["1" TO "10"]'))
+
+        assert lucene_filter.matches({"key": "1"})
+        assert lucene_filter.matches({"key": "10"})
+        assert lucene_filter.matches({"key": 1})
+        assert not lucene_filter.matches({"key": "2"})
+        assert not lucene_filter.matches({"key": 2})
+        assert not lucene_filter.matches({"key": "100"})
+
+    def test_created_range_filter_quoting_either_boundary_forces_string_range(
+        self,
+        range_query,
+    ):
+        lucene_filter = LuceneFilter.create(range_query('["1" TO 10]'))
+
+        assert not lucene_filter.matches({"key": 2})
+
+    def test_quoted_and_unquoted_numeric_ranges_are_distinguishable_in_repr(
+        self,
+        range_query,
+    ):
+        numeric_range = LuceneFilter.create(range_query("[1 TO 10]"))
+        string_range = LuceneFilter.create(range_query('["1" TO "10"]'))
+
+        assert str(numeric_range) != str(string_range)
 
     @pytest.mark.parametrize(
         ("range_expression", "matching_values", "non_matching_values"),
@@ -1390,7 +1306,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59Z",
                     "2025-01-01T00:00:00Z",
                 ),
-                id="iso-8601-utc-timestamp-range",
+                id="iso-8601-utc-ts-range",
             ),
             pytest.param(
                 "[2024-01-01T00:00:00.000Z TO 2024-01-01T00:00:00.999Z]",
@@ -1403,7 +1319,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59.999Z",
                     "2024-01-01T00:00:01.000Z",
                 ),
-                id="iso-8601-millisecond-timestamp-range",
+                id="iso-8601-millisecond-ts-range",
             ),
             pytest.param(
                 '["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]',
@@ -1416,7 +1332,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59+01:00",
                     "2025-01-01T00:00:00+01:00",
                 ),
-                id="quoted-iso-8601-offset-timestamp-range",
+                id="quoted-iso-8601-offset-ts-range",
             ),
         ),
     )
@@ -1449,7 +1365,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59Z",
                     "2025-01-01T00:00:00Z",
                 ),
-                id="iso-8601-inclusive-lower-inclusive-upper",
+                id="iso-8601-incl-lower-incl-upper",
             ),
             pytest.param(
                 "{2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z}",
@@ -1458,7 +1374,7 @@ class TestLueceneFilter:
                     "2024-01-01T00:00:00Z",
                     "2024-12-31T23:59:59Z",
                 ),
-                id="iso-8601-exclusive-lower-exclusive-upper",
+                id="iso-8601-excl-lower-excl-upper",
             ),
             pytest.param(
                 "{2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z]",
@@ -1470,7 +1386,7 @@ class TestLueceneFilter:
                     "2024-01-01T00:00:00Z",
                     "2025-01-01T00:00:00Z",
                 ),
-                id="iso-8601-exclusive-lower-inclusive-upper",
+                id="iso-8601-excl-lower-incl-upper",
             ),
             pytest.param(
                 "[2024-01-01T00:00:00Z TO 2024-12-31T23:59:59Z}",
@@ -1482,7 +1398,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59Z",
                     "2024-12-31T23:59:59Z",
                 ),
-                id="iso-8601-inclusive-lower-exclusive-upper",
+                id="iso-8601-incl-lower-excl-upper",
             ),
             pytest.param(
                 '["2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"]',
@@ -1495,7 +1411,7 @@ class TestLueceneFilter:
                     "2023-12-31T23:59:59+01:00",
                     "2025-01-01T00:00:00+01:00",
                 ),
-                id="quoted-iso-8601-offset-inclusive-lower-inclusive-upper",
+                id="quoted-iso-8601-offset-incl-lower-incl-upper",
             ),
             pytest.param(
                 '{"2024-01-01T00:00:00+01:00" TO "2024-12-31T23:59:59+01:00"}',
@@ -1504,7 +1420,7 @@ class TestLueceneFilter:
                     "2024-01-01T00:00:00+01:00",
                     "2024-12-31T23:59:59+01:00",
                 ),
-                id="quoted-iso-8601-offset-exclusive-lower-exclusive-upper",
+                id="quoted-iso-8601-offset-excl-lower-excl-upper",
             ),
         ),
     )
@@ -1528,23 +1444,23 @@ class TestLueceneFilter:
         (
             pytest.param(
                 "[2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z]",
-                id="reversed-inclusive-iso-8601-timestamp-range",
+                id="reverse-incl-iso-8601-ts-range",
             ),
             pytest.param(
                 "{2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z}",
-                id="reversed-exclusive-iso-8601-timestamp-range",
+                id="reverse-excl-iso-8601-ts-range",
             ),
             pytest.param(
                 "{2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z]",
-                id="reversed-exclusive-inclusive-iso-8601-timestamp-range",
+                id="reverse-excl-incl-iso-8601-ts-range",
             ),
             pytest.param(
                 "[2024-12-31T23:59:59Z TO 2024-01-01T00:00:00Z}",
-                id="reversed-inclusive-exclusive-iso-8601-timestamp-range",
+                id="reverse-incl-excl-iso-8601-ts-range",
             ),
             pytest.param(
                 '["2024-12-31T23:59:59+01:00" TO "2024-01-01T00:00:00+01:00"]',
-                id="reversed-quoted-iso-8601-offset-timestamp-range",
+                id="reverse-quoted-iso-8601-offset-ts-range",
             ),
         ),
     )
@@ -1567,19 +1483,19 @@ class TestLueceneFilter:
         (
             pytest.param(
                 "[2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00]",
-                id="unquoted-iso-8601-offset-inclusive-range",
+                id="unquoted-iso-8601-offset-incl-range",
             ),
             pytest.param(
                 "{2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00}",
-                id="unquoted-iso-8601-offset-exclusive-range",
+                id="unquoted-iso-8601-offset-excl-range",
             ),
             pytest.param(
                 "{2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00]",
-                id="unquoted-iso-8601-offset-exclusive-inclusive-range",
+                id="unquoted-iso-8601-offset-excl-incl-range",
             ),
             pytest.param(
                 "[2024-01-01T00:00:00+01:00 TO 2024-12-31T23:59:59+01:00}",
-                id="unquoted-iso-8601-offset-inclusive-exclusive-range",
+                id="unquoted-iso-8601-offset-incl-excl-range",
             ),
         ),
     )

--- a/tests/unit/filter/test_lucene_filter.py
+++ b/tests/unit/filter/test_lucene_filter.py
@@ -627,6 +627,12 @@ class TestLueceneFilter:
                 (-9223372036854775810, -9223372036854775807),
                 id="int-values-below-64-bit-bound",
             ),
+            pytest.param(
+                f"[-{10**400} TO {10**400}]",
+                (-(10**400), 10**400, f"-{10**400}", f"{10**400}"),
+                (-(10**400) - 1, 10**400 + 1),
+                id="int-values-above-64-bit-bound",
+            ),
         ),
     )
     def test_created_integer_range_filter_matches_values_inside_inclusive_range(


### PR DESCRIPTION
## Description

* filter: field values are now automatically coerced in range matches
* filter: allow mixed numeric range boundaries and type coercion for range matching
* filter: unquoted asterisks (`*`) in range expressions are now considered open boundaries
* filter: add support for `*` (open boundary) in range expressions
* filter: fix lucene range expressions not matching on mixed-type scenarios
* filter: treat `inf`/`nan` as string values instead of numeric range boundaries

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1019.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->