### PR TITLE
feat: add domain resolver timeout cache, prune domain map and rework cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Improvements
 * add a separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
 * add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
-* add metrics for cached timeouts and successfully resolved domains to `domain_resolver`
+* add metrics for cached timed-out domains and successfully resolved domains to `domain_resolver`
 * prune domains from `domain_resolver` mapping that are not in the cache
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 * grokker: improve performance by stopping on first matching expression
 
 ### Bugfix
-* Prune domains from `domain_resolver` mapping that are not in the cache 
+* prune domains from `domain_resolver` mapping that are not in the cache
 * chart: fix command handling
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 * filter: allow mixed numeric range boundaries and type coercion for range matching
 
 ### Improvements
+* add separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
+* add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
+* add metrics for cached timeouts and successfully resolved domains to `domain_resolver`
+* prune domains from `domain_resolver` mapping that are not in the cache
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")
 * docs: use processor name placeholders for most usages
@@ -41,6 +45,7 @@
 * grokker: improve performance by stopping on first matching expression
 
 ### Bugfix
+* Prune domains from `domain_resolver` mapping that are not in the cache 
 * chart: fix command handling
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * filter: allow mixed numeric range boundaries and type coercion for range matching
 
 ### Improvements
-* add separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
+* add a separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
 * add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
 * add metrics for cached timeouts and successfully resolved domains to `domain_resolver`
 * prune domains from `domain_resolver` mapping that are not in the cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Upcoming Changes
 ### Breaking
+* add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
+* add a separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache using the `timeout_block_time` parameter
 
 ### Features
 * timestamper: support generating timestamps from the current time when no `source_fields` are configured
 
 ### Improvements
 * timestamper: validate `source_format` and `source_timezone` according to the configured `source_fields`
+* add metrics for cached timed-out domains and successfully resolved domains to `domain_resolver`
+* make cache hold a payload in addition to timestamps and adapt `domain_resolver` accordingly
 
 ### Bugfix
 
@@ -25,10 +29,6 @@
 * filter: allow mixed numeric range boundaries and type coercion for range matching
 
 ### Improvements
-* add a separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
-* add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
-* add metrics for cached timed-out domains and successfully resolved domains to `domain_resolver`
-* prune domains from `domain_resolver` mapping that are not in the cache
 * docs: enable pydoc placeholders for facilitating component reuse through inheritance
 * docs: change processor natural naming to capital cased with whitespace (e.g. "Generic Resolver")
 * docs: use processor name placeholders for most usages
@@ -45,7 +45,6 @@
 * grokker: improve performance by stopping on first matching expression
 
 ### Bugfix
-* prune domains from `domain_resolver` mapping that are not in the cache
 * chart: fix command handling
 * ng: fix input timeout to also accept int parameters
 * ng: fix `http_input` `collect_meta` leading to shared dicts between events

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -97,9 +97,7 @@ class DomainResolver(Processor):
            Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
            your logs. The default is set to 0.5 seconds.
         """
-        lifetime: float = field(
-            default=1.0, validator=validators.optional(validators.instance_of(float))
-        )
+        lifetime: float = field(default=1.0, validator=validators.instance_of(float))
         """Total timeout for resolving of domains including multiple attempts."""
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
@@ -194,7 +192,7 @@ class DomainResolver(Processor):
 
     __slots__ = ["_domain_ip_map"]
 
-    _domain_ip_map: dict[str, Optional[SuccessResult | FailedResult]]
+    _domain_ip_map: dict[str, SuccessResult | FailedResult]
 
     rule_class = DomainResolverRule
 
@@ -251,7 +249,7 @@ class DomainResolver(Processor):
         if not domain_or_url_str:
             return
 
-        url = urlsplit(domain_or_url_str)
+        url = urlsplit(str(domain_or_url_str))
         domain = url.hostname
         if url.scheme == "":
             domain = url.path

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -14,11 +14,11 @@ Processor Configuration
         rules:
             - tests/testdata/rules/rules
         timeout: 0.5
+        lifetime: 1.0
         max_cached_domains: 20000
         max_caching_days: 1
         hash_salt: secure_salt
         cache_enabled: true
-        debug_cache: false
 
 .. autoclass:: logprep.processor.domain_resolver.processor.DomainResolver.Config
    :members:
@@ -31,38 +31,50 @@ Processor Configuration
 
 import datetime
 import logging
-import socket
 import typing
 from enum import IntEnum
 from functools import cached_property
-from multiprocessing import context
-from multiprocessing.pool import ThreadPool
+from typing import Optional
 from urllib.parse import urlsplit
 
-from attrs import define, field, validators
+from attr import define, field, validators
+from dns.exception import Timeout, FormError, SyntaxError as DNSSyntaxError, TooBig
+from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNameservers
 
+from logprep.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
-from logprep.ng.abc.processor import Processor
-from logprep.processor.base.rule import Rule
 from logprep.processor.domain_resolver.rule import DomainResolverRule
-from logprep.util.cache import Cache
+from logprep.util.cache import Cache, Timer
 from logprep.util.hasher import SHA256Hasher
-from logprep.util.helper import FieldValue, add_fields_to, get_dotted_field_value
+from logprep.util.helper import get_dotted_field_value
 
 logger = logging.getLogger("DomainResolver")
 
 
-class ResolveStatus(IntEnum):
+class FailureType(IntEnum):
     """Status of resolving domains"""
 
-    SUCCESS = 0
-    """Resolving the domain was successful"""
-    TIMEOUT = 1
+    TIMEOUT = 0
     """Domain resolver timeout while trying to resolve the domain (this is not a socket timeout)"""
-    INVALID = 2
+    INVALID = 1
     """The resolved domain was invalid and thus not resolved"""
-    UNKNOWN = 3
+    UNKNOWN = 2
     """Tried to resolve the domain, but the domain is unknown"""
+    NO_ANSWER = 3
+    """The resolved domain was valid, but returned no data"""
+    NO_NAMESERVERS = 4
+    """Nameservers do not exist or timed out"""
+
+
+@define
+class SuccessResult:
+    resolved_ip: str
+
+
+@define
+class FailedResult:
+    failure_type: FailureType
+    error: Exception | None = None
 
 
 class DomainResolver(Processor):
@@ -70,24 +82,47 @@ class DomainResolver(Processor):
 
     @define(kw_only=True)
     class Config(Processor.Config):
-        """DomainResolver config"""
+        """Config for |PROCESSOR|"""
 
         timeout: float = field(
             default=0.5,
             validator=validators.instance_of(float),
             converter=float,
         )
-        """Timeout for resolving of domains."""
+        """Timeout for resolving of domains.
+
+        .. security-best-practice::
+           :title: |PROCESSOR| - Timeout
+
+           Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
+           your logs. The default is set to 0.5 seconds.
+        """
+        lifetime: float = field(
+            default=1.0, validator=validators.optional(validators.instance_of(float))
+        )
+        """Total timeout for resolving of domains including multiple attempts."""
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
         million elements would require about 2.3 GB RAM. The cache is not persisted. Restarting
-        Logprep does therefore clear the cache."""
+        Logprep does therefore clear the cache.
+
+        .. security-best-practice::
+           :title: |PROCESSOR| - Max Cached Domains
+
+           Ensure to set this to a reasonable value to avoid excessive memory usage
+           and OOM situations by the domain resolver cache.
+
+        """
+        timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
+        """Minutes after which a timed out domain can be resolved again."""
+        cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
+        """Seconds after which decayed domains are pruned from caches."""
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
         This caching reduces the CPU load of Logprep (no demanding encryption must be performed
         repeatedly) and the load on subsequent components (i.e. Logstash or Opensearch).
         Setting the caching days to Null deactivates the caching. In case the cache size has been
-        exceeded (see `domain_resolver.max_cached_domains`),the oldest cached pseudonyms will
+        exceeded (see `domain_resolver.max_cached_domains`),the oldest cached resolved domains will
         be discarded first.Thus, it is possible that a domain is re-added to the cache before
         max_caching_days has elapsed if it was discarded due to the size limit."""
         hash_salt: str = field(validator=validators.instance_of(str))
@@ -95,9 +130,6 @@ class DomainResolver(Processor):
         cache_enabled: bool = field(default=True, validator=validators.instance_of(bool))
         """If enabled activates a cache such that already seen domains do not need to be resolved
         again."""
-        debug_cache: bool = field(default=False, validator=validators.instance_of(bool))
-        """If enabled adds debug information to the current event, for example if the event
-        was retrieved from the cache or newly resolved, as well as the cache size."""
 
     @define(kw_only=True)
     class Metrics(Processor.Metrics):
@@ -124,6 +156,13 @@ class DomainResolver(Processor):
             )
         )
         """Number of urls that were resolved from cache"""
+        resolved_domains: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of domains that were successfully resolved",
+                name="domain_resolver_resolved_domains",
+            )
+        )
+        """Number of domains that were successfully resolved"""
         timeouts: CounterMetric = field(
             factory=lambda: CounterMetric(
                 description="Number of timeouts that occurred while resolving a url",
@@ -131,6 +170,13 @@ class DomainResolver(Processor):
             )
         )
         """Number of timeouts that occurred while resolving a url"""
+        timeouts_cached: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of timeouts from the timeout cache for a url",
+                name="domain_resolver_timeouts_cached",
+            )
+        )
+        """Number of timeouts from the timeout cache for a url"""
         invalid_domains: CounterMetric = field(
             factory=lambda: CounterMetric(
                 description="Number of invalid domains",
@@ -148,11 +194,11 @@ class DomainResolver(Processor):
 
     __slots__ = ["_domain_ip_map"]
 
-    _domain_ip_map: dict[str, str | None]
+    _domain_ip_map: dict[str, Optional[SuccessResult | FailedResult]]
 
     rule_class = DomainResolverRule
 
-    def __init__(self, name: str, configuration: Processor.Config) -> None:
+    def __init__(self, name: str, configuration: Processor.Config):
         super().__init__(name, configuration)
         self._domain_ip_map = {}
 
@@ -162,88 +208,133 @@ class DomainResolver(Processor):
         return typing.cast(DomainResolver.Config, self._config)
 
     @cached_property
-    def _cache(self) -> Cache:
+    def _dns_resolver(self) -> Resolver:
+        dns_resolver = Resolver()
+        dns_resolver.timeout = self.config.timeout
+        dns_resolver.lifetime = self.config.lifetime
+        return dns_resolver
+
+    @cached_property
+    def _timeout_cache(self) -> Cache:
+        cache_max_timedelta = datetime.timedelta(minutes=self.config.timeout_block_time)
+        cache = Cache(
+            max_items=self.config.max_cached_domains,
+            max_timedelta=cache_max_timedelta,
+            prune_interval=self.config.cache_prune_interval,
+        )
+        return cache
+
+    @cached_property
+    def _domain_cache(self) -> Cache:
         cache_max_timedelta = datetime.timedelta(days=self.config.max_caching_days)
-        return Cache(max_items=self.config.max_cached_domains, max_timedelta=cache_max_timedelta)
+        cache = Cache(
+            max_items=self.config.max_cached_domains,
+            max_timedelta=cache_max_timedelta,
+            prune_interval=self.config.cache_prune_interval,
+        )
+        return cache
+
+    @cached_property
+    def _domain_ip_map_prune_timer(self) -> Timer:
+        return Timer(self.config.cache_prune_interval)
 
     @cached_property
     def _hasher(self) -> SHA256Hasher:
         return SHA256Hasher()
 
-    @cached_property
-    def _thread_pool(self) -> ThreadPool:
-        return ThreadPool(processes=1)
-
-    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
-        rule = typing.cast(DomainResolverRule, rule)
+    def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
+        self._timeout_cache.prune_decayed()
+        self._domain_cache.prune_decayed()
+        self._prune_domain_ip_map()
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
         if not domain_or_url_str:
             return
-        if not isinstance(domain_or_url_str, str):
-            raise ValueError("expected source_field to be a string")
 
         url = urlsplit(domain_or_url_str)
         domain = url.hostname
         if url.scheme == "":
             domain = url.path
         if not domain:
+            self.metrics.invalid_domains += 1
             return
         self.metrics.total_urls += 1
         if self.config.cache_enabled:
-            self._resolve_with_cache(domain, event, rule)
+            result = self._resolve_with_cache(domain)
         else:
-            resolved_ip, _ = self._resolve_ip(domain)
-            self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            result = self._resolve_ip(domain)
 
-    def _resolve_with_cache(
-        self, domain: str, event: dict[str, FieldValue], rule: DomainResolverRule
-    ) -> None:
+        match result:
+            case SuccessResult(resolved_ip) if resolved_ip:
+                self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            case FailedResult(_, error) if error:
+                self._handle_warning_error(event, rule, error)
+
+    def _resolve_with_timeout_check(self, domain: str) -> SuccessResult | FailedResult:
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
-        requires_storing = self._cache.requires_storing(hash_string)
-        if requires_storing:
-            resolved_ip, status = self._resolve_ip(domain)
-            if status in (ResolveStatus.SUCCESS, ResolveStatus.UNKNOWN, ResolveStatus.TIMEOUT):
-                self._domain_ip_map.update({hash_string: resolved_ip})
-            self.metrics.resolved_new += 1
-        else:
-            resolved_ip = self._domain_ip_map.get(hash_string)
+        if self._timeout_cache.is_cached(hash_string):
+            self.metrics.timeouts_cached += 1
+            return FailedResult(FailureType.TIMEOUT)
+
+        result = self._resolve_ip(domain)
+        if isinstance(result, FailedResult) and self._is_timeout(result):
+            self._timeout_cache.add(hash_string)
+        return result
+
+    def _resolve_with_cache(self, domain: str) -> SuccessResult | FailedResult:
+        hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
+
+        if self._domain_cache.is_cached(hash_string):
+            self._domain_cache.update_cache(hash_string)
+            result = self._domain_ip_map[hash_string]
             self.metrics.resolved_cached += 1
-        self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            return result
 
-        if self.config.debug_cache:
-            self._store_debug_infos(event, requires_storing)
+        result = self._resolve_with_timeout_check(domain)
+        match result:
+            case SuccessResult(_):
+                self._domain_cache.add(hash_string)
+                self._domain_ip_map.update({hash_string: result})
+            case FailedResult(_) if not self._is_timeout(result):
+                self._domain_cache.add(hash_string)
+                self._domain_ip_map.update({hash_string: result})
+        self.metrics.resolved_new += 1
+        return result
 
-    def _add_resolve_infos_to_event(
-        self, event: dict[str, FieldValue], rule: DomainResolverRule, resolved_ip: str | None
-    ) -> None:
+    @staticmethod
+    def _is_timeout(failed_result: FailedResult) -> bool:
+        return failed_result.failure_type in (FailureType.TIMEOUT, FailureType.NO_NAMESERVERS)
+
+    def _add_resolve_infos_to_event(self, event: dict, rule, resolved_ip: str):
         if resolved_ip:
             self._write_target_field(event, rule, resolved_ip)
 
-    def _resolve_ip(self, domain: str) -> tuple[str | None, int]:
+    def _resolve_ip(self, domain: str) -> SuccessResult | FailedResult:
         """Resolve domain with timeout.
 
         Assumes socket default timeout is None and relies on threading to create a timeout.
         """
         try:
-            result = self._thread_pool.apply_async(socket.gethostbyname, (domain,))
-            resolved_ip = result.get(timeout=self.config.timeout)
-            return resolved_ip, ResolveStatus.SUCCESS
-        except ValueError:  # Makes no connection so does not need to be cached
+            result = self._dns_resolver.resolve(domain, "A")
+            self.metrics.resolved_domains += 1
+            return SuccessResult(result[0].address)
+        except (FormError, DNSSyntaxError, TooBig):
             self.metrics.invalid_domains += 1
-            return None, ResolveStatus.INVALID
-        except context.TimeoutError:
+            return FailedResult(FailureType.INVALID)
+        except (Timeout, LifetimeTimeout):
             self.metrics.timeouts += 1
-            return None, ResolveStatus.TIMEOUT
-        except OSError:  # Won't be timeout if default timeout is None
+            return FailedResult(FailureType.TIMEOUT)
+        except NXDOMAIN:
             self.metrics.unknown_domains += 1
-            return None, ResolveStatus.UNKNOWN
+            return FailedResult(FailureType.UNKNOWN)
+        except NoAnswer:
+            return FailedResult(FailureType.NO_ANSWER)
+        except NoNameservers as error:
+            return FailedResult(FailureType.NO_NAMESERVERS, error)
 
-    def _store_debug_infos(self, event: dict[str, FieldValue], requires_storing: bool) -> None:
-        event_dbg = {
-            "resolved_ip_debug": {
-                "obtained_from_cache": not requires_storing,
-                "cache_size": len(self._domain_ip_map.keys()),
-            }
-        }
-        add_fields_to(event, event_dbg, overwrite_target=True)
+    def _prune_domain_ip_map(self):
+        if self._domain_ip_map_prune_timer.finished():
+            self._domain_ip_map_prune_timer.reset()
+            removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
+            for hash_Str in removed_keys:
+                self._domain_ip_map.pop(hash_Str)

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -34,7 +34,6 @@ import logging
 import typing
 from enum import IntEnum
 from functools import cached_property
-from typing import Optional
 from urllib.parse import urlsplit
 
 from attr import define, field, validators

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -41,10 +41,11 @@ from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNamese
 
 from logprep.ng.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
+from logprep.processor.base.rule import Rule
 from logprep.processor.domain_resolver.rule import DomainResolverRule
 from logprep.util.cache import Cache
 from logprep.util.hasher import SHA256Hasher
-from logprep.util.helper import get_dotted_field_value
+from logprep.util.helper import get_dotted_field_value, FieldValue
 
 logger = logging.getLogger("DomainResolver")
 
@@ -235,7 +236,8 @@ class DomainResolver(Processor):
 
         self._hasher = SHA256Hasher()
 
-    async def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
+    async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
+        rule = typing.cast(DomainResolverRule, rule)
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
         if not domain_or_url_str:

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -195,7 +195,7 @@ class DomainResolver(Processor):
 
     rule_class = DomainResolverRule
 
-    def __init__(self, name: str, configuration: Processor.Config):
+    def __init__(self, name: str, configuration: Processor.Config) -> None:
         super().__init__(name, configuration)
         self._domain_ip_map = {}
 

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -42,7 +42,7 @@ from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNamese
 from logprep.ng.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
 from logprep.processor.domain_resolver.rule import DomainResolverRule
-from logprep.util.cache import Cache, Timer
+from logprep.util.cache import Cache
 from logprep.util.hasher import SHA256Hasher
 from logprep.util.helper import get_dotted_field_value
 
@@ -118,9 +118,6 @@ class DomainResolver(Processor):
 
         timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
         """Minutes after which a timed out domain can be resolved again."""
-
-        cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
-        """Seconds after which decayed domains are pruned from caches."""
 
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
@@ -200,26 +197,18 @@ class DomainResolver(Processor):
         """Number of unknown domains that were trying to be resolved"""
 
     __slots__ = [
-        "_domain_ip_map",
         "_dns_resolver",
         "_timeout_cache",
         "_domain_cache",
-        "_domain_ip_map_prune_timer",
         "_hasher",
     ]
 
-    _domain_ip_map: dict[str, SuccessResult | FailedResult]
     _dns_resolver: Resolver
     _timeout_cache: Cache
     _domain_cache: Cache
-    _domain_ip_map_prune_timer: Timer
     _hasher: SHA256Hasher
 
     rule_class = DomainResolverRule
-
-    def __init__(self, name: str, configuration: Processor.Config) -> None:
-        super().__init__(name, configuration)
-        self._domain_ip_map = {}
 
     @property
     def config(self) -> Config:
@@ -236,23 +225,17 @@ class DomainResolver(Processor):
         self._timeout_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
-            prune_interval=self.config.cache_prune_interval,
         )
 
         cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
         self._domain_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
-            prune_interval=self.config.cache_prune_interval,
         )
 
