### PR TITLE
fix: allow grokker fallback matches without named fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * ci: enforce CHANGELOG.md is updated
 * ci: enforce PR TODOs are completed
 * ci: introduce umbrella job for enforcing merge status checks with GitHub
+* grokker: improve performance by stopping on first matching expression
 
 ### Bugfix
 * chart: fix command handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events
 * ng: fix error output structure to stay consistent with non-ng
-* generic_adder: allow None as valid input via `add`
+* generic_adder: allow `None` as valid input via `add`
+* grokker: allow fallback matches without named fields
 
 ## 20.0.0
 ### Breaking

--- a/logprep/ng/processor/grokker/processor.py
+++ b/logprep/ng/processor/grokker/processor.py
@@ -79,7 +79,7 @@ class Grokker(FieldManager):
 
     async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(GrokkerRule, rule)
-        matches = []
+        any_match = False
         source_values = []
         for dotted_field, grok in rule.actions.items():
             field_value = get_dotted_field_value(event, dotted_field)
@@ -95,9 +95,11 @@ class Grokker(FieldManager):
                     f"the grok pattern might be too complex.",
                     rule,
                 ) from error
-            if result is None or result == {}:
+            if result is None:
                 continue
-            matches.append(True)
+            any_match = True
+            if result == {}:
+                continue
             add_fields_to(
                 event,
                 result,
@@ -107,7 +109,7 @@ class Grokker(FieldManager):
             )
         if self._handle_missing_fields(event, rule, rule.actions.keys(), source_values):
             return
-        if not matches:
+        if not any_match:
             raise ProcessingWarning("no grok pattern matched", rule, event)
 
     async def setup(self) -> None:

--- a/logprep/processor/grokker/processor.py
+++ b/logprep/processor/grokker/processor.py
@@ -87,7 +87,7 @@ class Grokker(FieldManager):
         return typing.cast(list[GrokkerRule], super().rules)
 
     def _apply_rules(self, event: dict, rule: GrokkerRule):
-        matches = []
+        any_match = False
         source_values = []
         for dotted_field, grok in rule.actions.items():
             field_value = get_dotted_field_value(event, dotted_field)
@@ -103,9 +103,11 @@ class Grokker(FieldManager):
                     f"the grok pattern might be too complex.",
                     rule,
                 ) from error
-            if result is None or result == {}:
+            if result is None:
                 continue
-            matches.append(True)
+            any_match = True
+            if result == {}:
+                continue
             add_fields_to(
                 event,
                 result,
@@ -115,7 +117,7 @@ class Grokker(FieldManager):
             )
         if self._handle_missing_fields(event, rule, rule.actions.keys(), source_values):
             return
-        if not matches:
+        if not any_match:
             raise ProcessingWarning("no grok pattern matched", rule, event)
 
     def setup(self) -> None:

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -37,7 +37,6 @@ from attrs import define, field, validators
 
 from logprep.util.decorators import timeout
 from logprep.util.helper import field_list_to_dotted_field
-from logprep.util.validators import fix_type
 
 DEFAULT_PATTERNS_DIRS = [str(resources.files(__package__) / "patterns/ecs-v1")]
 LOGSTASH_NOTATION = r"(([^\[\]\{\}\.:]*)?(\[[^\[\]\{\}:]*\])*)"
