### PR TITLE
feat: support current time in timestamper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Breaking
 
 ### Features
+* timestamper: support generating timestamps from the current time when no `source_fields` are configured
 
 ### Improvements
 

--- a/logprep/ng/processor/timestamper/processor.py
+++ b/logprep/ng/processor/timestamper/processor.py
@@ -24,6 +24,7 @@ Processor Configuration
 .. automodule:: logprep.processor.timestamper.rule
 """
 
+import datetime
 import typing
 
 from logprep.ng.processor.field_manager.processor import FieldManager
@@ -41,27 +42,47 @@ class Timestamper(FieldManager):
 
     async def _apply_rules(self, event: dict[str, FieldValue], rule: Rule) -> None:
         rule = typing.cast(TimestamperRule, rule)
+
+        parsed_datetime = self._get_datetime(event, rule)
+        if parsed_datetime is None:
+            return
+
+        result = parsed_datetime.astimezone(rule.target_timezone).isoformat().replace("+00:00", "Z")
+        self._write_target_field(event, rule, result)
+
+    def _get_datetime(
+        self,
+        event: dict[str, FieldValue],
+        rule: TimestamperRule,
+    ) -> datetime.datetime | None:
+        """Return the datetime to use for timestamp generation
+
+        If no source field is configured, the current time is used
+        """
+        if not rule.source_fields:
+            return TimeParser.now(rule.target_timezone)
+
         source_value = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [source_value]):
-            return
-        source_value = str(source_value)
+            return None
 
-        source_timezone, target_timezone, source_formats = (
-            rule.source_timezone,
-            rule.target_timezone,
-            rule.source_format,
-        )
-        parsed_successfully = False
-        for source_format in source_formats:
+        return self._parse_datetime(str(source_value), event, rule)
+
+    @staticmethod
+    def _parse_datetime(
+        source_value: str,
+        event: dict[str, FieldValue],
+        rule: TimestamperRule,
+    ) -> datetime.datetime:
+        """Parse a timestamp value according to the configured source formats"""
+        for source_format in rule.source_format:
             try:
-                parsed_datetime = TimeParser.parse_datetime(
-                    source_value, source_format, source_timezone
+                return TimeParser.parse_datetime(
+                    source_value,
+                    source_format,
+                    rule.source_timezone,
                 )
             except TimeParserException:
                 continue
-            result = parsed_datetime.astimezone(target_timezone).isoformat().replace("+00:00", "Z")
-            self._write_target_field(event, rule, result)
-            parsed_successfully = True
-            break
-        if not parsed_successfully:
-            raise ProcessingWarning(str("Could not parse timestamp"), rule, event)
+
+        raise ProcessingWarning("Could not parse timestamp", rule, event)

--- a/logprep/ng/processor/timestamper/processor.py
+++ b/logprep/ng/processor/timestamper/processor.py
@@ -66,23 +66,4 @@ class Timestamper(FieldManager):
         if self._handle_missing_fields(event, rule, rule.source_fields, [source_value]):
             return None
 
-        return self._parse_datetime(str(source_value), event, rule)
-
-    @staticmethod
-    def _parse_datetime(
-        source_value: str,
-        event: dict[str, FieldValue],
-        rule: TimestamperRule,
-    ) -> datetime.datetime:
-        """Parse a timestamp value according to the configured source formats"""
-        for source_format in rule.source_format:
-            try:
-                return TimeParser.parse_datetime(
-                    source_value,
-                    source_format,
-                    rule.source_timezone,
-                )
-            except TimeParserException:
-                continue
-
-        raise ProcessingWarning("Could not parse timestamp", rule, event)
+        return rule.parse_datetime(str(source_value), event)

--- a/logprep/processor/base/rule.py
+++ b/logprep/processor/base/rule.py
@@ -334,14 +334,6 @@ class Rule:
     def failure_tags(self):
         return self._config.tag_on_failure
 
-    # pylint: enable=C0111
-
-    @classmethod
-    def normalize_rule_dict(cls, rule: dict) -> None:
-        """normalizes rule dict before create rule config object
-        can be used for deprecating rule language.
-        """
-
     @classmethod
     def create_from_dict(cls, rule: dict, processor_name: str | None = None) -> "Rule":
         """Create a Rule instance from a dictionary.