-        self._domain_ip_map_prune_timer = Timer(self.config.cache_prune_interval)
         self._hasher = SHA256Hasher()
 
     async def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
-        self._timeout_cache.prune_decayed()
-        self._domain_cache.prune_decayed()
-        self._prune_domain_ip_map()
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
         if not domain_or_url_str:
@@ -285,10 +268,9 @@ class DomainResolver(Processor):
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
 
         if self._domain_cache.is_cached(hash_string):
-            self._domain_cache.update_cache(hash_string)
-            result = self._domain_ip_map[hash_string]
             self.metrics.resolved_cached += 1
-            return result
+            self._domain_cache.refresh_time_to_live(hash_string)
+            return self._domain_cache[hash_string].value
 
         if self._timeout_cache.is_cached(hash_string):
             self.metrics.timeouts_cached += 1
@@ -296,14 +278,10 @@ class DomainResolver(Processor):
 
         result = self._resolve_ip(domain)
         match result:
-            case SuccessResult(_):
-                self._domain_cache.add(hash_string)
-                self._domain_ip_map.update({hash_string: result})
             case FailedResult(FailureType.TIMEOUT | FailureType.NO_NAMESERVERS):
                 self._timeout_cache.add(hash_string)
-            case FailedResult(_):
-                self._domain_cache.add(hash_string)
-                self._domain_ip_map.update({hash_string: result})
+            case _:
+                self._domain_cache.add(hash_string, result)
         self.metrics.resolved_new += 1
         return result
 
@@ -333,10 +311,3 @@ class DomainResolver(Processor):
             return FailedResult(FailureType.NO_ANSWER)
         except NoNameservers as error:
             return FailedResult(FailureType.NO_NAMESERVERS, error)
-
-    def _prune_domain_ip_map(self):
-        if self._domain_ip_map_prune_timer.finished():
-            self._domain_ip_map_prune_timer.reset()
-            removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
-            for hash_str in removed_keys:
-                self._domain_ip_map.pop(hash_str)

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -68,12 +68,14 @@ class FailureType(IntEnum):
 @define
 class SuccessResult:
     """Result object for successfully resolved domains"""
+
     resolved_ip: str
 
 
 @define
 class FailedResult:
     """Result object for unsuccessfully resolved domains"""
+
     failure_type: FailureType
     error: Exception | None = None
 

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -29,9 +29,9 @@ Processor Configuration
 .. automodule:: logprep.processor.domain_resolver.rule
 """
 
-import datetime
 import logging
 import typing
+from datetime import timedelta
 from enum import IntEnum
 from functools import cached_property
 from urllib.parse import urlsplit
@@ -213,7 +213,7 @@ class DomainResolver(Processor):
 
     @cached_property
     def _timeout_cache(self) -> Cache:
-        cache_max_timedelta = datetime.timedelta(minutes=self.config.timeout_block_time)
+        cache_max_timedelta = timedelta(minutes=self.config.timeout_block_time).total_seconds()
         cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
@@ -223,7 +223,7 @@ class DomainResolver(Processor):
 
     @cached_property
     def _domain_cache(self) -> Cache:
-        cache_max_timedelta = datetime.timedelta(days=self.config.max_caching_days)
+        cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
         cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -276,17 +276,6 @@ class DomainResolver(Processor):
             case FailedResult(_, error) if error:
                 self._handle_warning_error(event, rule, error)
 
-    def _resolve_with_timeout_check(self, domain: str) -> SuccessResult | FailedResult:
-        hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
-        if self._timeout_cache.is_cached(hash_string):
-            self.metrics.timeouts_cached += 1
-            return FailedResult(FailureType.TIMEOUT)
-
-        result = self._resolve_ip(domain)
-        if isinstance(result, FailedResult) and self._is_timeout(result):
-            self._timeout_cache.add(hash_string)
-        return result
-
     def _resolve_with_cache(self, domain: str) -> SuccessResult | FailedResult:
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
 
@@ -296,20 +285,22 @@ class DomainResolver(Processor):
             self.metrics.resolved_cached += 1
             return result
 
-        result = self._resolve_with_timeout_check(domain)
+        if self._timeout_cache.is_cached(hash_string):
+            self.metrics.timeouts_cached += 1
+            return FailedResult(FailureType.TIMEOUT)
+
+        result = self._resolve_ip(domain)
         match result:
             case SuccessResult(_):
                 self._domain_cache.add(hash_string)
                 self._domain_ip_map.update({hash_string: result})
-            case FailedResult(_) if not self._is_timeout(result):
+            case FailedResult(FailureType.TIMEOUT | FailureType.NO_NAMESERVERS):
+                self._timeout_cache.add(hash_string)
+            case FailedResult(_):
                 self._domain_cache.add(hash_string)
                 self._domain_ip_map.update({hash_string: result})
         self.metrics.resolved_new += 1
         return result
-
-    @staticmethod
-    def _is_timeout(failed_result: FailedResult) -> bool:
-        return failed_result.failure_type in (FailureType.TIMEOUT, FailureType.NO_NAMESERVERS)
 
     def _add_resolve_infos_to_event(self, event: dict, rule, resolved_ip: str):
         if resolved_ip:

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -67,11 +67,13 @@ class FailureType(IntEnum):
 
 @define
 class SuccessResult:
+    """Result object for successfully resolved domains"""
     resolved_ip: str
 
 
 @define
 class FailedResult:
+    """Result object for unsuccessfully resolved domains"""
     failure_type: FailureType
     error: Exception | None = None
 

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -96,8 +96,10 @@ class DomainResolver(Processor):
            Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
            your logs. The default is set to 0.5 seconds.
         """
+
         lifetime: float = field(default=1.0, validator=validators.instance_of(float))
         """Total timeout for resolving of domains including multiple attempts."""
+
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
         million elements would require about 2.3 GB RAM. The cache is not persisted. Restarting
@@ -110,10 +112,13 @@ class DomainResolver(Processor):
            and OOM situations by the domain resolver cache.
 
         """
+
         timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
         """Minutes after which a timed out domain can be resolved again."""
+
         cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
         """Seconds after which decayed domains are pruned from caches."""
+
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
         This caching reduces the CPU load of Logprep (no demanding encryption must be performed
@@ -122,8 +127,10 @@ class DomainResolver(Processor):
         exceeded (see `domain_resolver.max_cached_domains`),the oldest cached resolved domains will
         be discarded first.Thus, it is possible that a domain is re-added to the cache before
         max_caching_days has elapsed if it was discarded due to the size limit."""
+
         hash_salt: str = field(validator=validators.instance_of(str))
         """A salt that is used for hashing."""
+
         cache_enabled: bool = field(default=True, validator=validators.instance_of(bool))
         """If enabled activates a cache such that already seen domains do not need to be resolved
         again."""

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -39,7 +39,7 @@ from attr import define, field, validators
 from dns.exception import Timeout, FormError, SyntaxError as DNSSyntaxError, TooBig
 from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNameservers
 
-from logprep.abc.processor import Processor
+from logprep.ng.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
 from logprep.processor.domain_resolver.rule import DomainResolverRule
 from logprep.util.cache import Cache, Timer
@@ -226,8 +226,8 @@ class DomainResolver(Processor):
         """Provides the properly typed rule configuration object"""
         return typing.cast(DomainResolver.Config, self._config)
 
-    def setup(self):
-        super().setup()
+    async def setup(self):
+        await super().setup()
         self._dns_resolver = Resolver()
         self._dns_resolver.timeout = self.config.timeout
         self._dns_resolver.lifetime = self.config.lifetime
@@ -249,7 +249,7 @@ class DomainResolver(Processor):
         self._domain_ip_map_prune_timer = Timer(self.config.cache_prune_interval)
         self._hasher = SHA256Hasher()
 
-    def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
+    async def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
         self._timeout_cache.prune_decayed()
         self._domain_cache.prune_decayed()
         self._prune_domain_ip_map()

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -342,5 +342,5 @@ class DomainResolver(Processor):
         if self._domain_ip_map_prune_timer.finished():
             self._domain_ip_map_prune_timer.reset()
             removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
-            for hash_Str in removed_keys:
-                self._domain_ip_map.pop(hash_Str)
+            for hash_str in removed_keys:
+                self._domain_ip_map.pop(hash_str)

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -200,9 +200,21 @@ class DomainResolver(Processor):
         )
         """Number of unknown domains that were trying to be resolved"""
 
-    __slots__ = ["_domain_ip_map"]
+    __slots__ = [
+        "_domain_ip_map",
+        "_dns_resolver",
+        "_timeout_cache",
+        "_domain_cache",
+        "_domain_ip_map_prune_timer",
+        "_hasher",
+    ]
 
     _domain_ip_map: dict[str, SuccessResult | FailedResult]
+    _dns_resolver: Resolver
+    _timeout_cache: Cache
+    _domain_cache: Cache
+    _domain_ip_map_prune_timer: Timer
+    _hasher: SHA256Hasher
 
     rule_class = DomainResolverRule
 
@@ -215,40 +227,28 @@ class DomainResolver(Processor):
         """Provides the properly typed rule configuration object"""
         return typing.cast(DomainResolver.Config, self._config)
 
-    @cached_property
-    def _dns_resolver(self) -> Resolver:
-        dns_resolver = Resolver()
-        dns_resolver.timeout = self.config.timeout
-        dns_resolver.lifetime = self.config.lifetime
-        return dns_resolver
+    def setup(self):
+        super().setup()
+        self._dns_resolver = Resolver()
+        self._dns_resolver.timeout = self.config.timeout
+        self._dns_resolver.lifetime = self.config.lifetime
 
-    @cached_property
-    def _timeout_cache(self) -> Cache:
         cache_max_timedelta = timedelta(minutes=self.config.timeout_block_time).total_seconds()
-        cache = Cache(
+        self._timeout_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
             prune_interval=self.config.cache_prune_interval,
         )
-        return cache
 
-    @cached_property
-    def _domain_cache(self) -> Cache:
         cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
-        cache = Cache(
+        self._domain_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
             prune_interval=self.config.cache_prune_interval,
         )
-        return cache
 
-    @cached_property
-    def _domain_ip_map_prune_timer(self) -> Timer:
-        return Timer(self.config.cache_prune_interval)
-
-    @cached_property
-    def _hasher(self) -> SHA256Hasher:
-        return SHA256Hasher()
+        self._domain_ip_map_prune_timer = Timer(self.config.cache_prune_interval)
+        self._hasher = SHA256Hasher()
 
     def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
         self._timeout_cache.prune_decayed()

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -33,7 +33,6 @@ import logging
 import typing
 from datetime import timedelta
 from enum import IntEnum, auto
-from functools import cached_property
 from urllib.parse import urlsplit
 
 from attr import define, field, validators

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -32,7 +32,7 @@ Processor Configuration
 import logging
 import typing
 from datetime import timedelta
-from enum import IntEnum
+from enum import IntEnum, auto
 from functools import cached_property
 from urllib.parse import urlsplit
 
@@ -53,15 +53,15 @@ logger = logging.getLogger("DomainResolver")
 class FailureType(IntEnum):
     """Status of resolving domains"""
 
-    TIMEOUT = 0
+    TIMEOUT = auto()
     """Domain resolver timeout while trying to resolve the domain (this is not a socket timeout)"""
-    INVALID = 1
+    INVALID = auto()
     """The resolved domain was invalid and thus not resolved"""
-    UNKNOWN = 2
+    UNKNOWN = auto()
     """Tried to resolve the domain, but the domain is unknown"""
-    NO_ANSWER = 3
+    NO_ANSWER = auto()
     """The resolved domain was valid, but returned no data"""
-    NO_NAMESERVERS = 4
+    NO_NAMESERVERS = auto()
     """Nameservers do not exist or timed out"""
 
 

--- a/logprep/ng/processor/domain_resolver/processor.py
+++ b/logprep/ng/processor/domain_resolver/processor.py
@@ -258,7 +258,11 @@ class DomainResolver(Processor):
         if not domain_or_url_str:
             return
 
