### PR TITLE
fix: wrong syslog rfc number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * timestamper: validate `source_format` and `source_timezone` according to the configured `source_fields`
 
 ### Bugfix
+* decoder: corrected rfc 5324 in docs to 5424
 
 ## 21.0.0
 ### Breaking

--- a/logprep/ng/processor/decoder/processor.py
+++ b/logprep/ng/processor/decoder/processor.py
@@ -11,7 +11,7 @@ The `decoder` processor decodes or parses field values from the configured
 * nginx parser for kubernetes ingress
 * syslog_rfc3164
 * syslog_rfc3164_local
-* syslog_rfc5324
+* syslog_rfc5424
 * logfmt
 * cri
 * docker

--- a/logprep/processor/decoder/processor.py
+++ b/logprep/processor/decoder/processor.py
@@ -11,7 +11,7 @@ The `decoder` processor decodes or parses field values from the configured
 * nginx parser for kubernetes ingress
 * syslog_rfc3164
 * syslog_rfc3164_local
-* syslog_rfc5324
+* syslog_rfc5424
 * logfmt
 * cri
 * docker


### PR DESCRIPTION
## Description
Fix wrong syslog rfc number in documentation of decoder

## Assignee
- [x] The changes adhere to the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (e.g. flake8/mypy/pytest/...) other than deprecations
- [x] Relevant changes are applied to non-ng and ng

### Documentation
- [x] [README.md](https://github.com/fkie-cad/Logprep/blob/main/README.md) is up-to-date
- [x] [CHANGELOG.md](https://github.com/fkie-cad/Logprep/blob/main/CHANGELOG.md) is up-to-date
- [x] [Documentation](https://github.com/fkie-cad/Logprep/tree/main/doc/source) (doc/source) is up-to-date
- [x] [Preview for docs](#readthedocs-preview) looks fine
- [x] [Notebooks](https://github.com/fkie-cad/Logprep/tree/main/doc/source/development/notebooks) are up-to-date and functional
- [x] [Examples](https://github.com/fkie-cad/Logprep/tree/main/examples) are up-to-date and functional (including compose & k8s)

### Code Quality
- [x] Patch test coverage > 95% and does not decrease
- [x] New code uses correct & specific type hints

### How did you verify that the changes work in practice?
Looked at rtd preview

## Reviewer
- The code is readable/maintainable and follows the [contribution guidelines](https://github.com/fkie-cad/Logprep/blob/main/CONTRIBUTING.md)
- [Documentation](#documentation) is up-to-date
- Tests (unit & acceptance) are meaningful and not over-mocked


<!-- readthedocs-preview logprep start -->
---
<a name="readthedocs-preview"></a>The rendered docs for this PR can be found [here](https://logprep--1028.org.readthedocs.build/).
<!-- readthedocs-preview logprep end -->