@@ -361,7 +353,6 @@ class Rule:
             If the rule configuration is invalid or missing required fields.
         """
 
-        cls.normalize_rule_dict(rule)
         filter_expression = Rule._create_filter_expression(rule)
         cls.rule_type = camel_to_snake(cls.__name__.replace("Rule", ""))
         if not cls.rule_type:

--- a/logprep/processor/timestamper/processor.py
+++ b/logprep/processor/timestamper/processor.py
@@ -24,6 +24,7 @@ Processor Configuration
 .. automodule:: logprep.processor.timestamper.rule
 """
 
+import datetime
 import typing
 
 from logprep.processor.base.exceptions import ProcessingWarning
@@ -41,27 +42,43 @@ class Timestamper(FieldManager):
 
     def _apply_rules(self, event: dict, rule: Rule) -> None:
         rule = typing.cast(TimestamperRule, rule)
+
+        parsed_datetime = self._get_datetime(event, rule)
+        if parsed_datetime is None:
+            return
+
+        result = parsed_datetime.astimezone(rule.target_timezone).isoformat().replace("+00:00", "Z")
+        self._write_target_field(event, rule, result)
+
+    def _get_datetime(self, event: dict, rule: TimestamperRule) -> datetime.datetime | None:
+        """Return the datetime to use for timestamp generation.
+
+        If no source field is configured, the current time is used.
+        """
+        if not rule.source_fields:
+            return TimeParser.now(rule.target_timezone)
+
         source_value = get_dotted_field_value(event, rule.source_fields[0])
         if self._handle_missing_fields(event, rule, rule.source_fields, [source_value]):
-            return
-        source_value = str(source_value)
+            return None
 
-        source_timezone, target_timezone, source_formats = (
-            rule.source_timezone,
-            rule.target_timezone,
-            rule.source_format,
-        )
-        parsed_successfully = False
-        for source_format in source_formats:
+        return self._parse_datetime(str(source_value), event, rule)
+
+    @staticmethod
+    def _parse_datetime(
+        source_value: str,
+        event: dict,
+        rule: TimestamperRule,
+    ) -> datetime.datetime:
+        """Parse a timestamp value according to the configured source formats."""
+        for source_format in rule.source_format:
             try:
-                parsed_datetime = TimeParser.parse_datetime(
-                    source_value, source_format, source_timezone
+                return TimeParser.parse_datetime(
+                    source_value,
+                    source_format,
+                    rule.source_timezone,
                 )
             except TimeParserException:
                 continue
-            result = parsed_datetime.astimezone(target_timezone).isoformat().replace("+00:00", "Z")
-            self._write_target_field(event, rule, result)
-            parsed_successfully = True
-            break
-        if not parsed_successfully:
-            raise ProcessingWarning(str("Could not parse timestamp"), rule, event)
+
+        raise ProcessingWarning("Could not parse timestamp", rule, event)

--- a/logprep/processor/timestamper/processor.py
+++ b/logprep/processor/timestamper/processor.py
@@ -62,23 +62,4 @@ class Timestamper(FieldManager):
         if self._handle_missing_fields(event, rule, rule.source_fields, [source_value]):
             return None
 
-        return self._parse_datetime(str(source_value), event, rule)
-
-    @staticmethod
-    def _parse_datetime(
-        source_value: str,
-        event: dict,
-        rule: TimestamperRule,
-    ) -> datetime.datetime:
-        """Parse a timestamp value according to the configured source formats."""
-        for source_format in rule.source_format:
-            try:
-                return TimeParser.parse_datetime(
-                    source_value,
-                    source_format,
-                    rule.source_timezone,
-                )
-            except TimeParserException:
-                continue
-
-        raise ProcessingWarning("Could not parse timestamp", rule, event)
+        return rule.parse_datetime(str(source_value), event)

--- a/logprep/processor/timestamper/rule.py
+++ b/logprep/processor/timestamper/rule.py
@@ -42,6 +42,19 @@ A speaking example:
             },
         }
 