-        url = urlsplit(str(domain_or_url_str))
+        if not isinstance(domain_or_url_str, str):
+            self.metrics.invalid_domains += 1
+            return
+
+        url = urlsplit(domain_or_url_str)
         domain = url.hostname
         if url.scheme == "":
             domain = url.path

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -97,9 +97,7 @@ class DomainResolver(Processor):
            Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
            your logs. The default is set to 0.5 seconds.
         """
-        lifetime: float = field(
-            default=1.0, validator=validators.optional(validators.instance_of(float))
-        )
+        lifetime: float = field(default=1.0, validator=validators.instance_of(float))
         """Total timeout for resolving of domains including multiple attempts."""
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
@@ -194,7 +192,7 @@ class DomainResolver(Processor):
 
     __slots__ = ["_domain_ip_map"]
 
-    _domain_ip_map: dict[str, Optional[SuccessResult | FailedResult]]
+    _domain_ip_map: dict[str, SuccessResult | FailedResult]
 
     rule_class = DomainResolverRule
 
@@ -251,7 +249,7 @@ class DomainResolver(Processor):
         if not domain_or_url_str:
             return
 
-        url = urlsplit(domain_or_url_str)
+        url = urlsplit(str(domain_or_url_str))
         domain = url.hostname
         if url.scheme == "":
             domain = url.path

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -14,11 +14,11 @@ Processor Configuration
         rules:
             - tests/testdata/rules/rules
         timeout: 0.5
+        lifetime: 1.0
         max_cached_domains: 20000
         max_caching_days: 1
         hash_salt: secure_salt
         cache_enabled: true
-        debug_cache: false
 
 .. autoclass:: logprep.processor.domain_resolver.processor.DomainResolver.Config
    :members:
@@ -31,38 +31,50 @@ Processor Configuration
 
 import datetime
 import logging
-import socket
 import typing
 from enum import IntEnum
 from functools import cached_property
-from multiprocessing import context
-from multiprocessing.pool import ThreadPool
-from typing import Any, Optional
+from typing import Optional
 from urllib.parse import urlsplit
 
-from attrs import define, field, validators
+from attr import define, field, validators
+from dns.exception import Timeout, FormError, SyntaxError as DNSSyntaxError, TooBig
+from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNameservers
 
 from logprep.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
 from logprep.processor.domain_resolver.rule import DomainResolverRule
-from logprep.util.cache import Cache
+from logprep.util.cache import Cache, Timer
 from logprep.util.hasher import SHA256Hasher
-from logprep.util.helper import add_fields_to, get_dotted_field_value
+from logprep.util.helper import get_dotted_field_value
 
 logger = logging.getLogger("DomainResolver")
 
 
-class ResolveStatus(IntEnum):
+class FailureType(IntEnum):
     """Status of resolving domains"""
 
-    SUCCESS = 0
-    """Resolving the domain was successful"""
-    TIMEOUT = 1
+    TIMEOUT = 0
     """Domain resolver timeout while trying to resolve the domain (this is not a socket timeout)"""
-    INVALID = 2
+    INVALID = 1
     """The resolved domain was invalid and thus not resolved"""
-    UNKNOWN = 3
+    UNKNOWN = 2
     """Tried to resolve the domain, but the domain is unknown"""
+    NO_ANSWER = 3
+    """The resolved domain was valid, but returned no data"""
+    NO_NAMESERVERS = 4
+    """Nameservers do not exist or timed out"""
+
+
+@define
+class SuccessResult:
+    resolved_ip: str
+
+
+@define
+class FailedResult:
+    failure_type: FailureType
+    error: Exception | None = None
 
 
 class DomainResolver(Processor):
@@ -85,6 +97,10 @@ class DomainResolver(Processor):
            Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
            your logs. The default is set to 0.5 seconds.
         """
+        lifetime: float = field(
+            default=1.0, validator=validators.optional(validators.instance_of(float))
+        )
+        """Total timeout for resolving of domains including multiple attempts."""
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
         million elements would require about 2.3 GB RAM. The cache is not persisted. Restarting
@@ -97,6 +113,10 @@ class DomainResolver(Processor):
            and OOM situations by the domain resolver cache.
 
         """
+        timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
+        """Minutes after which a timed out domain can be resolved again."""
+        cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
+        """Seconds after which decayed domains are pruned from caches."""
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
         This caching reduces the CPU load of Logprep (no demanding encryption must be performed
@@ -110,9 +130,6 @@ class DomainResolver(Processor):
         cache_enabled: bool = field(default=True, validator=validators.instance_of(bool))
         """If enabled activates a cache such that already seen domains do not need to be resolved
         again."""
-        debug_cache: bool = field(default=False, validator=validators.instance_of(bool))
-        """If enabled adds debug information to the current event, for example if the event
-        was retrieved from the cache or newly resolved, as well as the cache size."""
 
     @define(kw_only=True)
     class Metrics(Processor.Metrics):
@@ -139,6 +156,13 @@ class DomainResolver(Processor):
             )
         )
         """Number of urls that were resolved from cache"""
+        resolved_domains: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of domains that were successfully resolved",
+                name="domain_resolver_resolved_domains",
+            )
+        )
+        """Number of domains that were successfully resolved"""
         timeouts: CounterMetric = field(
             factory=lambda: CounterMetric(
                 description="Number of timeouts that occurred while resolving a url",
@@ -146,6 +170,13 @@ class DomainResolver(Processor):
             )
         )
         """Number of timeouts that occurred while resolving a url"""
+        timeouts_cached: CounterMetric = field(
+            factory=lambda: CounterMetric(
+                description="Number of timeouts from the timeout cache for a url",
+                name="domain_resolver_timeouts_cached",
+            )
+        )
+        """Number of timeouts from the timeout cache for a url"""
         invalid_domains: CounterMetric = field(
             factory=lambda: CounterMetric(
                 description="Number of invalid domains",
@@ -163,7 +194,7 @@ class DomainResolver(Processor):
 
     __slots__ = ["_domain_ip_map"]
 
-    _domain_ip_map: dict[str, Optional[str]]
+    _domain_ip_map: dict[str, Optional[SuccessResult | FailedResult]]
 
     rule_class = DomainResolverRule
 
@@ -177,87 +208,133 @@ class DomainResolver(Processor):
         return typing.cast(DomainResolver.Config, self._config)
 
     @cached_property
-    def _cache(self) -> Cache:
+    def _dns_resolver(self) -> Resolver:
+        dns_resolver = Resolver()
+        dns_resolver.timeout = self.config.timeout
+        dns_resolver.lifetime = self.config.lifetime
+        return dns_resolver
+
+    @cached_property
+    def _timeout_cache(self) -> Cache:
+        cache_max_timedelta = datetime.timedelta(minutes=self.config.timeout_block_time)
+        cache = Cache(
+            max_items=self.config.max_cached_domains,
+            max_timedelta=cache_max_timedelta,
+            prune_interval=self.config.cache_prune_interval,
+        )
+        return cache
+
+    @cached_property
+    def _domain_cache(self) -> Cache:
         cache_max_timedelta = datetime.timedelta(days=self.config.max_caching_days)
-        return Cache(max_items=self.config.max_cached_domains, max_timedelta=cache_max_timedelta)
+        cache = Cache(
+            max_items=self.config.max_cached_domains,
+            max_timedelta=cache_max_timedelta,
+            prune_interval=self.config.cache_prune_interval,
+        )
+        return cache
+
+    @cached_property
+    def _domain_ip_map_prune_timer(self) -> Timer:
+        return Timer(self.config.cache_prune_interval)
 
     @cached_property
     def _hasher(self) -> SHA256Hasher:
         return SHA256Hasher()
 
-    @cached_property
-    def _thread_pool(self) -> ThreadPool:
-        return ThreadPool(processes=1)
-
-    def _apply_rules(self, event: dict[str, Any], rule: DomainResolverRule) -> None:
+    def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
+        self._timeout_cache.prune_decayed()
+        self._domain_cache.prune_decayed()
+        self._prune_domain_ip_map()
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
         if not domain_or_url_str:
             return
-        if not isinstance(domain_or_url_str, str):
-            raise ValueError("expected source_field to be a string")
 
         url = urlsplit(domain_or_url_str)
         domain = url.hostname
         if url.scheme == "":
             domain = url.path
         if not domain:
+            self.metrics.invalid_domains += 1
             return
         self.metrics.total_urls += 1
         if self.config.cache_enabled:
-            self._resolve_with_cache(domain, event, rule)
+            result = self._resolve_with_cache(domain)
         else:
-            resolved_ip, _ = self._resolve_ip(domain)
-            self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            result = self._resolve_ip(domain)
 
-    def _resolve_with_cache(
-        self, domain: str, event: dict[str, Any], rule: DomainResolverRule
-    ) -> None:
+        match result:
+            case SuccessResult(resolved_ip) if resolved_ip:
+                self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            case FailedResult(_, error) if error:
+                self._handle_warning_error(event, rule, error)
+
+    def _resolve_with_timeout_check(self, domain: str) -> SuccessResult | FailedResult:
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
-        requires_storing = self._cache.requires_storing(hash_string)
-        if requires_storing:
-            resolved_ip, status = self._resolve_ip(domain)
-            if status in (ResolveStatus.SUCCESS, ResolveStatus.UNKNOWN, ResolveStatus.TIMEOUT):
-                self._domain_ip_map.update({hash_string: resolved_ip})
-            self.metrics.resolved_new += 1
-        else:
-            resolved_ip = self._domain_ip_map.get(hash_string)
+        if self._timeout_cache.is_cached(hash_string):
+            self.metrics.timeouts_cached += 1
+            return FailedResult(FailureType.TIMEOUT)
+
+        result = self._resolve_ip(domain)
+        if isinstance(result, FailedResult) and self._is_timeout(result):
+            self._timeout_cache.add(hash_string)
+        return result
+
+    def _resolve_with_cache(self, domain: str) -> SuccessResult | FailedResult:
+        hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
+
+        if self._domain_cache.is_cached(hash_string):
+            self._domain_cache.update_cache(hash_string)
+            result = self._domain_ip_map[hash_string]
             self.metrics.resolved_cached += 1
-        self._add_resolve_infos_to_event(event, rule, resolved_ip)
+            return result
 
-        if self.config.debug_cache:
-            self._store_debug_infos(event, requires_storing)
+        result = self._resolve_with_timeout_check(domain)
+        match result:
+            case SuccessResult(_):
+                self._domain_cache.add(hash_string)
+                self._domain_ip_map.update({hash_string: result})
+            case FailedResult(_) if not self._is_timeout(result):
+                self._domain_cache.add(hash_string)
+                self._domain_ip_map.update({hash_string: result})
+        self.metrics.resolved_new += 1
+        return result
 
-    def _add_resolve_infos_to_event(
-        self, event: dict[str, Any], rule: DomainResolverRule, resolved_ip: Optional[str]
-    ) -> None:
+    @staticmethod
+    def _is_timeout(failed_result: FailedResult) -> bool:
+        return failed_result.failure_type in (FailureType.TIMEOUT, FailureType.NO_NAMESERVERS)
+
+    def _add_resolve_infos_to_event(self, event: dict, rule, resolved_ip: str):
         if resolved_ip:
             self._write_target_field(event, rule, resolved_ip)
 
-    def _resolve_ip(self, domain: str) -> tuple[Optional[str], int]:
+    def _resolve_ip(self, domain: str) -> SuccessResult | FailedResult:
         """Resolve domain with timeout.
 
         Assumes socket default timeout is None and relies on threading to create a timeout.
         """
         try:
-            result = self._thread_pool.apply_async(socket.gethostbyname, (domain,))
-            resolved_ip = result.get(timeout=self.config.timeout)
-            return resolved_ip, ResolveStatus.SUCCESS
-        except ValueError:  # Makes no connection so does not need to be cached
+            result = self._dns_resolver.resolve(domain, "A")
+            self.metrics.resolved_domains += 1
+            return SuccessResult(result[0].address)
+        except (FormError, DNSSyntaxError, TooBig):
             self.metrics.invalid_domains += 1
-            return None, ResolveStatus.INVALID
-        except context.TimeoutError:
+            return FailedResult(FailureType.INVALID)
+        except (Timeout, LifetimeTimeout):
             self.metrics.timeouts += 1
-            return None, ResolveStatus.TIMEOUT
-        except OSError:  # Won't be timeout if default timeout is None
+            return FailedResult(FailureType.TIMEOUT)
+        except NXDOMAIN:
             self.metrics.unknown_domains += 1
-            return None, ResolveStatus.UNKNOWN
+            return FailedResult(FailureType.UNKNOWN)
+        except NoAnswer:
+            return FailedResult(FailureType.NO_ANSWER)
+        except NoNameservers as error:
+            return FailedResult(FailureType.NO_NAMESERVERS, error)
 
-    def _store_debug_infos(self, event: dict[str, Any], requires_storing: bool) -> None:
-        event_dbg = {
-            "resolved_ip_debug": {
-                "obtained_from_cache": not requires_storing,
-                "cache_size": len(self._domain_ip_map.keys()),
-            }
-        }
-        add_fields_to(event, event_dbg, overwrite_target=True)
+    def _prune_domain_ip_map(self):
+        if self._domain_ip_map_prune_timer.finished():
+            self._domain_ip_map_prune_timer.reset()
+            removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
+            for hash_Str in removed_keys:
+                self._domain_ip_map.pop(hash_Str)

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -34,7 +34,6 @@ import logging
 import typing
 from enum import IntEnum
 from functools import cached_property
-from typing import Optional
 from urllib.parse import urlsplit
 
 from attr import define, field, validators

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -195,7 +195,7 @@ class DomainResolver(Processor):
 
     rule_class = DomainResolverRule
 
-    def __init__(self, name: str, configuration: Processor.Config):
+    def __init__(self, name: str, configuration: Processor.Config) -> None:
         super().__init__(name, configuration)
         self._domain_ip_map = {}
 

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -68,12 +68,14 @@ class FailureType(IntEnum):
 @define
 class SuccessResult:
     """Result object for successfully resolved domains"""
+
     resolved_ip: str
 
 
 @define
 class FailedResult:
     """Result object for unsuccessfully resolved domains"""
+
     failure_type: FailureType
     error: Exception | None = None
 

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -29,9 +29,9 @@ Processor Configuration
 .. automodule:: logprep.processor.domain_resolver.rule
 """
 
-import datetime
 import logging
 import typing
+from datetime import timedelta
 from enum import IntEnum
 from functools import cached_property
 from urllib.parse import urlsplit
@@ -213,7 +213,7 @@ class DomainResolver(Processor):
 
     @cached_property
     def _timeout_cache(self) -> Cache:
-        cache_max_timedelta = datetime.timedelta(minutes=self.config.timeout_block_time)
+        cache_max_timedelta = timedelta(minutes=self.config.timeout_block_time).total_seconds()
         cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
@@ -223,7 +223,7 @@ class DomainResolver(Processor):
 
     @cached_property
     def _domain_cache(self) -> Cache:
-        cache_max_timedelta = datetime.timedelta(days=self.config.max_caching_days)
+        cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
         cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -276,17 +276,6 @@ class DomainResolver(Processor):
             case FailedResult(_, error) if error:
                 self._handle_warning_error(event, rule, error)
 
-    def _resolve_with_timeout_check(self, domain: str) -> SuccessResult | FailedResult:
-        hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
-        if self._timeout_cache.is_cached(hash_string):
-            self.metrics.timeouts_cached += 1
-            return FailedResult(FailureType.TIMEOUT)
-
-        result = self._resolve_ip(domain)
-        if isinstance(result, FailedResult) and self._is_timeout(result):
-            self._timeout_cache.add(hash_string)
-        return result
-
     def _resolve_with_cache(self, domain: str) -> SuccessResult | FailedResult:
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
 
@@ -296,20 +285,22 @@ class DomainResolver(Processor):
             self.metrics.resolved_cached += 1
             return result
 
-        result = self._resolve_with_timeout_check(domain)
+        if self._timeout_cache.is_cached(hash_string):
+            self.metrics.timeouts_cached += 1
+            return FailedResult(FailureType.TIMEOUT)
+
+        result = self._resolve_ip(domain)
         match result:
             case SuccessResult(_):
                 self._domain_cache.add(hash_string)
                 self._domain_ip_map.update({hash_string: result})
