### PR TITLE
test: simplify timestamper test cases

### DIFF
--- a/tests/unit/ng/processor/timestamper/test_timestamper.py
+++ b/tests/unit/ng/processor/timestamper/test_timestamper.py
@@ -18,9 +18,6 @@ from tests.unit.processor.timestamper.test_timestamper import (
     FIXED_NOW,
 )
 from tests.unit.processor.timestamper.test_timestamper import (
-    current_time_test_cases as non_ng_current_time_test_cases,
-)
-from tests.unit.processor.timestamper.test_timestamper import (
     failure_test_cases as non_ng_failure_test_cases,
 )
 from tests.unit.processor.timestamper.test_timestamper import (
@@ -28,8 +25,13 @@ from tests.unit.processor.timestamper.test_timestamper import (
 )
 
 test_cases = deepcopy(non_ng_test_cases)
-current_time_test_cases = deepcopy(non_ng_current_time_test_cases)
 failure_test_cases = deepcopy(non_ng_failure_test_cases)
+
+
+@pytest.fixture(autouse=True)
+def mock_now():
+    with patch.object(TimeParser, "now", return_value=FIXED_NOW):
+        yield
 
 
 class TestTimestamper(BaseProcessorTestCase[Timestamper]):
@@ -52,27 +54,17 @@ class TestTimestamper(BaseProcessorTestCase[Timestamper]):
         assert event.data == expected, testcase
 
     @pytest.mark.parametrize(
-        "rule, event, expected, target_timezone",
-        current_time_test_cases,
+        "testcase, rule, event, expected, error_message",
+        failure_test_cases,
     )
-    async def test_uses_current_time_without_source_fields(
+    async def test_testcases_failure_handling(
         self,
+        testcase,
         rule,
         event,
         expected,
-        target_timezone,
+        error_message,
     ):
-        await self._load_rule(rule)
-        event = LogEvent(event, original=b"", input_meta=InputMeta())
-
-        with patch.object(TimeParser, "now", return_value=FIXED_NOW) as mock_now:
-            await self.object.process(event)
-
-        mock_now.assert_called_once_with(target_timezone)
-        assert event.data == expected
-
-    @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
-    async def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message):
         await self._load_rule(rule)
         event = LogEvent(event, original=b"", input_meta=InputMeta())
 

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -6,7 +6,6 @@
 import re
 from datetime import UTC, datetime
 from unittest.mock import patch
-from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -16,9 +15,15 @@ from tests.unit.processor.base import BaseProcessorTestCase
 
 FIXED_NOW = datetime(2026, 9, 2, 10, 15, 30, 123456, tzinfo=UTC)
 
-test_cases = [  # testcase, rule, event, expected
-    (
-        "normalizes unix timestamp with seconds precision",
+
+@pytest.fixture(autouse=True)
+def mock_now():
+    with patch.object(TimeParser, "now", return_value=FIXED_NOW):
+        yield
+
+
+example_test_cases = [
+    pytest.param(
         {
             "filter": "message",
             "timestamper": {
@@ -35,7 +40,133 @@ test_cases = [  # testcase, rule, event, expected
             "message": "1700000000",
             "@timestamp": "2023-11-14T23:13:20+01:00",
         },
+        id="normalize a UNIX timestamp",
     ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1700000000.123",
+        },
+        {
+            "message": "1700000000.123",
+            "@timestamp": "2023-11-14T23:13:20.123000+01:00",
+        },
+        id="normalize a fractional UNIX timestamp",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+            },
+        },
+        {
+            "message": "2009-06-15 13:45:30Z",
+        },
+        {
+            "message": "2009-06-15 13:45:30Z",
+            "@timestamp": "2009-06-15T13:45:30Z",
+        },
+        id="normalize an ISO8601 timestamp",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "%Y %m %d - %H:%M:%S",
+            },
+        },
+        {
+            "message": "2000 12 31 - 22:59:59",
+        },
+        {
+            "message": "2000 12 31 - 22:59:59",
+            "@timestamp": "2000-12-31T22:59:59Z",
+        },
+        id="normalize a timestamp with a custom source format",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "%Y %m %d - %H:%M:%S",
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "2000 12 31 - 22:59:59",
+        },
+        {
+            "message": "2000 12 31 - 22:59:59",
+            "@timestamp": "2000-12-31T23:59:59+01:00",
+        },
+        id="convert a timestamp to another timezone",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": ["ISO8601", "UNIX"],
+                "source_timezone": "UTC",
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "1642160449843",
+        },
+        {
+            "message": "1642160449843",
+            "@timestamp": "2022-01-14T12:40:49.843000+01:00",
+        },
+        id="try multiple source formats",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {},
+        },
+        {
+            "message": "whatever",
+        },
+        {
+            "message": "whatever",
+            "@timestamp": "2026-09-02T10:15:30.123456Z",
+        },
+        id="use the current time when source fields are omitted",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "message": "whatever",
+        },
+        {
+            "message": "whatever",
+            "@timestamp": "2026-09-02T12:15:30.123456+02:00",
+        },
+        id="use the current time with a target timezone",
+    ),
+]
+
+
+test_cases = [
+    *[(test_case.id, *test_case.values) for test_case in example_test_cases],
     (
         "normalizes unix timestamp with milliseconds precision",
         {
@@ -93,25 +224,6 @@ test_cases = [  # testcase, rule, event, expected
             # The timestamp is normalized from nanoseconds, but datetime only supports
             # microsecond precision. Therefore 123456789 ns is rounded to 123457 us.
             "@timestamp": "2023-11-14T23:13:20.123457+01:00",
-        },
-    ),
-    (
-        "parses fractional unix timestamp with seconds precision",
-        {
-            "filter": "message",
-            "timestamper": {
-                "source_fields": ["message"],
-                "source_format": "UNIX",
-                "source_timezone": "UTC",
-                "target_timezone": "Europe/Berlin",
-            },
-        },
-        {
-            "message": "1700000000.123",
-        },
-        {
-            "message": "1700000000.123",
-            "@timestamp": "2023-11-14T23:13:20.123000+01:00",
         },
     ),
     (
@@ -194,55 +306,17 @@ test_cases = [  # testcase, rule, event, expected
         "parses iso8601 without pattern",
         {
             "filter": "message",
-            "timestamper": {"source_fields": ["message"], "target_field": "@timestamp"},
-        },
-        {
-            "message": "2009-06-15 13:45:30Z",
-        },
-        {"message": "2009-06-15 13:45:30Z", "@timestamp": "2009-06-15T13:45:30Z"},
-    ),
-    (
-        "parses iso8601 to default target field",
-        {
-            "filter": "message",
-            "timestamper": {"source_fields": ["message"]},
-        },
-        {
-            "message": "2009-06-15 13:45:30Z",
-        },
-        {"message": "2009-06-15 13:45:30Z", "@timestamp": "2009-06-15T13:45:30Z"},
-    ),
-    (
-        "parses by datetime source format",
-        {
-            "filter": "message",
-            "timestamper": {"source_fields": ["message"], "source_format": "%Y %m %d - %H:%M:%S"},
-        },
-        {
-            "message": "2000 12 31 - 22:59:59",
-        },
-        {
-            "message": "2000 12 31 - 22:59:59",
-            "@timestamp": "2000-12-31T22:59:59Z",
-        },
-    ),
-    (
-        "converts timezone information",
-        {
-            "filter": "message",
             "timestamper": {
                 "source_fields": ["message"],
-                "source_format": "%Y %m %d - %H:%M:%S",
-                "source_timezone": "UTC",
-                "target_timezone": "Europe/Berlin",
+                "target_field": "@timestamp",
             },
         },
         {
-            "message": "2000 12 31 - 22:59:59",
+            "message": "2009-06-15 13:45:30Z",
         },
         {
-            "message": "2000 12 31 - 22:59:59",
-            "@timestamp": "2000-12-31T23:59:59+01:00",
+            "message": "2009-06-15 13:45:30Z",
+            "@timestamp": "2009-06-15T13:45:30Z",
         },
     ),
     (
@@ -252,25 +326,6 @@ test_cases = [  # testcase, rule, event, expected
             "timestamper": {
                 "source_fields": ["message"],
                 "source_format": "UNIX",
-                "source_timezone": "UTC",
-                "target_timezone": "Europe/Berlin",
-            },
-        },
-        {
-            "message": "1642160449843",
-        },
-        {
-            "message": "1642160449843",
-            "@timestamp": "2022-01-14T12:40:49.843000+01:00",
-        },
-    ),
-    (
-        "parses ISO8601 timestamp first and then UNIX after it failed",
-        {
-            "filter": "message",
-            "timestamper": {
-                "source_fields": ["message"],
-                "source_format": ["ISO8601", "UNIX"],
                 "source_timezone": "UTC",
                 "target_timezone": "Europe/Berlin",
             },
@@ -420,7 +475,10 @@ test_cases = [  # testcase, rule, event, expected
             "filter": "message",
             "timestamper": {
                 "source_fields": ["message"],
-                "source_format": ["%Y %m %d", "%Y %m %d - %H:%M:%S"],
+                "source_format": [
+                    "%Y %m %d",
+                    "%Y %m %d - %H:%M:%S",
+                ],
             },
         },
         {
@@ -437,7 +495,10 @@ test_cases = [  # testcase, rule, event, expected
             "filter": "message",
             "timestamper": {
                 "source_fields": ["message"],
-                "source_format": ["%Y %m %d - %H:%M:%S", "%Y %m %d - %H:%M:%S"],
+                "source_format": [
+                    "%Y %m %d - %H:%M:%S",
+                    "%Y %m %d - %H:%M:%S",
+                ],
             },
         },
         {
@@ -450,41 +511,6 @@ test_cases = [  # testcase, rule, event, expected
     ),
 ]
 
-current_time_test_cases = [
-    pytest.param(
-        {
-            "filter": "message",
-            "timestamper": {},
-        },
-        {
-            "message": "whatever",
-        },
-        {
-            "message": "whatever",
-            "@timestamp": "2026-09-02T10:15:30.123456Z",
-        },
-        ZoneInfo("UTC"),
-        id="uses current time when source fields are omitted",
-    ),
-    pytest.param(
-        {
-            "filter": "message",
-            "timestamper": {
-                "source_fields": [],
-                "target_timezone": "Europe/Berlin",
-            },
-        },
-        {
-            "message": "whatever",
-        },
-        {
-            "message": "whatever",
-            "@timestamp": "2026-09-02T12:15:30.123456+02:00",
-        },
-        ZoneInfo("Europe/Berlin"),
-        id="uses current time when source fields are empty",
-    ),
-]
 
 failure_test_cases = [
     (
@@ -588,7 +614,10 @@ failure_test_cases = [
         {
             "message": "2000 12 31 - 22:59:59",
         },
-        {"message": "2000 12 31 - 22:59:59", "tags": ["_timestamper_failure"]},
+        {
+            "message": "2000 12 31 - 22:59:59",
+            "tags": ["_timestamper_failure"],
+        },
         r"Could not parse timestamp",
     ),
     (
@@ -603,7 +632,10 @@ failure_test_cases = [
         {
             "@timestamp": "2000-12-31T22:59:59Z",
         },
-        {"@timestamp": "2000-12-31T22:59:59Z", "tags": ["_timestamper_failure"]},
+        {
+            "@timestamp": "2000-12-31T22:59:59Z",
+            "tags": ["_timestamper_failure"],
+        },
         r"Could not parse timestamp",
     ),
     (
@@ -618,7 +650,10 @@ failure_test_cases = [
         {
             "@timestamp": "2000-12-31T22:59:59Z",
         },
-        {"@timestamp": "2000-12-31T22:59:59Z", "tags": ["_timestamper_failure"]},
+        {
+            "@timestamp": "2000-12-31T22:59:59Z",
+            "tags": ["_timestamper_failure"],
+        },
         r"Could not parse timestamp",
     ),
     (
@@ -633,17 +668,30 @@ failure_test_cases = [
         {
             "message": "2019-09-07T15:50",
         },
-        {"message": "2019-09-07T15:50", "tags": ["_timestamper_failure"]},
+        {
+            "message": "2019-09-07T15:50",
+            "tags": ["_timestamper_failure"],
+        },
         r"Could not parse timestamp",
     ),
     (
         "raises if source field is none",
-        {"filter": "message", "timestamper": {"source_fields": ["@timestamp"]}},
-        {"message": "this does not matter"},
-        {"message": "this does not matter", "tags": ["_timestamper_missing_field_warning"]},
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["@timestamp"],
+            },
+        },
+        {
+            "message": "this does not matter",
+        },
+        {
+            "message": "this does not matter",
+            "tags": ["_timestamper_missing_field_warning"],
+        },
         r"missing source_fields: \['@timestamp']",
     ),
-]  # testcase, rule, event, expected
+]
 
 
 class TestTimestamper(BaseProcessorTestCase):
@@ -663,25 +711,9 @@ class TestTimestamper(BaseProcessorTestCase):
         assert event == expected, testcase
 
     @pytest.mark.parametrize(
-        "rule, event, expected, target_timezone",
-        current_time_test_cases,
+        "testcase, rule, event, expected, error_message",
+        failure_test_cases,
     )
-    def test_uses_current_time_without_source_fields(
-        self,
-        rule,
-        event,
-        expected,
-        target_timezone,
-    ):
-        self._load_rule(rule)
-
-        with patch.object(TimeParser, "now", return_value=FIXED_NOW) as mock_now:
-            self.object.process(event)
-
-        mock_now.assert_called_once_with(target_timezone)
-        assert event == expected
-
-    @pytest.mark.parametrize("testcase, rule, event, expected, error_message", failure_test_cases)
     def test_testcases_failure_handling(self, testcase, rule, event, expected, error_message):
         self._load_rule(rule)
         result = self.object.process(event)

--- a/tests/unit/processor/timestamper/test_timestamper.py
+++ b/tests/unit/processor/timestamper/test_timestamper.py
@@ -162,6 +162,23 @@ example_test_cases = [
         },
         id="use the current time with a target timezone",
     ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "target_field": "normalized_timestamp",
+            },
+        },
+        {
+            "message": "2009-06-15 13:45:30Z",
+        },
+        {
+            "message": "2009-06-15 13:45:30Z",
+            "normalized_timestamp": "2009-06-15T13:45:30Z",
+        },
+        id="write normalized timestamp to target field",
+    ),
 ]
 
 

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -1,4 +1,6 @@
 # pylint: disable=missing-docstring
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
@@ -11,7 +13,7 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.timestamper.rule import TimestamperRule
 
-example_test_cases = [
+test_cases = [
     pytest.param(
         {
             "filter": "message",
@@ -79,11 +81,6 @@ example_test_cases = [
         None,
         id="use current time with a target timezone",
     ),
-]
-
-
-test_cases = [
-    *example_test_cases,
     pytest.param(
         {
             "filter": "message",
@@ -125,6 +122,7 @@ test_cases = [
         {
             "filter": "message",
             "timestamper": {
+                "source_fields": [],
                 "source_format": "UNIX",
             },
         },
@@ -137,6 +135,7 @@ test_cases = [
         {
             "filter": "message",
             "timestamper": {
+                "source_fields": [],
                 "source_timezone": "Europe/Berlin",
             },
         },
@@ -174,7 +173,7 @@ test_cases = [
 ]
 
 
-example_parse_datetime_test_cases = [
+parse_datetime_test_cases = [
     pytest.param(
         {
             "source_format": ["ISO8601"],
@@ -230,11 +229,6 @@ example_parse_datetime_test_cases = [
         None,
         id="try multiple source formats",
     ),
-]
-
-
-parse_datetime_test_cases = [
-    *example_parse_datetime_test_cases,
     pytest.param(
         {
             "source_format": ["UNIX", "%Y-%m-%d"],

--- a/tests/unit/processor/timestamper/test_timestamper_rule.py
+++ b/tests/unit/processor/timestamper/test_timestamper_rule.py
@@ -1,4 +1,3 @@
-# pylint: disable=protected-access
 # pylint: disable=missing-docstring
 
 from datetime import UTC, datetime
@@ -12,262 +11,273 @@ from logprep.processor.base.exceptions import (
 )
 from logprep.processor.timestamper.rule import TimestamperRule
 
+example_test_cases = [
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "target_field": "new_field",
+            },
+        },
+        {
+            "source_fields": ["message"],
+            "target_field": "new_field",
+            "source_format": ["ISO8601"],
+            "source_timezone": ZoneInfo("UTC"),
+        },
+        None,
+        None,
+        id="use defaults with a source field",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": "UNIX",
+                "source_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "source_fields": ["message"],
+            "source_format": ["UNIX"],
+            "source_timezone": ZoneInfo("Europe/Berlin"),
+        },
+        None,
+        None,
+        id="configure source format and timezone",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {},
+        },
+        {
+            "source_fields": [],
+            "source_format": None,
+            "source_timezone": None,
+        },
+        None,
+        None,
+        id="use current time when source fields are omitted",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "target_timezone": "Europe/Berlin",
+            },
+        },
+        {
+            "source_fields": [],
+            "source_format": None,
+            "source_timezone": None,
+            "target_timezone": ZoneInfo("Europe/Berlin"),
+        },
+        None,
+        None,
+        id="use current time with a target timezone",
+    ),
+]
+
+
+test_cases = [
+    *example_test_cases,
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message", "timestamp"],
+                "target_field": "@timestamp",
+            },
+        },
+        None,
+        ValueError,
+        r"Length of 'source_fields' must be <= 1",
+        id="reject multiple source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_format": "UNIX",
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_format is not allowed when source_fields is omitted or empty",
+        id="reject source format without source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_timezone": "Europe/Berlin",
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_timezone is not allowed when source_fields is omitted or empty",
+        id="reject source timezone without source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_format": "UNIX",
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_format is not allowed when source_fields is omitted or empty",
+        id="reject source format with empty source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_timezone": "Europe/Berlin",
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_timezone is not allowed when source_fields is omitted or empty",
+        id="reject source timezone with empty source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_format": None,
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_format must not be None when source_fields is configured",
+        id="reject source format none with source fields",
+    ),
+    pytest.param(
+        {
+            "filter": "message",
+            "timestamper": {
+                "source_fields": ["message"],
+                "source_timezone": None,
+            },
+        },
+        None,
+        InvalidRuleDefinitionError,
+        r"source_timezone must not be None when source_fields is configured",
+        id="reject source timezone none with source fields",
+    ),
+]
+
+
+example_parse_datetime_test_cases = [
+    pytest.param(
+        {
+            "source_format": ["ISO8601"],
+            "source_timezone": "UTC",
+        },
+        "2009-06-15 13:45:30Z",
+        datetime(2009, 6, 15, 13, 45, 30, tzinfo=UTC),
+        None,
+        None,
+        id="parse ISO8601",
+    ),
+    pytest.param(
+        {
+            "source_format": ["UNIX"],
+            "source_timezone": "UTC",
+        },
+        "1700000000",
+        datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC),
+        None,
+        None,
+        id="parse UNIX",
+    ),
+    pytest.param(
+        {
+            "source_format": ["%Y %m %d - %H:%M:%S"],
+            "source_timezone": "Europe/Berlin",
+        },
+        "2000 12 31 - 22:59:59",
+        datetime(
+            2000,
+            12,
+            31,
+            22,
+            59,
+            59,
+            tzinfo=ZoneInfo("Europe/Berlin"),
+        ),
+        None,
+        None,
+        id="parse custom format with source timezone",
+    ),
+    pytest.param(
+        {
+            "source_format": [
+                "%Y %m %d",
+                "%Y %m %d - %H:%M:%S",
+            ],
+            "source_timezone": "UTC",
+        },
+        "2000 12 31 - 22:59:59",
+        datetime(2000, 12, 31, 22, 59, 59, tzinfo=UTC),
+        None,
+        None,
+        id="try multiple source formats",
+    ),
+]
+
+
+parse_datetime_test_cases = [
+    *example_parse_datetime_test_cases,
+    pytest.param(
+        {
+            "source_format": ["UNIX", "%Y-%m-%d"],
+            "source_timezone": "UTC",
+        },
+        "not a timestamp",
+        None,
+        ProcessingWarning,
+        r"Could not parse timestamp",
+        id="raise processing warning when no source format matches",
+    ),
+]
+
 
 class TestTimestamperRule:
-    def test_create_from_dict_returns_timestamper_rule(self):
-        rule = {
-            "filter": "message",
-            "timestamper": {"source_fields": ["message"], "target_field": "new_field"},
-        }
-        rule_dict = TimestamperRule.create_from_dict(rule)
-        assert isinstance(rule_dict, TimestamperRule)
-
     @pytest.mark.parametrize(
-        ["rule", "error", "message"],
-        [
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message"],
-                        "target_field": "@timestamp",
-                    },
-                },
-                None,
-                None,
-                id="source field",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message"],
-                        "target_field": "@timestamp",
-                        "source_format": ["UNIX"],
-                    },
-                },
-                None,
-                None,
-                id="source format with source field",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message"],
-                        "source_timezone": "Europe/Berlin",
-                    },
-                },
-                None,
-                None,
-                id="source timezone with source field",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {},
-                },
-                None,
-                None,
-                id="current time without source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": [],
-                    },
-                },
-                None,
-                None,
-                id="current time with empty source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message", "timestamp"],
-                        "target_field": "@timestamp",
-                    },
-                },
-                ValueError,
-                r"Length of 'source_fields' must be <= 1",
-                id="multiple source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_format": "UNIX",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_format is not allowed when source_fields is omitted or empty",
-                id="source format without source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_timezone": "Europe/Berlin",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_timezone is not allowed when source_fields is omitted or empty",
-                id="source timezone without source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": [],
-                        "source_format": "UNIX",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_format is not allowed when source_fields is omitted or empty",
-                id="source format with empty source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": [],
-                        "source_timezone": "Europe/Berlin",
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_timezone is not allowed when source_fields is omitted or empty",
-                id="source timezone with empty source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message"],
-                        "source_format": None,
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_format must not be None when source_fields is configured",
-                id="source format none with source fields",
-            ),
-            pytest.param(
-                {
-                    "filter": "message",
-                    "timestamper": {
-                        "source_fields": ["message"],
-                        "source_timezone": None,
-                    },
-                },
-                InvalidRuleDefinitionError,
-                r"source_timezone must not be None when source_fields is configured",
-                id="source timezone none with source fields",
-            ),
-        ],
+        "rule, expected, error, message",
+        test_cases,
     )
