### PR TITLE
fix: validate timestamper source options with source fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * timestamper: support generating timestamps from the current time when no `source_fields` are configured
 
 ### Improvements
+* timestamper: validate `source_format` and `source_timezone` according to the configured `source_fields`
 
 ### Bugfix
 

--- a/logprep/processor/timestamper/rule.py
+++ b/logprep/processor/timestamper/rule.py
@@ -85,7 +85,12 @@ from logprep.util.time import TimeParser, TimeParserException
 
 
 def _validate_source_option(instance, attribute, value) -> None:
-    """Validate source options when current time is used"""
+    """Validate source options depending on source_fields"""
+    if instance.source_fields and value is None:
+        raise InvalidRuleDefinitionError(
+            f"{attribute.name} must not be None when source_fields is configured"
+        )
+
     if not instance.source_fields and value is not None:
         raise InvalidRuleDefinitionError(
             f"{attribute.name} is not allowed when source_fields is omitted or empty"

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -140,6 +140,30 @@ class TestTimestamperRule:
                 r"source_timezone is not allowed when source_fields is omitted or empty",
                 id="source timezone with empty source fields",
             ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": ["message"],
+                        "source_format": None,
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_format must not be None when source_fields is configured",
+                id="source format none with source fields",
+            ),
+            pytest.param(
+                {
+                    "filter": "message",
+                    "timestamper": {
+                        "source_fields": ["message"],
+                        "source_timezone": None,
+                    },
+                },
+                InvalidRuleDefinitionError,
+                r"source_timezone must not be None when source_fields is configured",
+                id="source timezone none with source fields",
+            ),
         ],
     )
     def test_create_from_dict_validates_config(self, rule, error, message):


### PR DESCRIPTION
Hotfix for https://github.com/fkie-cad/Logprep/pull/1023

<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1025.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->