-            case FailedResult(_) if not self._is_timeout(result):
+            case FailedResult(FailureType.TIMEOUT | FailureType.NO_NAMESERVERS):
+                self._timeout_cache.add(hash_string)
+            case FailedResult(_):
                 self._domain_cache.add(hash_string)
                 self._domain_ip_map.update({hash_string: result})
         self.metrics.resolved_new += 1
         return result
-
-    @staticmethod
-    def _is_timeout(failed_result: FailedResult) -> bool:
-        return failed_result.failure_type in (FailureType.TIMEOUT, FailureType.NO_NAMESERVERS)
 
     def _add_resolve_infos_to_event(self, event: dict, rule, resolved_ip: str):
         if resolved_ip:

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -67,11 +67,13 @@ class FailureType(IntEnum):
 
 @define
 class SuccessResult:
+    """Result object for successfully resolved domains"""
     resolved_ip: str
 
 
 @define
 class FailedResult:
+    """Result object for unsuccessfully resolved domains"""
     failure_type: FailureType
     error: Exception | None = None
 

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -96,8 +96,10 @@ class DomainResolver(Processor):
            Ensure to set this to a reasonable value to avoid DOS attacks by malicious domains in
            your logs. The default is set to 0.5 seconds.
         """
+
         lifetime: float = field(default=1.0, validator=validators.instance_of(float))
         """Total timeout for resolving of domains including multiple attempts."""
+
         max_cached_domains: int = field(validator=validators.instance_of(int))
         """The maximum number of cached domains. One cache entry requires ~250 Byte, thus 10
         million elements would require about 2.3 GB RAM. The cache is not persisted. Restarting
@@ -110,10 +112,13 @@ class DomainResolver(Processor):
            and OOM situations by the domain resolver cache.
 
         """
+
         timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
         """Minutes after which a timed out domain can be resolved again."""
+
         cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
         """Seconds after which decayed domains are pruned from caches."""
+
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
         This caching reduces the CPU load of Logprep (no demanding encryption must be performed
@@ -122,8 +127,10 @@ class DomainResolver(Processor):
         exceeded (see `domain_resolver.max_cached_domains`),the oldest cached resolved domains will
         be discarded first.Thus, it is possible that a domain is re-added to the cache before
         max_caching_days has elapsed if it was discarded due to the size limit."""
+
         hash_salt: str = field(validator=validators.instance_of(str))
         """A salt that is used for hashing."""
+
         cache_enabled: bool = field(default=True, validator=validators.instance_of(bool))
         """If enabled activates a cache such that already seen domains do not need to be resolved
         again."""

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -342,5 +342,5 @@ class DomainResolver(Processor):
         if self._domain_ip_map_prune_timer.finished():
             self._domain_ip_map_prune_timer.reset()
             removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
-            for hash_Str in removed_keys:
-                self._domain_ip_map.pop(hash_Str)
+            for hash_str in removed_keys:
+                self._domain_ip_map.pop(hash_str)

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -200,9 +200,21 @@ class DomainResolver(Processor):
         )
         """Number of unknown domains that were trying to be resolved"""
 
-    __slots__ = ["_domain_ip_map"]
+    __slots__ = [
+        "_domain_ip_map",
+        "_dns_resolver",
+        "_timeout_cache",
+        "_domain_cache",
+        "_domain_ip_map_prune_timer",
+        "_hasher",
+    ]
 
     _domain_ip_map: dict[str, SuccessResult | FailedResult]
+    _dns_resolver: Resolver
+    _timeout_cache: Cache
+    _domain_cache: Cache
+    _domain_ip_map_prune_timer: Timer
+    _hasher: SHA256Hasher
 
     rule_class = DomainResolverRule
 
@@ -215,40 +227,28 @@ class DomainResolver(Processor):
         """Provides the properly typed rule configuration object"""
         return typing.cast(DomainResolver.Config, self._config)
 
-    @cached_property
-    def _dns_resolver(self) -> Resolver:
-        dns_resolver = Resolver()
-        dns_resolver.timeout = self.config.timeout
-        dns_resolver.lifetime = self.config.lifetime
-        return dns_resolver
+    def setup(self):
+        super().setup()
+        self._dns_resolver = Resolver()
+        self._dns_resolver.timeout = self.config.timeout
+        self._dns_resolver.lifetime = self.config.lifetime
 
-    @cached_property
-    def _timeout_cache(self) -> Cache:
         cache_max_timedelta = timedelta(minutes=self.config.timeout_block_time).total_seconds()
-        cache = Cache(
+        self._timeout_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
             prune_interval=self.config.cache_prune_interval,
         )
-        return cache
 
-    @cached_property
-    def _domain_cache(self) -> Cache:
         cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
-        cache = Cache(
+        self._domain_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
             prune_interval=self.config.cache_prune_interval,
         )
-        return cache
 
-    @cached_property
-    def _domain_ip_map_prune_timer(self) -> Timer:
-        return Timer(self.config.cache_prune_interval)
-
-    @cached_property
-    def _hasher(self) -> SHA256Hasher:
-        return SHA256Hasher()
+        self._domain_ip_map_prune_timer = Timer(self.config.cache_prune_interval)
+        self._hasher = SHA256Hasher()
 
     def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
         self._timeout_cache.prune_decayed()

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -42,7 +42,7 @@ from dns.resolver import Resolver, NXDOMAIN, LifetimeTimeout, NoAnswer, NoNamese
 from logprep.abc.processor import Processor
 from logprep.metrics.metrics import CounterMetric
 from logprep.processor.domain_resolver.rule import DomainResolverRule
-from logprep.util.cache import Cache, Timer
+from logprep.util.cache import Cache
 from logprep.util.hasher import SHA256Hasher
 from logprep.util.helper import get_dotted_field_value
 
@@ -118,9 +118,6 @@ class DomainResolver(Processor):
 
         timeout_block_time: float = field(default=5.0, validator=validators.instance_of(float))
         """Minutes after which a timed out domain can be resolved again."""
-
-        cache_prune_interval: float = field(default=3600.0, validator=validators.instance_of(float))
-        """Seconds after which decayed domains are pruned from caches."""
 
         max_caching_days: int = field(validator=validators.instance_of(int))
         """Number of days a domains is cached after the last time it appeared.
@@ -200,26 +197,18 @@ class DomainResolver(Processor):
         """Number of unknown domains that were trying to be resolved"""
 
     __slots__ = [
-        "_domain_ip_map",
         "_dns_resolver",
         "_timeout_cache",
         "_domain_cache",
-        "_domain_ip_map_prune_timer",
         "_hasher",
     ]
 
-    _domain_ip_map: dict[str, SuccessResult | FailedResult]
     _dns_resolver: Resolver
     _timeout_cache: Cache
     _domain_cache: Cache
-    _domain_ip_map_prune_timer: Timer
     _hasher: SHA256Hasher
 
     rule_class = DomainResolverRule
-
-    def __init__(self, name: str, configuration: Processor.Config) -> None:
-        super().__init__(name, configuration)
-        self._domain_ip_map = {}
 
     @property
     def config(self) -> Config:
@@ -236,23 +225,17 @@ class DomainResolver(Processor):
         self._timeout_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
-            prune_interval=self.config.cache_prune_interval,
         )
 
         cache_max_timedelta = timedelta(days=self.config.max_caching_days).total_seconds()
         self._domain_cache = Cache(
             max_items=self.config.max_cached_domains,
             max_timedelta=cache_max_timedelta,
-            prune_interval=self.config.cache_prune_interval,
         )
 
-        self._domain_ip_map_prune_timer = Timer(self.config.cache_prune_interval)
         self._hasher = SHA256Hasher()
 
     def _apply_rules(self, event: dict[str, typing.Any], rule: DomainResolverRule):
-        self._timeout_cache.prune_decayed()
-        self._domain_cache.prune_decayed()
-        self._prune_domain_ip_map()
         source_field = rule.source_fields[0]
         domain_or_url_str = get_dotted_field_value(event, source_field)
         if not domain_or_url_str:
@@ -285,10 +268,9 @@ class DomainResolver(Processor):
         hash_string = self._hasher.hash_str(domain, salt=self.config.hash_salt)
 
         if self._domain_cache.is_cached(hash_string):
-            self._domain_cache.update_cache(hash_string)
-            result = self._domain_ip_map[hash_string]
             self.metrics.resolved_cached += 1
-            return result
+            self._domain_cache.refresh_time_to_live(hash_string)
+            return self._domain_cache[hash_string].value
 
         if self._timeout_cache.is_cached(hash_string):
             self.metrics.timeouts_cached += 1
@@ -296,14 +278,10 @@ class DomainResolver(Processor):
 
         result = self._resolve_ip(domain)
         match result:
-            case SuccessResult(_):
-                self._domain_cache.add(hash_string)
-                self._domain_ip_map.update({hash_string: result})
             case FailedResult(FailureType.TIMEOUT | FailureType.NO_NAMESERVERS):
                 self._timeout_cache.add(hash_string)
-            case FailedResult(_):
-                self._domain_cache.add(hash_string)
-                self._domain_ip_map.update({hash_string: result})
+            case _:
+                self._domain_cache.add(hash_string, result)
         self.metrics.resolved_new += 1
         return result
 
@@ -333,10 +311,3 @@ class DomainResolver(Processor):
             return FailedResult(FailureType.NO_ANSWER)
         except NoNameservers as error:
             return FailedResult(FailureType.NO_NAMESERVERS, error)
-
-    def _prune_domain_ip_map(self):
-        if self._domain_ip_map_prune_timer.finished():
-            self._domain_ip_map_prune_timer.reset()
-            removed_keys = set(self._domain_ip_map.keys()).difference(self._domain_cache.keys())
-            for hash_str in removed_keys:
-                self._domain_ip_map.pop(hash_str)

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -33,7 +33,6 @@ import logging
 import typing
 from datetime import timedelta
 from enum import IntEnum, auto
-from functools import cached_property
 from urllib.parse import urlsplit
 
 from attr import define, field, validators

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -32,7 +32,7 @@ Processor Configuration
 import logging
 import typing
 from datetime import timedelta
-from enum import IntEnum
+from enum import IntEnum, auto
 from functools import cached_property
 from urllib.parse import urlsplit
 
@@ -53,15 +53,15 @@ logger = logging.getLogger("DomainResolver")
 class FailureType(IntEnum):
     """Status of resolving domains"""
 
-    TIMEOUT = 0
+    TIMEOUT = auto()
     """Domain resolver timeout while trying to resolve the domain (this is not a socket timeout)"""
-    INVALID = 1
+    INVALID = auto()
     """The resolved domain was invalid and thus not resolved"""
-    UNKNOWN = 2
+    UNKNOWN = auto()
     """Tried to resolve the domain, but the domain is unknown"""
-    NO_ANSWER = 3
+    NO_ANSWER = auto()
     """The resolved domain was valid, but returned no data"""
-    NO_NAMESERVERS = 4
+    NO_NAMESERVERS = auto()
     """Nameservers do not exist or timed out"""
 
 

--- a/logprep/processor/domain_resolver/processor.py
+++ b/logprep/processor/domain_resolver/processor.py
@@ -258,7 +258,11 @@ class DomainResolver(Processor):
         if not domain_or_url_str:
             return
 
-        url = urlsplit(str(domain_or_url_str))
+        if not isinstance(domain_or_url_str, str):
+            self.metrics.invalid_domains += 1
+            return
+
+        url = urlsplit(domain_or_url_str)
         domain = url.hostname
         if url.scheme == "":
             domain = url.path

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -1,20 +1,44 @@
 """Module for caching items and checking if they need to be stored (again)."""
 
+import time
+from typing import Union
+
 import datetime
 from collections import OrderedDict
+
+
+class Timer:
+    """Timer that can be reset."""
+
+    def __init__(self, interval_sec: float):
+        self._interval_sec = interval_sec
+        self._finished_sec = time.time() + interval_sec
+
+    def reset(self):
+        """Reset timer"""
+        self._finished_sec = time.time() + self._interval_sec
+
+    def remaining(self):
+        """Return seconds until timer is finished"""
+        return max(self._finished_sec - time.time(), 0)
+
+    def finished(self):
+        """Return if timer is finished"""
+        return self.remaining() == 0
 
 
 class Cache(OrderedDict):
     """Caches items along with a timestamp of when they were last stored."""
 
-    EPOCH = datetime.datetime(1970, 1, 1)
-
-    def __init__(self, max_items=1000000, max_timedelta=datetime.timedelta(days=90.0)):
+    def __init__(
+        self, max_items=1000000, max_timedelta=datetime.timedelta(days=90.0), prune_interval=5
+    ):
         self._max_items = max_items
         self._max_timedelta = max_timedelta
+        self._prune_timer = Timer(prune_interval)
         super().__init__()
 
-    def requires_storing(self, item: int | str) -> bool:
+    def is_cached(self, item: Union[int, str]) -> bool:
         """Check if the item was stored within the last timedelta.
 
         Parameters
@@ -23,13 +47,52 @@ class Cache(OrderedDict):
             Name of item to check for in the cache.
 
         """
-        now = datetime.datetime.now()
-        last_stored = self.get(item, self.__class__.EPOCH)
-        self[item] = last_stored
-        self.move_to_end(item)
-        if self._max_timedelta.total_seconds() == 0.0 or now - last_stored > self._max_timedelta:
-            self[item] = now
-            if len(self) > self._max_items:
-                self.popitem(last=False)
+        last_stored = self.get(item)
+        if last_stored is None:
+            return False
+
+        if datetime.datetime.now() - last_stored > self._max_timedelta:
+            self.pop(item)
+            return False
+        return True
+
+    def add(self, item: Union[int, str]):
+        """Add the item into the cache or update its timestamp.
+
+        Parameters
+        ----------
+        item : str
+            Item to add into the cache.
+
+        """
+        if self.update_cache(item):
+            return
+
+        self[item] = datetime.datetime.now()
+        if len(self) > self._max_items:
+            self.popitem(last=False)
+
+    def update_cache(self, item: int | str) -> bool:
+        """Update the items timestamp inside the cache.
+
+        Parameters
+        ----------
+        item : str
+            Item whose timestamp to update in the cache.
+
+        """
+        last_stored = self.get(item)
+        if last_stored is not None:
+            self[item] = datetime.datetime.now()
             return True
         return False
+
+    def prune_decayed(self):
+        """Prune cache if timer is finished."""
+        if self._prune_timer.finished():
+            now = datetime.datetime.now()
+            to_prune = [key for key, added in self.items() if now - added > self._max_timedelta]
+            for item in to_prune:
+                if item in self:
+                    del self[item]
+            self._prune_timer.reset()

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -1,9 +1,9 @@
 """Module for caching items and checking if they need to be stored (again)."""
 
 import time
+from datetime import timedelta
 from typing import Union
 
-import datetime
 from collections import OrderedDict
 
 
@@ -31,7 +31,10 @@ class Cache(OrderedDict):
     """Caches items along with a timestamp of when they were last stored."""
 
     def __init__(
-        self, max_items=1000000, max_timedelta=datetime.timedelta(days=90.0), prune_interval=5
+        self,
+        max_items=1000000,
+        max_timedelta=timedelta(days=90).total_seconds(),
+        prune_interval=5,
     ):
         self._max_items = max_items
         self._max_timedelta = max_timedelta
@@ -51,7 +54,7 @@ class Cache(OrderedDict):
         if last_stored is None:
             return False
 
-        if datetime.datetime.now() - last_stored > self._max_timedelta:
+        if time.time() - last_stored > self._max_timedelta:
             self.pop(item)
             return False
         return True
@@ -68,7 +71,7 @@ class Cache(OrderedDict):
         if self.update_cache(item):
             return
 
-        self[item] = datetime.datetime.now()
+        self[item] = time.time()
         if len(self) > self._max_items:
             self.popitem(last=False)
 
@@ -83,14 +86,14 @@ class Cache(OrderedDict):
         """
         last_stored = self.get(item)
         if last_stored is not None:
-            self[item] = datetime.datetime.now()
+            self[item] = time.time()
             return True
         return False
 
     def prune_decayed(self):
         """Prune cache if timer is finished."""
         if self._prune_timer.finished():
