### PR TITLE
release: 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Upcoming Changes
 ### Breaking
+
+### Features
+
+### Improvements
+
+### Bugfix
+
+## 21.0.0
+### Breaking
 * restrict UNIX timestamp normalization to seconds, milliseconds, microseconds, and nanoseconds.
 * handle non-string `concatenator` source fields with `ProcessingWarning` instead of `ProcessingCriticalError`
 * filter: field values are now automatically coerced in range matches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "logprep"
 description = "Logprep allows to collect, process and forward log messages from various data sources."
 requires-python = ">=3.11"
 readme = "README.md"
-version = "20.0.0"
+version = "21.0.0"
 license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -402,7 +402,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1449,7 +1449,7 @@ wheels = [
 
 [[package]]
 name = "logprep"
-version = "20.0.0"
+version = "21.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1022.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->