-    def test_create_from_dict_validates_config(self, rule, error, message):
+    def test_create_from_dict(self, rule, expected, error, message):
         if error:
             with pytest.raises(error, match=message):
                 TimestamperRule.create_from_dict(rule)
-        else:
-            rule_instance = TimestamperRule.create_from_dict(rule)
-            assert hasattr(rule_instance, "_config")
+            return
 
-            for key, value in rule.get("timestamper").items():
-                assert hasattr(rule_instance._config, key)
+        rule_instance = TimestamperRule.create_from_dict(rule)
 
-                config_value = getattr(rule_instance._config, key)
+        assert isinstance(rule_instance, TimestamperRule)
 
-                if key == "source_timezone":
-                    assert config_value == ZoneInfo(value)
-                else:
-                    assert value == config_value
-
-    def test_source_defaults_when_source_fields_are_configured(self):
-        rule = TimestamperRule.create_from_dict(
-            {
-                "filter": "message",
-                "timestamper": {
-                    "source_fields": ["message"],
-                },
-            }
-        )
-
-        assert rule.source_format == ["ISO8601"]
-        assert rule.source_timezone == ZoneInfo("UTC")
-
-    def test_source_defaults_when_source_fields_are_omitted(self):
-        rule = TimestamperRule.create_from_dict(
-            {
-                "filter": "message",
-                "timestamper": {},
-            }
-        )
-
-        assert rule.source_format is None
-        assert rule.source_timezone is None
-
-    def test_source_defaults_when_source_fields_are_empty(self):
-        rule = TimestamperRule.create_from_dict(
-            {
-                "filter": "message",
-                "timestamper": {
-                    "source_fields": [],
-                },
-            }
-        )
-
-        assert rule.source_format is None
-        assert rule.source_timezone is None
+        for attribute, value in expected.items():
+            assert getattr(rule_instance.config, attribute) == value
 
     @pytest.mark.parametrize(
-        "source_value, source_format, source_timezone, expected",
-        [
-            pytest.param(
-                "2009-06-15 13:45:30Z",
-                ["ISO8601"],
-                "UTC",
-                datetime(2009, 6, 15, 13, 45, 30, tzinfo=UTC),
-                id="iso8601",
-            ),
-            pytest.param(
-                "1700000000",
-                ["UNIX"],
-                "UTC",
-                datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC),
-                id="unix",
-            ),
-            pytest.param(
-                "2000 12 31 - 22:59:59",
-                ["%Y %m %d - %H:%M:%S"],
-                "Europe/Berlin",
-                datetime(
-                    2000,
-                    12,
-                    31,
-                    22,
-                    59,
-                    59,
-                    tzinfo=ZoneInfo("Europe/Berlin"),
-                ),
-                id="custom format with source timezone",
-            ),
-            pytest.param(
-                "2000 12 31 - 22:59:59",
-                ["%Y %m %d", "%Y %m %d - %H:%M:%S"],
-                "UTC",
-                datetime(2000, 12, 31, 22, 59, 59, tzinfo=UTC),
-                id="uses matching source format",
-            ),
-        ],
+        "config, source_value, expected, error, message",
+        parse_datetime_test_cases,
     )
     def test_parse_datetime(
         self,
+        config,
         source_value,
-        source_format,
-        source_timezone,
         expected,
+        error,
+        message,
     ):
         event = {"message": source_value}
         rule = TimestamperRule.create_from_dict(
@@ -275,27 +285,14 @@ class TestTimestamperRule:
                 "filter": "message",
                 "timestamper": {
                     "source_fields": ["message"],
-                    "source_format": source_format,
-                    "source_timezone": source_timezone,
+                    **config,
                 },
             }
         )
 
-        result = rule.parse_datetime(source_value, event)
+        if error:
+            with pytest.raises(error, match=message):
+                rule.parse_datetime(source_value, event)
+            return
 
-        assert result == expected
-
-    def test_parse_datetime_raises_processing_warning_if_no_format_matches(self):
-        event = {"message": "not a timestamp"}
-        rule = TimestamperRule.create_from_dict(
-            {
-                "filter": "message",
-                "timestamper": {
-                    "source_fields": ["message"],
-                    "source_format": ["UNIX", "%Y-%m-%d"],
-                },
-            }
-        )
-
-        with pytest.raises(ProcessingWarning, match=r"Could not parse timestamp"):
-            rule.parse_datetime(event["message"], event)
+        assert rule.parse_datetime(source_value, event) == expected


### PR DESCRIPTION
## Description
* simplify timestamper test cases

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?

* pytest

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1027.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->