-            now = datetime.datetime.now()
+            now = time.time()
             to_prune = [key for key, added in self.items() if now - added > self._max_timedelta]
             for item in to_prune:
                 if item in self:

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -1,30 +1,17 @@
 """Module for caching items and checking if they need to be stored (again)."""
 
 import time
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import Union
 
 from collections import OrderedDict
+from typing import Any
 
 
-class Timer:
-    """Timer that can be reset."""
-
-    def __init__(self, interval_sec: float):
-        self._interval_sec = interval_sec
-        self._finished_sec = time.time() + interval_sec
-
-    def reset(self):
-        """Reset timer"""
-        self._finished_sec = time.time() + self._interval_sec
-
-    def remaining(self):
-        """Return seconds until timer is finished"""
-        return max(self._finished_sec - time.time(), 0)
-
-    def finished(self):
-        """Return if timer is finished"""
-        return self.remaining() == 0
+@dataclass
+class CacheEntry:
+    value: Any
+    insertion_time: float
 
 
 class Cache(OrderedDict):
@@ -34,68 +21,65 @@ class Cache(OrderedDict):
         self,
         max_items=1000000,
         max_timedelta=timedelta(days=90).total_seconds(),
-        prune_interval=5,
     ):
         self._max_items = max_items
         self._max_timedelta = max_timedelta
-        self._prune_timer = Timer(prune_interval)
         super().__init__()
 
-    def is_cached(self, item: Union[int, str]) -> bool:
-        """Check if the item was stored within the last timedelta.
+    def __getitem__(self, key) -> CacheEntry:
+        return super().__getitem__(key)
+
+    def get(self, *args, **kwargs) -> CacheEntry | None:
+        """Get a cached item with the type CacheEntry."""
+        return super().get(*args, **kwargs)
+
+    def is_cached(self, key: str) -> bool:
+        """Check if the item has exceeded its time to live.
 
         Parameters
         ----------
-        item : str
+        key : str
             Name of item to check for in the cache.
 
         """
-        last_stored = self.get(item)
+        last_stored = self.get(key)
         if last_stored is None:
             return False
 
-        if time.time() - last_stored > self._max_timedelta:
-            self.pop(item)
+        if time.time() - last_stored.insertion_time > self._max_timedelta:
+            self.pop(key)
             return False
         return True
 
-    def add(self, item: int | str):
-        """Add the item into the cache or update its timestamp.
+    def add(self, key: str, value: Any = None):
+        """Add the item into the cache or refresh its time to live.
 
         Parameters
         ----------
-        item : str
-            Item to add into the cache.
+        key : str
+            Key for item to add into the cache.
+        value : Any
+            Value of item to add into the cache.
 
         """
-        if self.update_cache(item):
+        if self.refresh_time_to_live(key):
             return
 
-        self[item] = time.time()
+        self[key] = CacheEntry(value, time.time())
         if len(self) > self._max_items:
             self.popitem(last=False)
 
-    def update_cache(self, item: int | str) -> bool:
+    def refresh_time_to_live(self, key) -> bool:
         """Update the items timestamp inside the cache.
 
         Parameters
         ----------
-        item : str
+        key : str
             Item whose timestamp to update in the cache.
 
         """
-        last_stored = self.get(item)
+        last_stored = self.get(key)
         if last_stored is not None:
-            self[item] = time.time()
+            self[key].insertion_time = time.time()
             return True
         return False
-
-    def prune_decayed(self):
-        """Prune cache if timer is finished."""
-        if self._prune_timer.finished():
-            now = time.time()
-            to_prune = [key for key, added in self.items() if now - added > self._max_timedelta]
-            for item in to_prune:
-                if item in self:
-                    del self[item]
-            self._prune_timer.reset()

--- a/logprep/util/cache.py
+++ b/logprep/util/cache.py
@@ -59,7 +59,7 @@ class Cache(OrderedDict):
             return False
         return True
 