@@ -55,15 +54,14 @@ class Grok:
     oniguruma = re.compile(ONIGURUMA)
 
     pattern: str | list[str] = field(
-        validator=fix_type(
-            lambda: validators.or_(
-                validators.instance_of(str | float),
-                validators.deep_iterable(
-                    iterable_validator=validators.instance_of(list),
-                    member_validator=validators.instance_of(str),
-                ),
-            )
-        )
+        # TODO find a general pattern to consistently fix validator typing
+        validator=validators.or_(  # type: ignore
+            validators.instance_of(str),
+            validators.deep_iterable(
+                iterable_validator=validators.instance_of(list),
+                member_validator=validators.instance_of(str),
+            ),
+        ),
     )
     custom_patterns_dir: str = field(default="")
     custom_patterns: dict = field(factory=dict)

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -98,26 +98,30 @@ class Grok:
         or custom_patterns_dir.
         """
 
-        if self.fullmatch:
-            match_obj = [regex_pattern.fullmatch(text) for regex_pattern in self.regex_obj]
-        else:
-            match_obj = [regex_pattern.search(text) for regex_pattern in self.regex_obj]
+        for regex_pattern in self.regex_obj:
+            if self.fullmatch:
+                match_obj = regex_pattern.fullmatch(text)
+            else:
+                match_obj = regex_pattern.search(text)
 
-        match_obj = [match for match in match_obj if match is not None]
-        if not match_obj:
-            return None
-        match = match_obj[0]
-        hash_to_fvalue: dict[str, str | int | float] = {
-            k: v for k, v in match.groupdict(None).items() if v is not None
-        }
-        if self.type_mappings:
-            for key, match in hash_to_fvalue.items():
-                type_mapper = INT_FLOAT.get(self.type_mappings.get(key))
-                if type_mapper is not None:
-                    hash_to_fvalue[key] = type_mapper(match)
-        return {
-            self.field_mappings[field_hash]: value for field_hash, value in hash_to_fvalue.items()
-        }
+            if match_obj is None:
+                continue
+
+            result: dict[str, str | int | float] = {}
+            for field_hash, value in match_obj.groupdict(None).items():
+                if value is None:
+                    continue
+
+                if self.type_mappings:
+                    mapper = INT_FLOAT.get(self.type_mappings.get(field_hash))
+                    if mapper:
+                        value = mapper(value)
+
+                result[self.field_mappings[field_hash]] = value
+
+            return result
+
+        return None
 
     def _map_types(self, matches):
         for key, match in matches.items():

--- a/logprep/util/grok/grok.py
+++ b/logprep/util/grok/grok.py
@@ -25,6 +25,7 @@ SOFTWARE.
 
 import re
 import string
+from collections.abc import Callable
 from hashlib import md5
 from importlib import resources
 from itertools import chain
@@ -36,13 +37,14 @@ from attrs import define, field, validators
 
 from logprep.util.decorators import timeout
 from logprep.util.helper import field_list_to_dotted_field
+from logprep.util.validators import fix_type
 
 DEFAULT_PATTERNS_DIRS = [str(resources.files(__package__) / "patterns/ecs-v1")]
 LOGSTASH_NOTATION = r"(([^\[\]\{\}\.:]*)?(\[[^\[\]\{\}:]*\])*)"
 GROK = r"%\{" + rf"([A-Z0-9_]*)(:({LOGSTASH_NOTATION}))?(:(int|float))?" + r"\}"
 ONIGURUMA = r"\(\?<([^()]*)>\(?(([^()]*|\(([^()]*|\([^()]*\))*\))*)\)?\)"
 NON_RESOLVED_ONIGURUMA = r"\(\?<[^md5].*>"
-INT_FLOAT = {"int": int, "float": float}
+INT_FLOAT: dict[str | None, Callable[[str], int | float]] = {"int": int, "float": float}
 
 
 @define(slots=True)
@@ -53,19 +55,21 @@ class Grok:
     oniguruma = re.compile(ONIGURUMA)
 
     pattern: str | list[str] = field(
-        validator=validators.or_(
-            validators.instance_of(str),
-            validators.deep_iterable(
-                iterable_validator=validators.instance_of(list),
-                member_validator=validators.instance_of(str),
-            ),
+        validator=fix_type(
+            lambda: validators.or_(
+                validators.instance_of(str | float),
+                validators.deep_iterable(
+                    iterable_validator=validators.instance_of(list),
+                    member_validator=validators.instance_of(str),
+                ),
+            )
         )
     )
     custom_patterns_dir: str = field(default="")
     custom_patterns: dict = field(factory=dict)
     fullmatch: bool = field(default=True)
     predefined_patterns: dict = field(init=False, factory=dict, repr=False)
-    type_mappings: dict = field(init=False, factory=dict)
+    type_mappings: dict[str, str] = field(init=False, factory=dict)
     field_mappings: dict = field(init=False, factory=dict)
     regex_obj = field(init=False, default=None)
 
@@ -85,7 +89,7 @@ class Grok:
         self._load_search_pattern()
 
     @timeout(seconds=1)
-    def match(self, text):
+    def match(self, text) -> dict[str, str | int | float] | None:
         """If text is matched with pattern, return variable names
         specified(%{pattern:variable name}) in pattern and their
         corresponding values. If not matched, return None.
@@ -100,18 +104,20 @@ class Grok:
             match_obj = [regex_pattern.search(text) for regex_pattern in self.regex_obj]
 
         match_obj = [match for match in match_obj if match is not None]