+If :code:`source_fields` is omitted or empty, the current time is used.
+In this case, :code:`source_format` and :code:`source_timezone` must not be configured.
+
+..  code-block:: yaml
+    :linenos:
+    :caption: Timestamper rule using the current time
+
+    filter: "winlog.event_id: 123456789"
+    timestamper:
+        target_field: "@timestamp"
+        target_timezone: Europe/Berlin
+    description: example timestamper rule using the current time
+
 
 .. autoclass:: logprep.processor.timestamper.rule.TimestamperRule.Config
    :members:
@@ -62,6 +75,7 @@ from zoneinfo import ZoneInfo
 
 from attrs import define, field, validators
 
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
 
 
@@ -73,14 +87,17 @@ class TimestamperRule(FieldManagerRule):
         """Config for TimestamperRule"""
 
         source_fields: list = field(
+            factory=list,
             validator=[
                 validators.instance_of(list),
-                validators.min_len(1),
+                validators.min_len(0),
                 validators.max_len(1),
                 validators.deep_iterable(member_validator=validators.instance_of(str)),
-            ]
+            ],
         )
-        """The field from where to get the time from as list with one element"""
+        """The field from where to get the time from as list with one element.
+        If omitted or empty, the current time will be used.
+        """
         target_field: str = field(validator=validators.instance_of(str), default="@timestamp")
         """The field where to write the processed values to, defaults to :code:`@timestamp`"""
         source_format: list = field(
@@ -121,21 +138,53 @@ class TimestamperRule(FieldManagerRule):
         If you don't want this behavior, you have to use the :code:`datetime.strptime` syntax.
         With this syntax, the :code:`timestamper`errors out with a :code:`TimeParserException` and
         a tag :code:`_timestamper_failure` will be added to the event.
+
+        This option must not be configured if :code:`source_fields` is omitted or empty.
         """
         source_timezone: ZoneInfo = field(
-            validator=(validators.instance_of(ZoneInfo)),
+            validator=validators.instance_of(ZoneInfo),
             converter=lambda x: ZoneInfo(x) if isinstance(x, str) else x,
             default=ZoneInfo("UTC"),
         )
-        """ timezone of source_fields. defaults to :code:`UTC`"""
+        """ timezone of source_fields. defaults to :code:`UTC`.
+        This option must not be configured if :code:`source_fields` is omitted or empty.
+        """
         target_timezone: ZoneInfo = field(
-            validator=(validators.instance_of(ZoneInfo)),
+            validator=validators.instance_of(ZoneInfo),
             converter=lambda x: ZoneInfo(x) if isinstance(x, str) else x,
             default=ZoneInfo("UTC"),
         )
         """ timezone for target_field. defaults to :code:`UTC`"""
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
+
+    @classmethod
+    def normalize_rule_dict(cls, rule: dict) -> None:
+        """Normalize and validate the timestamper rule configuration"""
+        super().normalize_rule_dict(rule)
+        cls._validate_source_configuration(rule)
+
+    @staticmethod
+    def _validate_source_configuration(rule: dict) -> None:
+        """Validate configuration options that require source_fields"""
+        config = rule.get("timestamper")
+
+        if not isinstance(config, dict) or config.get("source_fields"):
+            return
+
+        invalid_options = [
+            option for option in ("source_format", "source_timezone") if option in config
+        ]
+
+        if not invalid_options:
+            return
+
+        if len(invalid_options) == 1:
+            message = f"{invalid_options[0]} requires source_fields"
+        else:
+            message = f"{', '.join(invalid_options)} require source_fields"
+
+        raise InvalidRuleDefinitionError(message)
 
     @property
     def config(self) -> Config:

--- a/logprep/processor/timestamper/rule.py
+++ b/logprep/processor/timestamper/rule.py
@@ -70,13 +70,18 @@ Examples for timestamper:
 
 """
 
+import datetime
 import typing
 from zoneinfo import ZoneInfo
 
 from attrs import Factory, define, field, validators
 
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.base.exceptions import (
+    InvalidRuleDefinitionError,
+    ProcessingWarning,
+)
 from logprep.processor.field_manager.rule import FieldManagerRule
+from logprep.util.time import TimeParser, TimeParserException
 
 
 def _validate_source_option(instance, attribute, value) -> None:
@@ -208,3 +213,20 @@ class TimestamperRule(FieldManagerRule):
     def source_timezone(self) -> ZoneInfo | None:
         """returns the source timezone"""
         return self.config.source_timezone
+
+    def parse_datetime(self, source_value: str, event: dict) -> datetime.datetime:
+        """Parse a timestamp value according to the configured source formats"""
+        assert self.source_format is not None
+        assert self.source_timezone is not None
+
+        for source_format in self.source_format:
+            try:
+                return TimeParser.parse_datetime(
+                    source_value,
+                    source_format,
+                    self.source_timezone,
+                )
+            except TimeParserException:
+                continue
+
+        raise ProcessingWarning("Could not parse timestamp", self, event)

--- a/logprep/processor/timestamper/rule.py
+++ b/logprep/processor/timestamper/rule.py
@@ -73,9 +73,18 @@ Examples for timestamper:
 import typing
 from zoneinfo import ZoneInfo
 
-from attrs import define, field, validators
+from attrs import Factory, define, field, validators
 
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
+
+
+def _validate_source_option(instance, attribute, value) -> None:
+    """Validate source options when current time is used"""
+    if not instance.source_fields and value is not None:
+        raise InvalidRuleDefinitionError(
+            f"{attribute.name} is not allowed when source_fields is omitted or empty"
+        )
 
 
 class TimestamperRule(FieldManagerRule):
@@ -97,23 +106,37 @@ class TimestamperRule(FieldManagerRule):
         """The field from where to get the time from as list with one element.
         If omitted or empty, the current time will be used.
         """
-        target_field: str = field(validator=validators.instance_of(str), default="@timestamp")
+
+        target_field: str = field(
+            validator=validators.instance_of(str),
+            default="@timestamp",
+        )
         """The field where to write the processed values to, defaults to :code:`@timestamp`"""
-        source_format: list = field(
-            validator=validators.deep_iterable(
-                member_validator=validators.instance_of(str),
-                iterable_validator=validators.instance_of(list),
+
+        source_format: list | None = field(
+            validator=[
+                validators.optional(
+                    validators.deep_iterable(
+                        member_validator=validators.instance_of(str),
+                        iterable_validator=validators.instance_of(list),
+                    )
+                ),
+                _validate_source_option,
+            ],
+            default=Factory(
+                lambda self: ["ISO8601"] if self.source_fields else None,
+                takes_self=True,
             ),
-            default=["ISO8601"],
-            converter=lambda x: x if isinstance(x, list) else [x],
+            converter=lambda x: x if x is None or isinstance(x, list) else [x],
         )
         """A list of possible source formats if source_fields is not an iso8601 compliant
         time format string the format must be given in the syntax of the
         python builtin :code:`datetime.strptime`
         (see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
-        Additionally, the value :code:`ISO8601` (default)  and :code:`UNIX` can be used in the list
-        of the source_formats field. The former can be used if the timestamp already exists
-        in the ISO8601 format, such that only a timezone conversion should be applied.
+        Additionally, the value :code:`ISO8601` (default if source_fields is configured)
+        and :code:`UNIX` can be used in the list of the source_formats field.
+        The former can be used if the timestamp already exists in the ISO8601 format,
+        such that only a timezone conversion should be applied.
         And the latter can be used if the timestamp is given in the UNIX Epoch Time.
         This supports the Unix timestamps in seconds and milliseconds.
         Be aware that :code:`UNIX` and :code:`ISO8601` formats do not validate the completeness of
@@ -140,20 +163,29 @@ class TimestamperRule(FieldManagerRule):
 
         This option must not be configured if :code:`source_fields` is omitted or empty.
         """
-        source_timezone: ZoneInfo = field(
-            validator=validators.instance_of(ZoneInfo),
+
+        source_timezone: ZoneInfo | None = field(
+            validator=[
+                validators.optional(validators.instance_of(ZoneInfo)),
+                _validate_source_option,
+            ],
             converter=lambda x: ZoneInfo(x) if isinstance(x, str) else x,
-            default=ZoneInfo("UTC"),
+            default=Factory(
+                lambda self: ZoneInfo("UTC") if self.source_fields else None,
+                takes_self=True,
+            ),
         )
-        """ timezone of source_fields. defaults to :code:`UTC`.
+        """Timezone of source_fields, defaults to :code:`UTC` if source_fields is configured.
         This option must not be configured if :code:`source_fields` is omitted or empty.
         """
+
         target_timezone: ZoneInfo = field(
             validator=validators.instance_of(ZoneInfo),
             converter=lambda x: ZoneInfo(x) if isinstance(x, str) else x,
             default=ZoneInfo("UTC"),
         )
         """ timezone for target_field. defaults to :code:`UTC`"""
+
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
 
@@ -163,7 +195,7 @@ class TimestamperRule(FieldManagerRule):
         return typing.cast(TimestamperRule.Config, self._config)
 
     @property
-    def source_format(self) -> str | list[str]:
+    def source_format(self) -> list[str] | None:
         """returns the source format"""
         return self.config.source_format
 
@@ -173,6 +205,6 @@ class TimestamperRule(FieldManagerRule):
         return self.config.target_timezone
 
     @property
-    def source_timezone(self) -> ZoneInfo:
+    def source_timezone(self) -> ZoneInfo | None:
         """returns the source timezone"""
         return self.config.source_timezone

--- a/logprep/processor/timestamper/rule.py
+++ b/logprep/processor/timestamper/rule.py
@@ -75,7 +75,6 @@ from zoneinfo import ZoneInfo
 
 from attrs import define, field, validators
 
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.field_manager.rule import FieldManagerRule
 
 
@@ -157,34 +156,6 @@ class TimestamperRule(FieldManagerRule):
         """ timezone for target_field. defaults to :code:`UTC`"""
         mapping: dict = field(default="", init=False, repr=False, eq=False)
         ignore_missing_fields: bool = field(default=False, init=False, repr=False, eq=False)
-
-    @classmethod
-    def normalize_rule_dict(cls, rule: dict) -> None:
-        """Normalize and validate the timestamper rule configuration"""
-        super().normalize_rule_dict(rule)
-        cls._validate_source_configuration(rule)
-
-    @staticmethod
-    def _validate_source_configuration(rule: dict) -> None:
-        """Validate configuration options that require source_fields"""
-        config = rule.get("timestamper")
-
-        if not isinstance(config, dict) or config.get("source_fields"):
-            return
-
-        invalid_options = [
-            option for option in ("source_format", "source_timezone") if option in config
-        ]
-
-        if not invalid_options:
-            return
-
-        if len(invalid_options) == 1:
-            message = f"{invalid_options[0]} requires source_fields"
-        else:
-            message = f"{', '.join(invalid_options)} require source_fields"
-
-        raise InvalidRuleDefinitionError(message)
 
     @property
     def config(self) -> Config:

--- a/tests/unit/ng/processor/timestamper/test_timestamper.py
+++ b/tests/unit/ng/processor/timestamper/test_timestamper.py
@@ -5,13 +5,21 @@
 
 import re
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 
 from logprep.ng.abc.event import InputMeta, LogEvent
 from logprep.ng.processor.field_manager.processor import FieldManager
 from logprep.ng.processor.timestamper.processor import Timestamper
+from logprep.util.time import TimeParser
 from tests.unit.ng.processor.base import BaseProcessorTestCase
+from tests.unit.processor.timestamper.test_timestamper import (
+    FIXED_NOW,
+)
+from tests.unit.processor.timestamper.test_timestamper import (
+    current_time_test_cases as non_ng_current_time_test_cases,
+)
 from tests.unit.processor.timestamper.test_timestamper import (
     failure_test_cases as non_ng_failure_test_cases,
 )
@@ -20,6 +28,7 @@ from tests.unit.processor.timestamper.test_timestamper import (
 )
 
 test_cases = deepcopy(non_ng_test_cases)
+current_time_test_cases = deepcopy(non_ng_current_time_test_cases)
 failure_test_cases = deepcopy(non_ng_failure_test_cases)
 
 
@@ -37,14 +46,38 @@ class TestTimestamper(BaseProcessorTestCase[Timestamper]):
     async def test_testcases(self, testcase, rule, event, expected):
         await self._load_rule(rule)
         event = LogEvent(event, original=b"", input_meta=InputMeta())
+
         await self.object.process(event)
+
         assert event.data == expected, testcase
+
+    @pytest.mark.parametrize(
+        "rule, event, expected, target_timezone",
+        current_time_test_cases,
+    )
+    async def test_uses_current_time_without_source_fields(
+        self,
+        rule,
+        event,
+        expected,
+        target_timezone,
+    ):
+        await self._load_rule(rule)
+        event = LogEvent(event, original=b"", input_meta=InputMeta())
+
+        with patch.object(TimeParser, "now", return_value=FIXED_NOW) as mock_now:
+            await self.object.process(event)
+
+        mock_now.assert_called_once_with(target_timezone)
+        assert event.data == expected
 
     @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
     async def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message):
         await self._load_rule(rule)
         event = LogEvent(event, original=b"", input_meta=InputMeta())
+
         result = await self.object.process(event)
+
         assert len(result.warnings) == 1
         assert re.match(rf".*{error_message}", str(result.warnings[0]))
         assert event.data == expected, testcase

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -4,11 +4,17 @@
 # pylint: disable=too-many-positional-arguments
 
 import re
+from datetime import UTC, datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from logprep.processor.field_manager.processor import FieldManager
+from logprep.util.time import TimeParser
 from tests.unit.processor.base import BaseProcessorTestCase
+
+FIXED_NOW = datetime(2026, 9, 2, 10, 15, 30, 123456, tzinfo=UTC)
 
 test_cases = [  # testcase, rule, event, expected
     (
@@ -444,6 +450,42 @@ test_cases = [  # testcase, rule, event, expected
     ),
 ]
 
+current_time_test_cases = [
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {},
+        },
+        {
+            "message": "whatever",
+        },
+        {
+            "message": "whatever",
+            "@timestamp": "2026-09-02T10:15:30.123456Z",
+        },
+        ZoneInfo("UTC"),
+        id="uses current time when source fields are omitted",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": [],
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "whatever",
+        },
+        {
+            "message": "whatever",
+            "@timestamp": "2026-09-02T12:15:30.123456+02:00",
+        },
+        ZoneInfo("Europe/Berlin"),
+        id="uses current time when source fields are empty",
+    ),
+]
+
 failure_test_cases = [
     (
         "parsing timestamp fails on empty message",
@@ -619,6 +661,25 @@ class TestTimestamper(BaseProcessorTestCase):
         self._load_rule(rule)
         self.object.process(event)
         assert event == expected, testcase
+
+    @pytest.mark.parametrize(
+        "rule, event, expected, target_timezone",
+        current_time_test_cases,
+    )
+    def test_uses_current_time_without_source_fields(
+        self,
+        rule,
+        event,
+        expected,
+        target_timezone,
+    ):
+        self._load_rule(rule)
+
+        with patch.object(TimeParser, "now", return_value=FIXED_NOW) as mock_now:
+            self.object.process(event)
+
+        mock_now.assert_called_once_with(target_timezone)
+        assert event == expected
 
     @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
     def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message):

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -1,7 +1,9 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
+
 import pytest
 
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.timestamper.rule import TimestamperRule
 
 
@@ -17,15 +19,19 @@ class TestTimestamperRule:
     @pytest.mark.parametrize(
         ["rule", "error", "message"],
         [
-            (
+            pytest.param(
                 {
                     "filter": "message",
-                    "timestamper": {"source_fields": ["message"], "target_field": "@timestamp"},
+                    "timestamper": {
+                        "source_fields": ["message"],
+                        "target_field": "@timestamp",
+                    },
                 },
                 None,
                 None,
+                id="source field",
             ),
-            (
+            pytest.param(
                 {
                     "filter": "message",
                     "timestamper": {
@@ -36,8 +42,29 @@ class TestTimestamperRule:
                 },
                 None,
                 None,
+                id="source format with source field",
             ),
-            (
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {},
+                },
+                None,
+                None,
+                id="source fields omitted",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": [],
+                    },
+                },
+                None,
+                None,
+                id="source fields empty",
+            ),
+            pytest.param(
                 {
                     "filter": "message",
                     "timestamper": {
@@ -47,6 +74,42 @@ class TestTimestamperRule:
                 },
                 ValueError,
                 r"Length of 'source_fields' must be <= 1",
+                id="multiple source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_format": "UNIX",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_format requires source_fields",
+                id="source format without source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_timezone": "Europe/Berlin",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_timezone requires source_fields",
+                id="source timezone without source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": [],
+                        "source_format": "UNIX",
+                        "source_timezone": "Europe/Berlin",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_format, source_timezone require source_fields",
+                id="source configuration with empty source fields",
             ),
         ],
     )

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.timestamper.rule import TimestamperRule
 
 
@@ -47,26 +46,6 @@ class TestTimestamperRule:
             pytest.param(
                 {
                     "filter": "message",
-                    "timestamper": {},
-                },
-                None,
-                None,
-                id="source fields omitted",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": [],
-                    },
-                },
-                None,
-                None,
-                id="source fields empty",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
                     "timestamper": {
                         "source_fields": ["message", "timestamp"],
                         "target_field": "@timestamp",
@@ -75,41 +54,6 @@ class TestTimestamperRule:
                 ValueError,
                 r"Length of 'source_fields' must be <= 1",
                 id="multiple source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_format": "UNIX",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_format requires source_fields",
-                id="source format without source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_timezone": "Europe/Berlin",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_timezone requires source_fields",
-                id="source timezone without source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": [],
-                        "source_format": "UNIX",
-                        "source_timezone": "Europe/Berlin",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_format, source_timezone require source_fields",
-                id="source configuration with empty source fields",
             ),
         ],
     )

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -1,11 +1,15 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
 
+from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 import pytest
 
-from logprep.processor.base.exceptions import InvalidRuleDefinitionError
+from logprep.processor.base.exceptions import (
+    InvalidRuleDefinitionError,
+    ProcessingWarning,
+)
 from logprep.processor.timestamper.rule import TimestamperRule
 
 
@@ -145,6 +149,7 @@ class TestTimestamperRule:
         else:
             rule_instance = TimestamperRule.create_from_dict(rule)
             assert hasattr(rule_instance, "_config")
+
             for key, value in rule.get("timestamper").items():
                 assert hasattr(rule_instance._config, key)
 
@@ -191,3 +196,82 @@ class TestTimestamperRule:
 
         assert rule.source_format is None
         assert rule.source_timezone is None
+
+    @pytest.mark.parametrize(
+        "source_value, source_format, source_timezone, expected",
+        [
+            pytest.param(
+                "2009-06-15 13:45:30Z",
+                ["ISO8601"],
+                "UTC",
+                datetime(2009, 6, 15, 13, 45, 30, tzinfo=UTC),
+                id="iso8601",
+            ),
+            pytest.param(
+                "1700000000",
+                ["UNIX"],
+                "UTC",
+                datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC),
+                id="unix",
+            ),
+            pytest.param(
+                "2000 12 31 - 22:59:59",
+                ["%Y %m %d - %H:%M:%S"],
+                "Europe/Berlin",
+                datetime(
+                    2000,
+                    12,
+                    31,
+                    22,
+                    59,
+                    59,
+                    tzinfo=ZoneInfo("Europe/Berlin"),
+                ),
+                id="custom format with source timezone",
+            ),
+            pytest.param(
+                "2000 12 31 - 22:59:59",
+                ["%Y %m %d", "%Y %m %d - %H:%M:%S"],
+                "UTC",
+                datetime(2000, 12, 31, 22, 59, 59, tzinfo=UTC),
+                id="uses matching source format",
+            ),
+        ],
+    )
+    def test_parse_datetime(
+        self,
+        source_value,
+        source_format,
+        source_timezone,
+        expected,
+    ):
+        event = {"message": source_value}
+        rule = TimestamperRule.create_from_dict(
+            {
+                "filter": "message",
+                "timestamper": {
+                    "source_fields": ["message"],
+                    "source_format": source_format,
+                    "source_timezone": source_timezone,
+                },
+            }
+        )
+
+        result = rule.parse_datetime(source_value, event)
+
+        assert result == expected
+
+    def test_parse_datetime_raises_processing_warning_if_no_format_matches(self):
+        event = {"message": "not a timestamp"}
+        rule = TimestamperRule.create_from_dict(
+            {
+                "filter": "message",
+                "timestamper": {
+                    "source_fields": ["message"],
+                    "source_format": ["UNIX", "%Y-%m-%d"],
+                },
+            }
+        )
+
+        with pytest.raises(ProcessingWarning, match=r"Could not parse timestamp"):
+            rule.parse_datetime(event["message"], event)

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -1,8 +1,11 @@
 # pylint: disable=protected-access
 # pylint: disable=missing-docstring
 
+from zoneinfo import ZoneInfo
+
 import pytest
 
+from logprep.processor.base.exceptions import InvalidRuleDefinitionError
 from logprep.processor.timestamper.rule import TimestamperRule
 
 
@@ -47,6 +50,38 @@ class TestTimestamperRule:
                 {
                     "filter": "message",
                     "timestamper": {
+                        "source_fields": ["message"],
+                        "source_timezone": "Europe/Berlin",
+                    },
+                },
+                None,
+                None,
+                id="source timezone with source field",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {},
+                },
+                None,
+                None,
+                id="current time without source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": [],
+                    },
+                },
+                None,
+                None,
+                id="current time with empty source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
                         "source_fields": ["message", "timestamp"],
                         "target_field": "@timestamp",
                     },
@@ -54,6 +89,52 @@ class TestTimestamperRule:
                 ValueError,
                 r"Length of 'source_fields' must be <= 1",
                 id="multiple source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_format": "UNIX",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_format is not allowed when source_fields is omitted or empty",
+                id="source format without source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_timezone": "Europe/Berlin",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_timezone is not allowed when source_fields is omitted or empty",
+                id="source timezone without source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": [],
+                        "source_format": "UNIX",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_format is not allowed when source_fields is omitted or empty",
+                id="source format with empty source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": [],
+                        "source_timezone": "Europe/Berlin",
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_timezone is not allowed when source_fields is omitted or empty",
+                id="source timezone with empty source fields",
             ),
         ],
     )
@@ -66,4 +147,47 @@ class TestTimestamperRule:
             assert hasattr(rule_instance, "_config")
             for key, value in rule.get("timestamper").items():
                 assert hasattr(rule_instance._config, key)
-                assert value == getattr(rule_instance._config, key)
+
+                config_value = getattr(rule_instance._config, key)
+
+                if key == "source_timezone":
+                    assert config_value == ZoneInfo(value)
+                else:
+                    assert value == config_value
+
+    def test_source_defaults_when_source_fields_are_configured(self):
+        rule = TimestamperRule.create_from_dict(
+            {
+                "filter": "message",
+                "timestamper": {
+                    "source_fields": ["message"],
+                },
+            }
+        )
+
+        assert rule.source_format == ["ISO8601"]
+        assert rule.source_timezone == ZoneInfo("UTC")
+
+    def test_source_defaults_when_source_fields_are_omitted(self):
+        rule = TimestamperRule.create_from_dict(
+            {
+                "filter": "message",
+                "timestamper": {},
+            }
+        )
+
+        assert rule.source_format is None
+        assert rule.source_timezone is None
+
+    def test_source_defaults_when_source_fields_are_empty(self):
+        rule = TimestamperRule.create_from_dict(
+            {
+                "filter": "message",
+                "timestamper": {
+                    "source_fields": [],
+                },
+            }
+        )
+
+        assert rule.source_format is None
+        assert rule.source_timezone is None


### PR DESCRIPTION
## Description

* `timestamper`: support using the current time when no `source_fields` are configured
* `timestamper`: reject `source_format` and `source_timezone` when no `source_fields` are configured
* apply the new behavior to both non-ng and ng implementations
* add tests and documentation for the new current-time behavior

## Assignee

* [x] The changes adhere to the [[contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
* [x] Relevant changes are applied to non-ng and ng

### Documentation

* [x] https://github.com/fkie-cad/Logprep/blob/main/README.md is up-to-date
* [x] https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md is up-to-date
* [x] [[Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source)](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
* [x] [[Preview for docs](https://github.com/fkie-cad/Logprep/compare/feat-support-current-time-in-timestamper?expand=1#readthedocs-preview)](#readthedocs-preview) looks fine
* [x] [[Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks)](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
* [x] [[Examples](https://github.com/fkie-cad/Logprep/tree/main/examples)](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality

* [x] Patch test coverage > 95% and does not decrease
* [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* `pytest`

## Reviewer

* The code is readable/maintainable and follows the [[contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
* [[Documentation](https://github.com/fkie-cad/Logprep/compare/feat-support-current-time-in-timestamper?expand=1#documentation)](#documentation) is up-to-date
* Tests (unit & acceptance) are meaningful and not over-mocked

<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1023.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->