-    def add(self, item: Union[int, str]):
+    def add(self, item: int | str):
         """Add the item into the cache or update its timestamp.
 
         Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
   "uvloop<1",
   "httptools<1",
   "more-itertools>=11.1.0",
+  "dnspython==2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "uvloop<1",
   "httptools<1",
   "more-itertools>=11.1.0",
-  "dnspython==2.8.0",
+  "dnspython>=2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -1,21 +1,29 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+import datetime
+import re
+import time
 from copy import deepcopy
-from multiprocessing import context
-from pathlib import Path
+from typing import cast
 from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
+
+from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
+from logprep.ng.processor.domain_resolver.processor import (
+    DomainResolver,
+    FailureType,
+    FailedResult,
+    SuccessResult,
+)
 
 from logprep.factory import Factory
-from logprep.ng.abc.event import InputMeta, LogEvent
-from logprep.ng.processor.domain_resolver.processor import DomainResolver, ResolveStatus
-from logprep.processor.base.exceptions import FieldExistsWarning
-from tests.unit.ng.processor.base import BaseProcessorTestCase
-
-REL_TLD_LIST_PATH = "tests/testdata/external/public_suffix_list.dat"
-TLD_LIST = f"file://{Path().absolute().joinpath(REL_TLD_LIST_PATH).as_posix()}"
+from tests.unit.processor.base import BaseProcessorTestCase
 
 
-class TestDomainResolver(BaseProcessorTestCase[DomainResolver]):
+class TestDomainResolver(BaseProcessorTestCase):
     CONFIG = {
         "type": "domain_resolver",
         "rules": ["tests/testdata/unit/domain_resolver/rules"],
@@ -30,228 +38,282 @@ class TestDomainResolver(BaseProcessorTestCase[DomainResolver]):
         "logprep_domain_resolver_total_urls",
         "logprep_domain_resolver_resolved_new",
         "logprep_domain_resolver_resolved_cached",
+        "logprep_domain_resolver_resolved_domains",
         "logprep_domain_resolver_timeouts",
         "logprep_domain_resolver_invalid_domains",
         "logprep_domain_resolver_unknown_domains",
+        "logprep_domain_resolver_timeouts_cached",
     ]
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_domain_to_ip_resolved_and_added(self, mock_gethostbyname):
+    def test_domain_to_ip_resolved_and_added(self):
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
-        await self._load_rule(rule)
-        document = {"fqdn": "google.de"}
-        expected = {"fqdn": "google.de", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        mock_gethostbyname.assert_called_once()
-        assert log_event.data == expected
+        fqdn = "google.de"
+        self._load_rule(rule)
+        document = {"fqdn": fqdn}
+        expected = {"fqdn": fqdn, "resolved_ip": "1.2.3.4"}
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+            mock_resolve.assert_called_once()
+            mock_resolve.assert_called_with(fqdn, "A")
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_domain_to_ip_resolved_and_added_from_cache(self, mock_gethostbyname):
+    def test_domain_to_ip_timeout_cached(self):
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
-        await self._load_rule(rule)
+        self._load_rule(rule)
         document = {"fqdn": "google.de"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        document = {"fqdn": "google.de"}
-        expected = {"fqdn": "google.de", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        mock_gethostbyname.assert_called_once()
-        assert log_event.data == expected
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert len(self.object._timeout_cache) == 0
+            self.object.process(document)
+            mock_resolve.assert_called_once()
+            mock_resolve.side_effect = None
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert len(self.object._timeout_cache) == 1
+            self.object.process(document)
+            assert len(self.object._timeout_cache) == 1
+            mock_resolve.assert_called_once()
+        assert document.get("reoslved_ip") is None
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_url_to_ip_resolved_and_added(self, _):
+    def test_url_to_ip_resolved_and_added(self):
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        await self._load_rule(rule)
+        self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document == expected
 
-    async def test_domain_ip_map_greater_cache(self):
+    @pytest.mark.skip_autouse
+    def test_domain_invalid(self):
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"fqdn": "https://www.google.de"}
+
+        assert self.object.config.cache_enabled is True
+
+        with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
+            self.object.process(document)
+            mock_resolve.assert_called_with("www.google.de")
+
+        document = {"fqdn": "http://"}
+        with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
+            self.object.process(document)
+            mock_resolve.assert_not_called()
+
+    def test_domain_ip_map_not_in_cache_gets_pruned(self):
         config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 1})
-        self.object = Factory.create({"resolver": config})
+        config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        await self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        with mock.patch("socket.gethostbyname", return_value="1.2.3.4"):
-            await self.object.process(log_event)
-        document = {"url": "https://www.google.de/something_else"}
-        expected = {"url": "https://www.google.de/something_else", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        with mock.patch("socket.gethostbyname", return_value="1.2.3.4"):
-            await self.object.process(log_event)
-        assert log_event.data == expected
+        self._load_rule(rule)
+        document = {"url": "https://www.google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
+        document = {"url": "https://www.not-google.de"}
+        expected = {"url": "https://www.not-google.de", "resolved_ip": "5.6.7.8"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("5.6.7.8", mock_resolve)
+            domain_resolver.process(document)
+        assert document == expected
+        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
+        domain_resolver._domain_cache.popitem()
+        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
+        domain_resolver._domain_ip_map_prune_timer.reset()
+        domain_resolver._prune_domain_ip_map()
+        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
+        time.sleep(0.1)
+        domain_resolver._prune_domain_ip_map()
+        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
 
-    async def test_do_nothing_if_source_not_in_event(self):
+    def test_timeout_cache_gets_pruned(self):
+        def mark_cache_item_as_decayed_and_return_hash(resolver):
+            cached_hash_to_decay = next(iter(resolver._timeout_cache))
+            resolver._timeout_cache[cached_hash_to_decay] = datetime.datetime.min
+            return cached_hash_to_decay
+
+        config = deepcopy(self.CONFIG)
+        config.update({"max_cached_domains": 10})
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        rule = {
+            "filter": "url",
+            "domain_resolver": {"source_fields": ["url"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"url": "https://www.google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
+        document = {"url": "https://www.not-google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("5.6.7.8", mock_resolve)
+            domain_resolver.process(document)
+        assert document.get("resolved_ip") is None
+        assert len(domain_resolver._timeout_cache) == 2
+
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 2
+
+        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 2
+
+        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 1
+        assert cached_hash not in domain_resolver._timeout_cache
+
+        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
+        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 0
+        assert cached_hash not in domain_resolver._timeout_cache
+
+    def test_domain_timeout_gets_not_resolved(self):
+        config = deepcopy(self.CONFIG)
+        config.update({"max_cached_domains": 10})
+        rule = {
+            "filter": "url",
+            "domain_resolver": {"source_fields": ["url"]},
+            "description": "",
+        }
+
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        self._load_rule(rule)
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, SuccessResult)
+            assert result.resolved_ip == "1.2.3.4"
+            assert len(domain_resolver._timeout_cache) == 0
+
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        self._load_rule(rule)
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, FailedResult)
+            assert result.failure_type == FailureType.TIMEOUT
+            assert len(domain_resolver._timeout_cache) == 1
+
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, FailedResult)
+            assert result.failure_type == FailureType.TIMEOUT
+            assert len(domain_resolver._timeout_cache) == 1
+
+            domain_resolver._timeout_cache.clear()
+
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, SuccessResult)
+            assert result.resolved_ip == "1.2.3.4"
+            assert len(domain_resolver._timeout_cache) == 0
+
+    def test_do_nothing_if_source_not_in_event(self):
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["not_available"]},
             "description": "",
         }
-        await self._load_rule(rule)
+        self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        self.object.process(document)
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_url_to_ip_resolved_and_added_with_debug_cache(self, _):
-        config = deepcopy(self.CONFIG)
-        config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config})
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        await self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        expected = {
-            "url": "https://www.google.de/something",
-            "resolved_ip_debug": {"obtained_from_cache": False, "cache_size": 1},
-            "resolved_ip": "1.2.3.4",
-        }
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_url_to_ip_resolved_from_cache_and_added_with_debug_cache(self, _):
-        config = deepcopy(self.CONFIG)
-        config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config})
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        await self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        document = {"url": "https://www.google.de/something_else"}
-        expected = {
-            "url": "https://www.google.de/something_else",
-            "resolved_ip_debug": {"obtained_from_cache": True, "cache_size": 1},
-            "resolved_ip": "1.2.3.4",
-        }
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_url_to_ip_resolved_and_added_with_cache_disabled(self, _):
+    def test_url_to_ip_resolved_and_added_with_cache_disabled(self):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
-        self.object = Factory.create({"resolver": config})
+        domain_resolver = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        await self._load_rule(rule)
+        self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", side_effect=UnicodeError("invalid"), return_value="1.2.3.4")
-    async def test_invalid_domain_with_unicode_error_is_resolved_to_none_and_returns_status(
-        self, _
-    ):
-        resolved_ip, status = self.object._resolve_ip("google..invalid.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.INVALID
+    def test_domain_to_ip_not_resolved(self):
+        domain = "google.thisisnotavalidtld"
+        document = {"url": domain}
+        self.object.process(document)
+        assert document.get("resolved_ip") is None
 
-    @mock.patch("socket.gethostbyname", side_effect=context.TimeoutError, return_value="1.2.3.4")
-    async def test_valid_domain_with_timeout_error_is_resolved_to_none_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.TIMEOUT
-
-    @mock.patch("socket.gethostbyname", side_effect=OSError, return_value="1.2.3.4")
-    async def test_unknown_domain_with_os_error_is_resolved_to_none_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.UNKNOWN
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_existing_domain_is_resolved_to_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip == "1.2.3.4"
-        assert status is ResolveStatus.SUCCESS
-
-    async def test_empty_domain_is_snot_resolved(self):
-        document = {"url": " "}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data.get("resolved_ip") is None
-
-    async def test_domain_to_ip_not_resolved(self):
-        document = {"url": "google.thisisnotavalidtld"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data.get("resolved_ip") is None
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4", side_effect=TimeoutError)
-    async def test_domain_to_ip_timed_out(self, _):
+    def test_domain_to_ip_timed_out(self):
         document = {"url": "google.de"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data.get("resolved_ip") is None
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document.get("resolved_ip") is None
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_configured_dotted_subfield(self, _):
+    def test_configured_dotted_subfield(self):
         document = {"source": "google.de"}
         expected = {"source": "google.de", "resolved": {"ip": "1.2.3.4"}}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_field_exits_warning(self, _):
+    @staticmethod
+    def _mock_resolve_answer(expected_ip, mock_resolve):
+        mock_answer = MagicMock()
+        mock_answer.address = expected_ip
+        mock_resolve.return_value = [mock_answer]
+
+    def test_duplication_error(self):
         document = {"client": "google.de"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
 
-        result = await self.object.process(log_event)
-        assert len(result.warnings) == 1
-        assert isinstance(result.warnings[0], FieldExistsWarning)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = self.object.process(document)
+            assert len(result.warnings) == 1
+            assert isinstance(result.warnings[0], FieldExistsWarning)
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_no_duplication_error(self, _):
+    def test_no_duplication_error(self):
         document = {"client_2": "google.de"}
         expected = {"client_2": "google.de", "resolved_ip": "1.2.3.4"}
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
 
         # Rules have same effect, but are equal and thus one is ignored
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_overwrite_target_field(self, _):
+    def test_overwrite_target_field(self):
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"client": "google.de", "resolved": "1.2.3.4"}
         rule_dict = {
@@ -263,13 +325,13 @@ class TestDomainResolver(BaseProcessorTestCase[DomainResolver]):
             },
             "description": "",
         }
-        await self._load_rule(rule_dict)
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        self._load_rule(rule_dict)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    async def test_delete_source_field(self, _):
+    def test_delete_source_field(self):
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"resolved": "1.2.3.4"}
         rule_dict = {
@@ -282,7 +344,43 @@ class TestDomainResolver(BaseProcessorTestCase[DomainResolver]):
             },
             "description": "",
         }
-        await self._load_rule(rule_dict)
-        log_event = LogEvent(document, original=b"", input_meta=InputMeta())
-        await self.object.process(log_event)
-        assert log_event.data == expected
+        self._load_rule(rule_dict)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+        assert document == expected
+
+    def test_resolve_domain_syntax_error(self):
+        domain = ".."
+        result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.INVALID
+
+    def test_resolve_domain_too_big(self):
+        domain = "0" * 64
+        result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.INVALID
+
+    def test_resolve_domain_no_answer(self):
+        domain = "https://google.de"
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NoAnswer
+            result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.NO_ANSWER
+
+    def test_resole_domain_no_nameservers(self):
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"fqdn": "https://www.google.de"}
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NoNameservers
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = self.object.process(document)
+            assert len(result.warnings) == 1
+            assert isinstance(result.warnings[0], ProcessingWarning)
+            assert re.match(
+                ".*All nameservers failed to answer the query*", str(result.warnings[0])
+            )

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -87,6 +87,22 @@ class TestDomainResolver(BaseProcessorTestCase):
             mock_resolve.assert_called_once()
         assert event.data.get("reoslved_ip") is None
 
+    async def test_domain_is_no_string(self):
+        await self.object.setup()
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        await self._load_rule(rule)
+        document = {"fqdn": 123}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            await self.object.process(event)
+            mock_resolve.assert_not_called()
+        assert document.get("resolved_ip") is None
+
     async def test_url_to_ip_resolved_and_added(self):
         await self.object.setup()
         rule = {

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import datetime
 import re
 import time
 from copy import deepcopy
@@ -152,7 +151,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_timeout_cache_gets_pruned(self):
         def mark_cache_item_as_decayed_and_return_hash(resolver):
             cached_hash_to_decay = next(iter(resolver._timeout_cache))
-            resolver._timeout_cache[cached_hash_to_decay] = datetime.datetime.min
+            resolver._timeout_cache[cached_hash_to_decay] = 0
             return cached_hash_to_decay
 
         config = deepcopy(self.CONFIG)

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -207,7 +207,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, SuccessResult)
             assert result.resolved_ip == "1.2.3.4"
             assert len(domain_resolver._timeout_cache) == 0
@@ -217,21 +217,21 @@ class TestDomainResolver(BaseProcessorTestCase):
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, FailedResult)
             assert result.failure_type == FailureType.TIMEOUT
             assert len(domain_resolver._timeout_cache) == 1
 
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, FailedResult)
             assert result.failure_type == FailureType.TIMEOUT
             assert len(domain_resolver._timeout_cache) == 1
 
             domain_resolver._timeout_cache.clear()
 
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, SuccessResult)
             assert result.resolved_ip == "1.2.3.4"
             assert len(domain_resolver._timeout_cache) == 0

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -7,9 +7,9 @@ from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
-import pytest
 from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
 
+from logprep.ng.abc.event import LogEvent, InputMeta
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.ng.processor.domain_resolver.processor import (
     DomainResolver,
@@ -19,14 +19,10 @@ from logprep.ng.processor.domain_resolver.processor import (
 )
 
 from logprep.factory import Factory
-from tests.unit.processor.base import BaseProcessorTestCase
+from tests.unit.ng.processor.base import BaseProcessorTestCase
 
 
 class TestDomainResolver(BaseProcessorTestCase):
-    def setup_method(self):
-        super().setup_method()
-        self.object.setup()
-
     CONFIG = {
         "type": "domain_resolver",
         "rules": ["tests/testdata/unit/domain_resolver/rules"],
@@ -48,100 +44,110 @@ class TestDomainResolver(BaseProcessorTestCase):
         "logprep_domain_resolver_timeouts_cached",
     ]
 
-    def test_domain_to_ip_resolved_and_added(self):
+    async def test_domain_to_ip_resolved_and_added(self):
+        await self.object.setup()
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
         fqdn = "google.de"
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"fqdn": fqdn}
         expected = {"fqdn": fqdn, "resolved_ip": "1.2.3.4"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
             mock_resolve.assert_called_once()
             mock_resolve.assert_called_with(fqdn, "A")
         assert document == expected
 
-    def test_domain_to_ip_timeout_cached(self):
+    async def test_domain_to_ip_timeout_cached(self):
+        await self.object.setup()
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"fqdn": "google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
             assert len(self.object._timeout_cache) == 0
-            self.object.process(document)
+            await self.object.process(event)
             mock_resolve.assert_called_once()
             mock_resolve.side_effect = None
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
             assert len(self.object._timeout_cache) == 1
-            self.object.process(document)
+            await self.object.process(event)
             assert len(self.object._timeout_cache) == 1
             mock_resolve.assert_called_once()
-        assert document.get("reoslved_ip") is None
+        assert event.data.get("reoslved_ip") is None
 
-    def test_url_to_ip_resolved_and_added(self):
+    async def test_url_to_ip_resolved_and_added(self):
+        await self.object.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document == expected
 
-    @pytest.mark.skip_autouse
-    def test_domain_invalid(self):
+    async def test_domain_invalid(self):
+        await self.object.setup()
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"fqdn": "https://www.google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
 
         assert self.object.config.cache_enabled is True
 
         with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
-            self.object.process(document)
+            await self.object.process(event)
             mock_resolve.assert_called_with("www.google.de")
 
         document = {"fqdn": "http://"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
-            self.object.process(document)
+            await self.object.process(event)
             mock_resolve.assert_not_called()
 
-    def test_domain_ip_map_not_in_cache_gets_pruned(self):
+    async def test_domain_ip_map_not_in_cache_gets_pruned(self):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
+        await domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"url": "https://www.google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            domain_resolver.process(document)
+            await domain_resolver.process(event)
         document = {"url": "https://www.not-google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         expected = {"url": "https://www.not-google.de", "resolved_ip": "5.6.7.8"}
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            domain_resolver.process(document)
+            await domain_resolver.process(event)
         assert document == expected
         assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
         domain_resolver._domain_cache.popitem()
@@ -153,7 +159,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         domain_resolver._prune_domain_ip_map()
         assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
 
-    def test_timeout_cache_gets_pruned(self):
+    async def test_timeout_cache_gets_pruned(self):
         def mark_cache_item_as_decayed_and_return_hash(resolver):
             cached_hash_to_decay = next(iter(resolver._timeout_cache))
             resolver._timeout_cache[cached_hash_to_decay] = 0
@@ -162,24 +168,26 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
+        await domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"url": "https://www.google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            domain_resolver.process(document)
+            await domain_resolver.process(event)
         document = {"url": "https://www.not-google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            domain_resolver.process(document)
-        assert document.get("resolved_ip") is None
+            await domain_resolver.process(event)
+        assert event.data.get("resolved_ip") is None
         assert len(domain_resolver._timeout_cache) == 2
 
         domain_resolver._timeout_cache.prune_decayed()
@@ -200,7 +208,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         assert len(domain_resolver._timeout_cache) == 0
         assert cached_hash not in domain_resolver._timeout_cache
 
-    def test_domain_timeout_gets_not_resolved(self):
+    async def test_domain_timeout_gets_not_resolved(self):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10})
         rule = {
@@ -210,8 +218,8 @@ class TestDomainResolver(BaseProcessorTestCase):
         }
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
-        self._load_rule(rule)
+        await domain_resolver.setup()
+        await self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
             result = domain_resolver._resolve_with_cache("domain")
@@ -220,8 +228,8 @@ class TestDomainResolver(BaseProcessorTestCase):
             assert len(domain_resolver._timeout_cache) == 0
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
-        self._load_rule(rule)
+        await domain_resolver.setup()
+        await self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
@@ -244,56 +252,64 @@ class TestDomainResolver(BaseProcessorTestCase):
             assert result.resolved_ip == "1.2.3.4"
             assert len(domain_resolver._timeout_cache) == 0
 
-    def test_do_nothing_if_source_not_in_event(self):
+    async def test_do_nothing_if_source_not_in_event(self):
+        await self.object.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["not_available"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something"}
-        self.object.process(document)
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
+        await self.object.process(event)
         assert document == expected
 
-    def test_url_to_ip_resolved_and_added_with_cache_disabled(self):
+    async def test_url_to_ip_resolved_and_added_with_cache_disabled(self):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
-        domain_resolver = Factory.create({"resolver": config})
-        domain_resolver.setup()
+        domain_resolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        await domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            domain_resolver.process(document)
+            await domain_resolver.process(event)
         assert document == expected
 
-    def test_domain_to_ip_not_resolved(self):
+    async def test_domain_to_ip_not_resolved(self):
         domain = "google.thisisnotavalidtld"
         document = {"url": domain}
-        self.object.process(document)
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
+        await self.object.process(event)
         assert document.get("resolved_ip") is None
 
-    def test_domain_to_ip_timed_out(self):
+    async def test_domain_to_ip_timed_out(self):
+        await self.object.setup()
         document = {"url": "google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document.get("resolved_ip") is None
 
-    def test_configured_dotted_subfield(self):
+    async def test_configured_dotted_subfield(self):
+        await self.object.setup()
         document = {"source": "google.de"}
         expected = {"source": "google.de", "resolved": {"ip": "1.2.3.4"}}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document == expected
 
     @staticmethod
@@ -302,26 +318,31 @@ class TestDomainResolver(BaseProcessorTestCase):
         mock_answer.address = expected_ip
         mock_resolve.return_value = [mock_answer]
 
-    def test_duplication_error(self):
+    async def test_duplication_error(self):
+        await self.object.setup()
         document = {"client": "google.de"}
 
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = self.object.process(document)
+            result = await self.object.process(event)
             assert len(result.warnings) == 1
             assert isinstance(result.warnings[0], FieldExistsWarning)
 
-    def test_no_duplication_error(self):
+    async def test_no_duplication_error(self):
+        await self.object.setup()
         document = {"client_2": "google.de"}
         expected = {"client_2": "google.de", "resolved_ip": "1.2.3.4"}
 
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         # Rules have same effect, but are equal and thus one is ignored
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document == expected
 
-    def test_overwrite_target_field(self):
+    async def test_overwrite_target_field(self):
+        await self.object.setup()
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"client": "google.de", "resolved": "1.2.3.4"}
         rule_dict = {
@@ -333,13 +354,15 @@ class TestDomainResolver(BaseProcessorTestCase):
             },
             "description": "",
         }
-        self._load_rule(rule_dict)
+        await self._load_rule(rule_dict)
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document == expected
 
-    def test_delete_source_field(self):
+    async def test_delete_source_field(self):
+        await self.object.setup()
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"resolved": "1.2.3.4"}
         rule_dict = {
@@ -352,41 +375,47 @@ class TestDomainResolver(BaseProcessorTestCase):
             },
             "description": "",
         }
-        self._load_rule(rule_dict)
+        await self._load_rule(rule_dict)
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            self.object.process(document)
+            await self.object.process(event)
         assert document == expected
 
-    def test_resolve_domain_syntax_error(self):
+    async def test_resolve_domain_syntax_error(self):
+        await self.object.setup()
         domain = ".."
         result = self.object._resolve_ip(domain)
         assert result.failure_type == FailureType.INVALID
 
-    def test_resolve_domain_too_big(self):
+    async def test_resolve_domain_too_big(self):
+        await self.object.setup()
         domain = "0" * 64
         result = self.object._resolve_ip(domain)
         assert result.failure_type == FailureType.INVALID
 
-    def test_resolve_domain_no_answer(self):
+    async def test_resolve_domain_no_answer(self):
+        await self.object.setup()
         domain = "https://google.de"
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = NoAnswer
             result = self.object._resolve_ip(domain)
         assert result.failure_type == FailureType.NO_ANSWER
 
-    def test_resole_domain_no_nameservers(self):
+    async def test_resole_domain_no_nameservers(self):
+        await self.object.setup()
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
             "description": "",
         }
-        self._load_rule(rule)
+        await self._load_rule(rule)
         document = {"fqdn": "https://www.google.de"}
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
         with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = NoNameservers
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = self.object.process(document)
+            result = await self.object.process(event)
             assert len(result.warnings) == 1
             assert isinstance(result.warnings[0], ProcessingWarning)
             assert re.match(

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -1,13 +1,12 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 import re
-import time
 from copy import deepcopy
 from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
-from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
+from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer, NXDOMAIN
 
 from logprep.ng.abc.event import LogEvent, InputMeta
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
@@ -103,6 +102,28 @@ class TestDomainResolver(BaseProcessorTestCase):
             mock_resolve.assert_not_called()
         assert document.get("resolved_ip") is None
 
+    async def test_unknown_domain_exception(self):
+        await self.object.setup()
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        await self._load_rule(rule)
+        domain = "google.de"
+        document = {"fqdn": domain}
+        hash_str = self.object._hasher.hash_str(domain, salt=self.object.config.hash_salt)
+        event = LogEvent(document, original=b"", input_meta=InputMeta())
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NXDOMAIN
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert not self.object._domain_cache.is_cached(hash_str)
+            await self.object.process(event)
+            mock_resolve.assert_called_once()
+            assert self.object._domain_cache.is_cached(hash_str)
+            assert not self.object._domain_cache.is_cached("some_hash")
+        assert document.get("reoslved_ip") is None
+
     async def test_url_to_ip_resolved_and_added(self):
         await self.object.setup()
         rule = {
@@ -141,88 +162,6 @@ class TestDomainResolver(BaseProcessorTestCase):
         with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
             await self.object.process(event)
             mock_resolve.assert_not_called()
-
-    async def test_domain_ip_map_not_in_cache_gets_pruned(self):
-        config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
-        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        await domain_resolver.setup()
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        await self._load_rule(rule)
-        document = {"url": "https://www.google.de"}
-        event = LogEvent(document, original=b"", input_meta=InputMeta())
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            await domain_resolver.process(event)
-        document = {"url": "https://www.not-google.de"}
-        event = LogEvent(document, original=b"", input_meta=InputMeta())
-        expected = {"url": "https://www.not-google.de", "resolved_ip": "5.6.7.8"}
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            await domain_resolver.process(event)
-        assert document == expected
-        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
-        domain_resolver._domain_cache.popitem()
-        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
-        domain_resolver._domain_ip_map_prune_timer.reset()
-        domain_resolver._prune_domain_ip_map()
-        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
-        time.sleep(0.1)
-        domain_resolver._prune_domain_ip_map()
-        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
-
-    async def test_timeout_cache_gets_pruned(self):
-        def mark_cache_item_as_decayed_and_return_hash(resolver):
-            cached_hash_to_decay = next(iter(resolver._timeout_cache))
-            resolver._timeout_cache[cached_hash_to_decay] = 0
-            return cached_hash_to_decay
-
-        config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 10})
-        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        await domain_resolver.setup()
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        await self._load_rule(rule)
-        document = {"url": "https://www.google.de"}
-        event = LogEvent(document, original=b"", input_meta=InputMeta())
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            mock_resolve.side_effect = LifetimeTimeout
-            self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            await domain_resolver.process(event)
-        document = {"url": "https://www.not-google.de"}
-        event = LogEvent(document, original=b"", input_meta=InputMeta())
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            mock_resolve.side_effect = LifetimeTimeout
-            self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            await domain_resolver.process(event)
-        assert event.data.get("resolved_ip") is None
-        assert len(domain_resolver._timeout_cache) == 2
-
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 2
-
-        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 2
-
-        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 1
-        assert cached_hash not in domain_resolver._timeout_cache
-
-        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
-        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 0
-        assert cached_hash not in domain_resolver._timeout_cache
 
     async def test_domain_timeout_gets_not_resolved(self):
         config = deepcopy(self.CONFIG)

--- a/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/ng/processor/domain_resolver/test_domain_resolver.py
@@ -23,6 +23,10 @@ from tests.unit.processor.base import BaseProcessorTestCase
 
 
 class TestDomainResolver(BaseProcessorTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.object.setup()
+
     CONFIG = {
         "type": "domain_resolver",
         "rules": ["tests/testdata/unit/domain_resolver/rules"],
@@ -122,6 +126,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -157,6 +162,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -204,6 +210,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         }
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
@@ -213,6 +220,7 @@ class TestDomainResolver(BaseProcessorTestCase):
             assert len(domain_resolver._timeout_cache) == 0
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
@@ -252,6 +260,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
         domain_resolver = Factory.create({"resolver": config})
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -1,17 +1,26 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
+import datetime
+import re
+import time
 from copy import deepcopy
-from multiprocessing import context
-from pathlib import Path
+from typing import cast
 from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
+
+from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
+from logprep.processor.domain_resolver.processor import (
+    DomainResolver,
+    FailureType,
+    FailedResult,
+    SuccessResult,
+)
 
 from logprep.factory import Factory
-from logprep.processor.base.exceptions import FieldExistsWarning
-from logprep.processor.domain_resolver.processor import ResolveStatus
 from tests.unit.processor.base import BaseProcessorTestCase
-
-REL_TLD_LIST_PATH = "tests/testdata/external/public_suffix_list.dat"
-TLD_LIST = f"file://{Path().absolute().joinpath(REL_TLD_LIST_PATH).as_posix()}"
 
 
 class TestDomainResolver(BaseProcessorTestCase):
@@ -29,17 +38,31 @@ class TestDomainResolver(BaseProcessorTestCase):
         "logprep_domain_resolver_total_urls",
         "logprep_domain_resolver_resolved_new",
         "logprep_domain_resolver_resolved_cached",
+        "logprep_domain_resolver_resolved_domains",
         "logprep_domain_resolver_timeouts",
         "logprep_domain_resolver_invalid_domains",
         "logprep_domain_resolver_unknown_domains",
+        "logprep_domain_resolver_timeouts_cached",
     ]
 
-    def setup_method(self) -> None:
-        super().setup_method()
-        self.object._cache.clear()
+    def test_domain_to_ip_resolved_and_added(self):
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        fqdn = "google.de"
+        self._load_rule(rule)
+        document = {"fqdn": fqdn}
+        expected = {"fqdn": fqdn, "resolved_ip": "1.2.3.4"}
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+            mock_resolve.assert_called_once()
+            mock_resolve.assert_called_with(fqdn, "A")
+        assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_domain_to_ip_resolved_and_added(self, mock_gethostbyname):
+    def test_domain_to_ip_timeout_cached(self):
         rule = {
             "filter": "fqdn",
             "domain_resolver": {"source_fields": ["fqdn"]},
@@ -47,29 +70,21 @@ class TestDomainResolver(BaseProcessorTestCase):
         }
         self._load_rule(rule)
         document = {"fqdn": "google.de"}
-        expected = {"fqdn": "google.de", "resolved_ip": "1.2.3.4"}
-        self.object.process(document)
-        mock_gethostbyname.assert_called_once()
-        assert document == expected
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert len(self.object._timeout_cache) == 0
+            self.object.process(document)
+            mock_resolve.assert_called_once()
+            mock_resolve.side_effect = None
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert len(self.object._timeout_cache) == 1
+            self.object.process(document)
+            assert len(self.object._timeout_cache) == 1
+            mock_resolve.assert_called_once()
+        assert document.get("reoslved_ip") is None
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_domain_to_ip_resolved_and_added_from_cache(self, mock_gethostbyname):
-        rule = {
-            "filter": "fqdn",
-            "domain_resolver": {"source_fields": ["fqdn"]},
-            "description": "",
-        }
-        self._load_rule(rule)
-        document = {"fqdn": "google.de"}
-        self.object.process(document)
-        document = {"fqdn": "google.de"}
-        expected = {"fqdn": "google.de", "resolved_ip": "1.2.3.4"}
-        self.object.process(document)
-        mock_gethostbyname.assert_called_once()
-        assert document == expected
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_url_to_ip_resolved_and_added(self, _):
+    def test_url_to_ip_resolved_and_added(self):
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -78,27 +93,149 @@ class TestDomainResolver(BaseProcessorTestCase):
         self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document == expected
 
-    def test_domain_ip_map_greater_cache(self):
+    @pytest.mark.skip_autouse
+    def test_domain_invalid(self):
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"fqdn": "https://www.google.de"}
+
+        assert self.object.config.cache_enabled is True
+
+        with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
+            self.object.process(document)
+            mock_resolve.assert_called_with("www.google.de")
+
+        document = {"fqdn": "http://"}
+        with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
+            self.object.process(document)
+            mock_resolve.assert_not_called()
+
+    def test_domain_ip_map_not_in_cache_gets_pruned(self):
         config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 1})
-        self.object = Factory.create({"resolver": config})
+        config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
             "description": "",
         }
         self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        with mock.patch("socket.gethostbyname", return_value="1.2.3.4"):
-            self.object.process(document)
-        document = {"url": "https://www.google.de/something_else"}
-        expected = {"url": "https://www.google.de/something_else", "resolved_ip": "1.2.3.4"}
-        with mock.patch("socket.gethostbyname", return_value="1.2.3.4"):
-            self.object.process(document)
+        document = {"url": "https://www.google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
+        document = {"url": "https://www.not-google.de"}
+        expected = {"url": "https://www.not-google.de", "resolved_ip": "5.6.7.8"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("5.6.7.8", mock_resolve)
+            domain_resolver.process(document)
         assert document == expected
+        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
+        domain_resolver._domain_cache.popitem()
+        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
+        domain_resolver._domain_ip_map_prune_timer.reset()
+        domain_resolver._prune_domain_ip_map()
+        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
+        time.sleep(0.1)
+        domain_resolver._prune_domain_ip_map()
+        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
+
+    def test_timeout_cache_gets_pruned(self):
+        def mark_cache_item_as_decayed_and_return_hash(resolver):
+            cached_hash_to_decay = next(iter(resolver._timeout_cache))
+            resolver._timeout_cache[cached_hash_to_decay] = datetime.datetime.min
+            return cached_hash_to_decay
+
+        config = deepcopy(self.CONFIG)
+        config.update({"max_cached_domains": 10})
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        rule = {
+            "filter": "url",
+            "domain_resolver": {"source_fields": ["url"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"url": "https://www.google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
+        document = {"url": "https://www.not-google.de"}
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("5.6.7.8", mock_resolve)
+            domain_resolver.process(document)
+        assert document.get("resolved_ip") is None
+        assert len(domain_resolver._timeout_cache) == 2
+
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 2
+
+        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 2
+
+        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 1
+        assert cached_hash not in domain_resolver._timeout_cache
+
+        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
+        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
+        domain_resolver._timeout_cache.prune_decayed()
+        assert len(domain_resolver._timeout_cache) == 0
+        assert cached_hash not in domain_resolver._timeout_cache
+
+    def test_domain_timeout_gets_not_resolved(self):
+        config = deepcopy(self.CONFIG)
+        config.update({"max_cached_domains": 10})
+        rule = {
+            "filter": "url",
+            "domain_resolver": {"source_fields": ["url"]},
+            "description": "",
+        }
+
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        self._load_rule(rule)
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, SuccessResult)
+            assert result.resolved_ip == "1.2.3.4"
+            assert len(domain_resolver._timeout_cache) == 0
+
+        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        self._load_rule(rule)
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, FailedResult)
+            assert result.failure_type == FailureType.TIMEOUT
+            assert len(domain_resolver._timeout_cache) == 1
+
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, FailedResult)
+            assert result.failure_type == FailureType.TIMEOUT
+            assert len(domain_resolver._timeout_cache) == 1
+
+            domain_resolver._timeout_cache.clear()
+
+            result = domain_resolver._resolve_with_timeout_check("domain")
+            assert isinstance(result, SuccessResult)
+            assert result.resolved_ip == "1.2.3.4"
+            assert len(domain_resolver._timeout_cache) == 0
 
     def test_do_nothing_if_source_not_in_event(self):
         rule = {
@@ -112,53 +249,10 @@ class TestDomainResolver(BaseProcessorTestCase):
         self.object.process(document)
         assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_url_to_ip_resolved_and_added_with_debug_cache(self, _):
-        config = deepcopy(self.CONFIG)
-        config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config})
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        expected = {
-            "url": "https://www.google.de/something",
-            "resolved_ip_debug": {"obtained_from_cache": False, "cache_size": 1},
-            "resolved_ip": "1.2.3.4",
-        }
-        self.object.process(document)
-        assert document == expected
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_url_to_ip_resolved_from_cache_and_added_with_debug_cache(self, _):
-        config = deepcopy(self.CONFIG)
-        config.update({"debug_cache": True})
-        self.object = Factory.create({"resolver": config})
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        self._load_rule(rule)
-        document = {"url": "https://www.google.de/something"}
-        self.object.process(document)
-        document = {"url": "https://www.google.de/something_else"}
-        expected = {
-            "url": "https://www.google.de/something_else",
-            "resolved_ip_debug": {"obtained_from_cache": True, "cache_size": 1},
-            "resolved_ip": "1.2.3.4",
-        }
-        self.object.process(document)
-        assert document == expected
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_url_to_ip_resolved_and_added_with_cache_disabled(self, _):
+    def test_url_to_ip_resolved_and_added_with_cache_disabled(self):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
-        self.object = Factory.create({"resolver": config})
+        domain_resolver = Factory.create({"resolver": config})
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -167,75 +261,59 @@ class TestDomainResolver(BaseProcessorTestCase):
         self._load_rule(rule)
         document = {"url": "https://www.google.de/something"}
         expected = {"url": "https://www.google.de/something", "resolved_ip": "1.2.3.4"}
-        self.object.process(document)
+        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            domain_resolver.process(document)
         assert document == expected
-
-    @mock.patch("socket.gethostbyname", side_effect=UnicodeError("invalid"), return_value="1.2.3.4")
-    def test_invalid_domain_with_unicode_error_is_resolved_to_none_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google..invalid.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.INVALID
-
-    @mock.patch("socket.gethostbyname", side_effect=context.TimeoutError, return_value="1.2.3.4")
-    def test_valid_domain_with_timeout_error_is_resolved_to_none_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.TIMEOUT
-
-    @mock.patch("socket.gethostbyname", side_effect=OSError, return_value="1.2.3.4")
-    def test_unknown_domain_with_os_error_is_resolved_to_none_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip is None
-        assert status is ResolveStatus.UNKNOWN
-
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_existing_domain_is_resolved_to_and_returns_status(self, _):
-        resolved_ip, status = self.object._resolve_ip("google.de")
-        assert resolved_ip == "1.2.3.4"
-        assert status is ResolveStatus.SUCCESS
-
-    def test_empty_domain_is_snot_resolved(self):
-        document = {"url": " "}
-        self.object.process(document)
-        assert document.get("resolved_ip") is None
 
     def test_domain_to_ip_not_resolved(self):
-        document = {"url": "google.thisisnotavalidtld"}
+        domain = "google.thisisnotavalidtld"
+        document = {"url": domain}
         self.object.process(document)
         assert document.get("resolved_ip") is None
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4", side_effect=TimeoutError)
-    def test_domain_to_ip_timed_out(self, _):
+    def test_domain_to_ip_timed_out(self):
         document = {"url": "google.de"}
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = LifetimeTimeout
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document.get("resolved_ip") is None
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_configured_dotted_subfield(self, _):
+    def test_configured_dotted_subfield(self):
         document = {"source": "google.de"}
         expected = {"source": "google.de", "resolved": {"ip": "1.2.3.4"}}
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_field_exits_warning(self, _):
+    @staticmethod
+    def _mock_resolve_answer(expected_ip, mock_resolve):
+        mock_answer = MagicMock()
+        mock_answer.address = expected_ip
+        mock_resolve.return_value = [mock_answer]
+
+    def test_duplication_error(self):
         document = {"client": "google.de"}
 
-        result = self.object.process(document)
-        assert len(result.warnings) == 1
-        assert isinstance(result.warnings[0], FieldExistsWarning)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = self.object.process(document)
+            assert len(result.warnings) == 1
+            assert isinstance(result.warnings[0], FieldExistsWarning)
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_no_duplication_error(self, _):
+    def test_no_duplication_error(self):
         document = {"client_2": "google.de"}
         expected = {"client_2": "google.de", "resolved_ip": "1.2.3.4"}
 
         # Rules have same effect, but are equal and thus one is ignored
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_overwrite_target_field(self, _):
+    def test_overwrite_target_field(self):
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"client": "google.de", "resolved": "1.2.3.4"}
         rule_dict = {
@@ -248,11 +326,12 @@ class TestDomainResolver(BaseProcessorTestCase):
             "description": "",
         }
         self._load_rule(rule_dict)
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document == expected
 
-    @mock.patch("socket.gethostbyname", return_value="1.2.3.4")
-    def test_delete_source_field(self, _):
+    def test_delete_source_field(self):
         document = {"client": "google.de", "resolved": "this will be overwritten"}
         expected = {"resolved": "1.2.3.4"}
         rule_dict = {
@@ -266,5 +345,42 @@ class TestDomainResolver(BaseProcessorTestCase):
             "description": "",
         }
         self._load_rule(rule_dict)
-        self.object.process(document)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
         assert document == expected
+
+    def test_resolve_domain_syntax_error(self):
+        domain = ".."
+        result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.INVALID
+
+    def test_resolve_domain_too_big(self):
+        domain = "0" * 64
+        result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.INVALID
+
+    def test_resolve_domain_no_answer(self):
+        domain = "https://google.de"
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NoAnswer
+            result = self.object._resolve_ip(domain)
+        assert result.failure_type == FailureType.NO_ANSWER
+
+    def test_resole_domain_no_nameservers(self):
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"fqdn": "https://www.google.de"}
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NoNameservers
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            result = self.object.process(document)
+            assert len(result.warnings) == 1
+            assert isinstance(result.warnings[0], ProcessingWarning)
+            assert re.match(
+                ".*All nameservers failed to answer the query*", str(result.warnings[0])
+            )

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -86,6 +86,21 @@ class TestDomainResolver(BaseProcessorTestCase):
             mock_resolve.assert_called_once()
         assert document.get("reoslved_ip") is None
 
+    def test_domain_is_no_string(self):
+        self.object.setup()
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        document = {"fqdn": 123}
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            self.object.process(document)
+            mock_resolve.assert_not_called()
+        assert document.get("resolved_ip") is None
+
     def test_url_to_ip_resolved_and_added(self):
         rule = {
             "filter": "url",

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -7,7 +7,6 @@ from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
-import pytest
 from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
 
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
@@ -101,7 +100,6 @@ class TestDomainResolver(BaseProcessorTestCase):
             self.object.process(document)
         assert document == expected
 
-    @pytest.mark.skip_autouse
     def test_domain_invalid(self):
         rule = {
             "filter": "fqdn",

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import datetime
 import re
 import time
 from copy import deepcopy
@@ -152,7 +151,7 @@ class TestDomainResolver(BaseProcessorTestCase):
     def test_timeout_cache_gets_pruned(self):
         def mark_cache_item_as_decayed_and_return_hash(resolver):
             cached_hash_to_decay = next(iter(resolver._timeout_cache))
-            resolver._timeout_cache[cached_hash_to_decay] = datetime.datetime.min
+            resolver._timeout_cache[cached_hash_to_decay] = 0
             return cached_hash_to_decay
 
         config = deepcopy(self.CONFIG)

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -1,13 +1,12 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 import re
-import time
 from copy import deepcopy
 from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
-from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer
+from dns.resolver import LifetimeTimeout, NoNameservers, NoAnswer, NXDOMAIN
 
 from logprep.processor.base.exceptions import FieldExistsWarning, ProcessingWarning
 from logprep.processor.domain_resolver.processor import (
@@ -101,6 +100,27 @@ class TestDomainResolver(BaseProcessorTestCase):
             mock_resolve.assert_not_called()
         assert document.get("resolved_ip") is None
 
+    def test_unknown_domain_exception(self):
+        self.object.setup()
+        rule = {
+            "filter": "fqdn",
+            "domain_resolver": {"source_fields": ["fqdn"]},
+            "description": "",
+        }
+        self._load_rule(rule)
+        domain = "google.de"
+        document = {"fqdn": domain}
+        hash_str = self.object._hasher.hash_str(domain, salt=self.object.config.hash_salt)
+        with mock.patch.object(self.object._dns_resolver, "resolve") as mock_resolve:
+            mock_resolve.side_effect = NXDOMAIN
+            self._mock_resolve_answer("1.2.3.4", mock_resolve)
+            assert not self.object._domain_cache.is_cached(hash_str)
+            self.object.process(document)
+            mock_resolve.assert_called_once()
+            assert self.object._domain_cache.is_cached(hash_str)
+            assert not self.object._domain_cache.is_cached("some_hash")
+        assert document.get("reoslved_ip") is None
+
     def test_url_to_ip_resolved_and_added(self):
         rule = {
             "filter": "url",
@@ -134,84 +154,6 @@ class TestDomainResolver(BaseProcessorTestCase):
         with mock.patch.object(self.object, "_resolve_with_cache") as mock_resolve:
             self.object.process(document)
             mock_resolve.assert_not_called()
-
-    def test_domain_ip_map_not_in_cache_gets_pruned(self):
-        config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
-        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        self._load_rule(rule)
-        document = {"url": "https://www.google.de"}
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            domain_resolver.process(document)
-        document = {"url": "https://www.not-google.de"}
-        expected = {"url": "https://www.not-google.de", "resolved_ip": "5.6.7.8"}
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            domain_resolver.process(document)
-        assert document == expected
-        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
-        domain_resolver._domain_cache.popitem()
-        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
-        domain_resolver._domain_ip_map_prune_timer.reset()
-        domain_resolver._prune_domain_ip_map()
-        assert len(domain_resolver._domain_ip_map) > len(domain_resolver._domain_cache)
-        time.sleep(0.1)
-        domain_resolver._prune_domain_ip_map()
-        assert len(domain_resolver._domain_ip_map) == len(domain_resolver._domain_cache)
-
-    def test_timeout_cache_gets_pruned(self):
-        def mark_cache_item_as_decayed_and_return_hash(resolver):
-            cached_hash_to_decay = next(iter(resolver._timeout_cache))
-            resolver._timeout_cache[cached_hash_to_decay] = 0
-            return cached_hash_to_decay
-
-        config = deepcopy(self.CONFIG)
-        config.update({"max_cached_domains": 10})
-        domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
-        domain_resolver.setup()
-        rule = {
-            "filter": "url",
-            "domain_resolver": {"source_fields": ["url"]},
-            "description": "",
-        }
-        self._load_rule(rule)
-        document = {"url": "https://www.google.de"}
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            mock_resolve.side_effect = LifetimeTimeout
-            self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            domain_resolver.process(document)
-        document = {"url": "https://www.not-google.de"}
-        with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
-            mock_resolve.side_effect = LifetimeTimeout
-            self._mock_resolve_answer("5.6.7.8", mock_resolve)
-            domain_resolver.process(document)
-        assert document.get("resolved_ip") is None
-        assert len(domain_resolver._timeout_cache) == 2
-
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 2
-
-        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 2
-
-        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 1
-        assert cached_hash not in domain_resolver._timeout_cache
-
-        cached_hash = mark_cache_item_as_decayed_and_return_hash(domain_resolver)
-        domain_resolver._timeout_cache._prune_timer._finished_sec = 0
-        domain_resolver._timeout_cache.prune_decayed()
-        assert len(domain_resolver._timeout_cache) == 0
-        assert cached_hash not in domain_resolver._timeout_cache
 
     def test_domain_timeout_gets_not_resolved(self):
         config = deepcopy(self.CONFIG)

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -207,7 +207,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, SuccessResult)
             assert result.resolved_ip == "1.2.3.4"
             assert len(domain_resolver._timeout_cache) == 0
@@ -217,21 +217,21 @@ class TestDomainResolver(BaseProcessorTestCase):
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, FailedResult)
             assert result.failure_type == FailureType.TIMEOUT
             assert len(domain_resolver._timeout_cache) == 1
 
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, FailedResult)
             assert result.failure_type == FailureType.TIMEOUT
             assert len(domain_resolver._timeout_cache) == 1
 
             domain_resolver._timeout_cache.clear()
 
-            result = domain_resolver._resolve_with_timeout_check("domain")
+            result = domain_resolver._resolve_with_cache("domain")
             assert isinstance(result, SuccessResult)
             assert result.resolved_ip == "1.2.3.4"
             assert len(domain_resolver._timeout_cache) == 0

--- a/tests/unit/processor/domain_resolver/test_domain_resolver.py
+++ b/tests/unit/processor/domain_resolver/test_domain_resolver.py
@@ -23,6 +23,10 @@ from tests.unit.processor.base import BaseProcessorTestCase
 
 
 class TestDomainResolver(BaseProcessorTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.object.setup()
+
     CONFIG = {
         "type": "domain_resolver",
         "rules": ["tests/testdata/unit/domain_resolver/rules"],
@@ -122,6 +126,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10, "cache_prune_interval": 0.1})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -157,6 +162,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"max_cached_domains": 10})
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},
@@ -204,6 +210,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         }
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             self._mock_resolve_answer("1.2.3.4", mock_resolve)
@@ -213,6 +220,7 @@ class TestDomainResolver(BaseProcessorTestCase):
             assert len(domain_resolver._timeout_cache) == 0
 
         domain_resolver: DomainResolver = cast(DomainResolver, Factory.create({"resolver": config}))
+        domain_resolver.setup()
         self._load_rule(rule)
         with mock.patch.object(domain_resolver._dns_resolver, "resolve") as mock_resolve:
             mock_resolve.side_effect = LifetimeTimeout
@@ -252,6 +260,7 @@ class TestDomainResolver(BaseProcessorTestCase):
         config = deepcopy(self.CONFIG)
         config.update({"cache_enabled": False})
         domain_resolver = Factory.create({"resolver": config})
+        domain_resolver.setup()
         rule = {
             "filter": "url",
             "domain_resolver": {"source_fields": ["url"]},

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -99,5 +99,7 @@ class TestCache:
         assert cache.is_cached("foo")
         old_decay_time = cache.get("foo")
         time.sleep(0.1)
-        cache.add("foo")
-        assert cache.get("foo") > old_decay_time
+        new_decay = cache.add("foo")
+        assert new_decay is not None
+        assert old_decay_time is not None
+        assert new_decay > old_decay_time

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -6,16 +6,37 @@ from collections import OrderedDict
 
 import pytest
 
-from logprep.util.cache import Cache
+from logprep.util.cache import Cache, Timer
 
 
 @pytest.fixture(name="cache")
 def cache_fixture():
-    return Cache(max_items=3, max_timedelta=datetime.timedelta(milliseconds=100))
+    return Cache(
+        max_items=3, max_timedelta=datetime.timedelta(milliseconds=100), prune_interval=0.1
+    )
+
+
+class TestTimer:
+    def test_reset_timer(self):
+        timer = Timer(60)
+        start_remaining = timer.remaining()
+        time.sleep(0.01)  # nosemgrep
+        assert timer.remaining() < start_remaining
+        pre_reset = timer.remaining()
+        time.sleep(0.01)  # nosemgrep
+        timer.reset()
+        assert timer.remaining() > pre_reset
+
+    def test_finished(self):
+        timer = Timer(0.1)
+        time.sleep(0.01)  # nosemgrep
+        assert not timer.finished()
+        time.sleep(0.1)  # nosemgrep
+        assert timer.finished()
 
 
 class TestCache:
-    def test_is_ordered_dict(self, cache):
+    def test_is_ordered_dict(self, cache: Cache):
         assert isinstance(cache, OrderedDict)
 
     def test_init_default(self):
@@ -23,27 +44,60 @@ class TestCache:
         assert default_cache._max_items == 1000000
         assert default_cache._max_timedelta == datetime.timedelta(days=90)
 
-    def test_init_custom(self, cache):
+    def test_init_custom(self, cache: Cache):
         assert cache._max_items == 3
         assert cache._max_timedelta == datetime.timedelta(milliseconds=100)
 
-    def test_new_cache_is_empty(self, cache):
+    def test_new_cache_is_empty(self, cache: Cache):
         assert not cache
 
-    def test_requires_storing_nonzero_deltatime(self, cache):
+    def test_is_cached_nonzero_deltatime(self, cache: Cache):
         for _ in range(3):
-            assert cache.requires_storing("foo")
-            assert not cache.requires_storing("foo")
+            assert not cache.is_cached("foo")
+            cache.add("foo")
+            assert cache.is_cached("foo")
             time.sleep(0.1)  # nosemgrep
 
-    def test_requires_storing_zero_deltatime(self, cache):
+    def test_is_cached_zero_deltatime(self, cache: Cache):
         cache._max_timedelta = datetime.timedelta(days=0)
         for _ in range(10):
-            assert cache.requires_storing("foo")
+            assert not cache.is_cached("foo")
 
-    def test_max_items(self, cache):
+    def test_max_items_add(self, cache):
         extra_items = 3
+        cache_hash = hash(frozenset(cache))
         for i in range(cache._max_items + extra_items):
-            assert cache.requires_storing(i)
+            cache.add(i)
+            new_cache_hash = hash(frozenset(cache))
+            assert cache_hash != new_cache_hash
+            cache_hash = new_cache_hash
             assert len(cache) == min(i + 1, cache._max_items)
         assert set(cache.keys()) == set(range(extra_items, cache._max_items + extra_items))
+
+    def test_prune_decayed(self, cache: Cache):
+        for idx in range(3):
+            cache.add(idx)
+            cache.prune_decayed()
+            assert idx in cache
+            time.sleep(cache._prune_timer.remaining() + 0.005)  # nosemgrep
+            assert idx in cache
+            cache.prune_decayed()
+            assert idx not in cache
+
+    def test_prune_decayed_and_keep_rest(self, cache: Cache):
+        cache.add(0)
+        time.sleep(0.15)
+        cache.add(1)
+        cache.add(2)
+        assert len(cache) == 3
+        cache.prune_decayed()
+        assert len(cache) == 2
+
+    def test_add_refreshes(self, cache: Cache):
+        assert not cache.is_cached("foo")
+        cache.add("foo")
+        assert cache.is_cached("foo")
+        old_decay_time = cache.get("foo")
+        time.sleep(0.1)
+        cache.add("foo")
+        assert cache.get("foo") > old_decay_time

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -99,7 +99,8 @@ class TestCache:
         assert cache.is_cached("foo")
         old_decay_time = cache.get("foo")
         time.sleep(0.1)
-        new_decay = cache.add("foo")
+        cache.add("foo")
+        new_decay = cache.get("foo")
         assert new_decay is not None
         assert old_decay_time is not None
         assert new_decay > old_decay_time

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -6,33 +6,12 @@ from datetime import timedelta
 
 import pytest
 
-from logprep.util.cache import Cache, Timer
+from logprep.util.cache import Cache
 
 
 @pytest.fixture(name="cache")
 def cache_fixture():
-    return Cache(
-        max_items=3, max_timedelta=0.1, prune_interval=0.1
-    )
-
-
-class TestTimer:
-    def test_reset_timer(self):
-        timer = Timer(60)
-        start_remaining = timer.remaining()
-        time.sleep(0.01)  # nosemgrep
-        assert timer.remaining() < start_remaining
-        pre_reset = timer.remaining()
-        time.sleep(0.01)  # nosemgrep
-        timer.reset()
-        assert timer.remaining() > pre_reset
-
-    def test_finished(self):
-        timer = Timer(0.1)
-        time.sleep(0.01)  # nosemgrep
-        assert not timer.finished()
-        time.sleep(0.1)  # nosemgrep
-        assert timer.finished()
+    return Cache(max_items=3, max_timedelta=0.1)
 
 
 class TestCache:
@@ -74,33 +53,14 @@ class TestCache:
             assert len(cache) == min(i + 1, cache._max_items)
         assert set(cache.keys()) == set(range(extra_items, cache._max_items + extra_items))
 
-    def test_prune_decayed(self, cache: Cache):
-        for idx in range(3):
-            cache.add(idx)
-            cache.prune_decayed()
-            assert idx in cache
-            time.sleep(cache._prune_timer.remaining() + 0.005)  # nosemgrep
-            assert idx in cache
-            cache.prune_decayed()
-            assert idx not in cache
-
-    def test_prune_decayed_and_keep_rest(self, cache: Cache):
-        cache.add(0)
-        time.sleep(0.15)
-        cache.add(1)
-        cache.add(2)
-        assert len(cache) == 3
-        cache.prune_decayed()
-        assert len(cache) == 2
-
     def test_add_refreshes(self, cache: Cache):
         assert not cache.is_cached("foo")
         cache.add("foo")
         assert cache.is_cached("foo")
-        old_decay_time = cache.get("foo")
+        old_decay_time = cache.get("foo").insertion_time
         time.sleep(0.1)
         cache.add("foo")
-        new_decay = cache.get("foo")
+        new_decay = cache.get("foo").insertion_time
         assert new_decay is not None
         assert old_decay_time is not None
         assert new_decay > old_decay_time

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import datetime
 import time
 from collections import OrderedDict
+from datetime import timedelta
 
 import pytest
 
@@ -12,7 +12,7 @@ from logprep.util.cache import Cache, Timer
 @pytest.fixture(name="cache")
 def cache_fixture():
     return Cache(
-        max_items=3, max_timedelta=datetime.timedelta(milliseconds=100), prune_interval=0.1
+        max_items=3, max_timedelta=0.1, prune_interval=0.1
     )
 
 
@@ -42,11 +42,11 @@ class TestCache:
     def test_init_default(self):
         default_cache = Cache()
         assert default_cache._max_items == 1000000
-        assert default_cache._max_timedelta == datetime.timedelta(days=90)
+        assert default_cache._max_timedelta == timedelta(days=90).total_seconds()
 
     def test_init_custom(self, cache: Cache):
         assert cache._max_items == 3
-        assert cache._max_timedelta == datetime.timedelta(milliseconds=100)
+        assert cache._max_timedelta == 0.1
 
     def test_new_cache_is_empty(self, cache: Cache):
         assert not cache
@@ -59,7 +59,7 @@ class TestCache:
             time.sleep(0.1)  # nosemgrep
 
     def test_is_cached_zero_deltatime(self, cache: Cache):
-        cache._max_timedelta = datetime.timedelta(days=0)
+        cache._max_timedelta = 0
         for _ in range(10):
             assert not cache.is_cached("foo")
 

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -57,10 +57,10 @@ class TestCache:
         assert not cache.is_cached("foo")
         cache.add("foo")
         assert cache.is_cached("foo")
-        old_decay_time = cache.get("foo").insertion_time
+        old_decay_time = cache["foo"].insertion_time
         time.sleep(0.1)
         cache.add("foo")
-        new_decay = cache.get("foo").insertion_time
+        new_decay = cache["foo"].insertion_time
         assert new_decay is not None
         assert old_decay_time is not None
         assert new_decay > old_decay_time

--- a/uv.lock
+++ b/uv.lock
@@ -836,6 +836,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1457,6 +1466,7 @@ dependencies = [
     { name = "boto3" },
     { name = "click" },
     { name = "confluent-kafka" },
+    { name = "dnspython" },
     { name = "falcon" },
     { name = "filelock" },
     { name = "geoip2" },
@@ -1528,6 +1538,7 @@ requires-dist = [
     { name = "click", specifier = "<9" },
     { name = "confluent-kafka", specifier = ">2,<3" },
     { name = "deepdiff", marker = "extra == 'dev'", specifier = ">=8.6.2,<9" },
+    { name = "dnspython", specifier = "==2.8.0" },
     { name = "falcon", specifier = ">=3.1.3,<5" },
     { name = "filelock", specifier = "<4" },
     { name = "geoip2", specifier = ">=5.2.0,<6" },

--- a/uv.lock
+++ b/uv.lock
@@ -1538,7 +1538,7 @@ requires-dist = [
     { name = "click", specifier = "<9" },
     { name = "confluent-kafka", specifier = ">2,<3" },
     { name = "deepdiff", marker = "extra == 'dev'", specifier = ">=8.6.2,<9" },
-    { name = "dnspython", specifier = "==2.8.0" },
+    { name = "dnspython", specifier = ">=2.8.0" },
     { name = "falcon", specifier = ">=3.1.3,<5" },
     { name = "filelock", specifier = "<4" },
     { name = "geoip2", specifier = ">=5.2.0,<6" },


### PR DESCRIPTION
## Description

* add separate cache for timeouts in `domain_resolver` to allow different lifetimes than the regular domain cache
* add `lifetime` parameter to `domain_resolver` in addition to `timeout` parameter
* add metrics for cached timeouts and successfully resolved domains to `domain_resolver`
* prune domains from `domain_resolver` mapping that are not in the cache
* prune domains from `domain_resolver` mapping that are not in the cache 

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* List of (preferably easy reproducible) tests including OS

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1021.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->