-        matches = [
-            {k: v for k, v in match.groupdict(None).items() if v is not None} for match in match_obj
-        ]
-        if not matches:
-            return {}
-        first_match = matches[0]
+        if not match_obj:
+            return None
+        match = match_obj[0]
+        hash_to_fvalue: dict[str, str | int | float] = {
+            k: v for k, v in match.groupdict(None).items() if v is not None
+        }
         if self.type_mappings:
-            for key, match in first_match.items():
+            for key, match in hash_to_fvalue.items():
                 type_mapper = INT_FLOAT.get(self.type_mappings.get(key))
                 if type_mapper is not None:
-                    first_match[key] = type_mapper(match)
-        return {self.field_mappings[field_hash]: value for field_hash, value in first_match.items()}
+                    hash_to_fvalue[key] = type_mapper(match)
+        return {
+            self.field_mappings[field_hash]: value for field_hash, value in hash_to_fvalue.items()
+        }
 
     def _map_types(self, matches):
         for key, match in matches.items():

--- a/logprep/util/validators.py
+++ b/logprep/util/validators.py
@@ -2,22 +2,10 @@
 
 import os
 import typing
-from collections.abc import Callable
-from typing import TypeVar
 from urllib.parse import urlparse
 
 from logprep.factory_error import InvalidConfigurationError
 from logprep.util.json_handling import is_json
-
-_T = TypeVar("_T")
-
-
-def fix_type(thunk: Callable[[], _T]) -> _T:
-    """
-    Forces mypy into bottom-up type resolution when used with `lambda`.
-    A typical usage would looks like this: `fix_type(lambda: complicated_expression)`.
-    """
-    return thunk()
 
 
 def json_validator(_, __, value):

--- a/logprep/util/validators.py
+++ b/logprep/util/validators.py
@@ -2,10 +2,19 @@
 
 import os
 import typing
+from collections.abc import Callable
+from typing import TypeVar
 from urllib.parse import urlparse
 
 from logprep.factory_error import InvalidConfigurationError
 from logprep.util.json_handling import is_json
+
+_T = TypeVar("_T")
+
+
+def fix_type(thunk: Callable[[], _T]) -> _T:
+    """Forces mypy into bottom-up type resolution"""
+    return thunk()
 
 
 def json_validator(_, __, value):

--- a/logprep/util/validators.py
+++ b/logprep/util/validators.py
@@ -13,7 +13,10 @@ _T = TypeVar("_T")
 
 
 def fix_type(thunk: Callable[[], _T]) -> _T:
-    """Forces mypy into bottom-up type resolution"""
+    """
+    Forces mypy into bottom-up type resolution when used with `lambda`.
+    A typical usage would looks like this: `fix_type(lambda: complicated_expression)`.
+    """
     return thunk()
 
 

--- a/tests/unit/processor/grokker/test_grok.py
+++ b/tests/unit/processor/grokker/test_grok.py
@@ -65,7 +65,7 @@ def test_one_pat_7():
     pat = "%{NUMBER:test_num}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match == {}, f"grok match failed: {text}, {pat}"
+    assert match is None, f"grok match failed: {text}, {pat}"
     # not match
 
 
@@ -98,7 +98,7 @@ def test_multiple_pats():
     pat = "%{WORD:name} %{INT:age} %{QUOTEDSTRING:motto}"
     grok = Grok(pat)
     match = grok.match(text)
-    assert match == {}, f"grok match failed:{text}, {pat}"
+    assert match is None, f"grok match failed:{text}, {pat}"
 
     # nginx log
     text = (

--- a/tests/unit/processor/grokker/test_grokker.py
+++ b/tests/unit/processor/grokker/test_grokker.py
@@ -221,6 +221,18 @@ test_cases = [
     ),
     pytest.param(
         {
+            "filter": "message",
+            "grokker": {
+                "mapping": {"message": "%{SOMEPATTERN}|%{GREEDYDATA}"},
+                "patterns": {"SOMEPATTERN": "i will not match %{DATA:never_match}"},
+            },
+        },
+        {"message": "whatever"},
+        {"message": "whatever"},
+        id="fallback match with no fields",
+    ),
+    pytest.param(
+        {
             "filter": "win\\.log.event\\._id: 123456789",
             "grokker": {
                 "mapping": {


### PR DESCRIPTION
## Description

* grokker: allow fallback matches without named fields
* grokker: improve performance by stopping on first matching expression

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1020.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->